### PR TITLE
log character counts and estimated tokens

### DIFF
--- a/crates/mcp-apollo-server/src/operations.rs
+++ b/crates/mcp-apollo-server/src/operations.rs
@@ -194,7 +194,7 @@ impl Operation {
                 "Tool {} loaded with a character count of {}. Estimated tokens: {}",
                 operation_name,
                 length,
-                length / 4
+                length / 4 // We don't know the tokenization algorithm, so we just use 4 characters per token as a rough estimate. https://docs.anthropic.com/en/docs/resources/glossary#tokens
             ),
             Err(_) => tracing::info!(
                 "Tool {} loaded with an unknown character count",

--- a/crates/mcp-apollo-server/src/operations.rs
+++ b/crates/mcp-apollo-server/src/operations.rs
@@ -25,7 +25,6 @@ pub struct Operation {
     tool: Tool,
     source_text: String,
     persisted_query_id: Option<String>,
-    character_count: usize,
 }
 
 impl AsRef<Tool> for Operation {
@@ -119,13 +118,14 @@ impl Operation {
             ));
         };
 
-        let tool = Tool::new(operation_name.clone(), description, schema);
+        let tool: Tool = Tool::new(operation_name.clone(), description, schema);
         let character_count = tool_character_length(&tool);
         match character_count {
             Ok(length) => tracing::info!(
-                "Tool {} loaded with a character count of {}",
+                "Tool {} loaded with a character count of {}. Estimated tokens: {}",
                 operation_name,
-                length
+                length,
+                length / 4
             ),
             Err(_) => tracing::info!(
                 "Tool {} loaded with an unknown character count",
@@ -136,7 +136,6 @@ impl Operation {
             tool,
             source_text: source_text.to_string(),
             persisted_query_id,
-            character_count: character_count.unwrap_or_default(),
         })
     }
 
@@ -261,10 +260,6 @@ impl Operation {
         ));
 
         lines.join("\n")
-    }
-
-    pub fn tool_character_length(&self) -> usize {
-        self.character_count
     }
 }
 

--- a/crates/mcp-apollo-server/src/server.rs
+++ b/crates/mcp-apollo-server/src/server.rs
@@ -110,6 +110,14 @@ impl Server {
             (None, None)
         };
 
+        tracing::info!("Size of tools:");
+        let total_characters = operations
+            .iter()
+            .map(|op| op.tool_character_length())
+            .sum::<usize>();
+        tracing::info!("    characters: {}", total_characters);
+        tracing::info!("    estimated tokens: {}", total_characters / 4);
+
         // Load headers
         let mut default_headers = HeaderMap::new();
         default_headers.append(CONTENT_TYPE, HeaderValue::from_static("application/json"));

--- a/crates/mcp-apollo-server/src/server.rs
+++ b/crates/mcp-apollo-server/src/server.rs
@@ -110,14 +110,6 @@ impl Server {
             (None, None)
         };
 
-        tracing::info!("Size of tools:");
-        let total_characters = operations
-            .iter()
-            .map(|op| op.tool_character_length())
-            .sum::<usize>();
-        tracing::info!("    characters: {}", total_characters);
-        tracing::info!("    estimated tokens: {}", total_characters / 4);
-
         // Load headers
         let mut default_headers = HeaderMap::new();
         default_headers.append(CONTENT_TYPE, HeaderValue::from_static("application/json"));


### PR DESCRIPTION
Logs the character size of each tool as it loads, logs the total character length of all tools and an estimate of the tokens (seems like ~4 characters is roughly a token, but will obviously vary)

Formatting I have right now, definitely open to suggestions to make it better
```
2025-04-29T19:33:04.100713Z  INFO mcp_apollo_server: Loading schema schema_path="supergraph.graphql"
2025-04-29T19:33:04.107599Z  INFO mcp_apollo_server::server: Loading operation operation_path="graphql/weather/operations/alerts.graphql"
2025-04-29T19:33:04.108761Z  INFO mcp_apollo_server::operations: Tool GetAlerts loaded with a character count of 754
2025-04-29T19:33:04.108793Z  INFO mcp_apollo_server::server: Loading operation operation_path="graphql/weather/operations/all.graphql"
2025-04-29T19:33:04.109415Z  INFO mcp_apollo_server::operations: Tool GetAllWeatherData loaded with a character count of 1489
2025-04-29T19:33:04.109429Z  INFO mcp_apollo_server::server: Loading operation operation_path="graphql/weather/operations/forecast.graphql"
2025-04-29T19:33:04.109708Z  INFO mcp_apollo_server::operations: Tool GetForecast loaded with a character count of 801
2025-04-29T19:33:04.109723Z  INFO mcp_apollo_server::server: Size of tools:
2025-04-29T19:33:04.109727Z  INFO mcp_apollo_server::server:     characters: 3044
2025-04-29T19:33:04.109730Z  INFO mcp_apollo_server::server:     estimated tokens: 761
2025-04-29T19:33:04.109892Z  INFO mcp_apollo_server: Starting MCP server in stdio mode
```