### PR TITLE
Parse the comments before the operation as it’s description

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,6 +1134,7 @@ dependencies = [
  "derive-new",
  "futures-util",
  "insta",
+ "regex",
  "reqwest",
  "rmcp",
  "rover-copy",

--- a/crates/mcp-apollo-server/Cargo.toml
+++ b/crates/mcp-apollo-server/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { version = "1.44.2", features = [
 ] }
 tracing.workspace = true
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+regex = "1.11.1"
 
 [dev-dependencies]
 insta = "1.42.2"


### PR DESCRIPTION
This adds a secondary description option. If the generated descriptions aren't working for the models, or they are too big users can add a comment before the operation that will be used for the description instead. If no comment exists, it will still do the generated description.

In this example the description would be "this tool will just return a hat for you."
```graphql
# this tool will just return a hat for you.
query AToolToGetHats {
  hat
}
```