### PR TITLE
Retrieve schema from uplink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +135,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "apollo-federation"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b5f5e991345ac059cb3dc3c155e772d2b27e8cc0c6a7603672fa9ff1a81d92"
+dependencies = [
+ "apollo-compiler",
+ "derive_more 0.99.20",
+ "either",
+ "hashbrown 0.15.2",
+ "http",
+ "indexmap",
+ "itertools",
+ "line-col",
+ "multi_try",
+ "multimap",
+ "nom",
+ "nom_locate",
+ "percent-encoding",
+ "petgraph",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_json_bytes",
+ "shape",
+ "strum",
+ "strum_macros",
+ "thiserror 1.0.69",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "apollo-parser"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +190,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +210,17 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -278,6 +338,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "buildstructor"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +365,12 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "bytecount"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytes"
@@ -427,6 +503,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +569,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive-new"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +615,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -523,6 +677,12 @@ name = "dyn-clone"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -574,6 +734,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +754,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -662,6 +834,7 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+ "num_cpus",
 ]
 
 [[package]]
@@ -751,6 +924,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
 name = "graphql-introspection-query"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +1024,11 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -850,6 +1041,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
@@ -1157,6 +1354,7 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+ "serde",
 ]
 
 [[package]]
@@ -1186,8 +1384,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
 dependencies = [
  "console",
+ "globset",
  "once_cell",
+ "pest",
+ "pest_derive",
+ "serde",
  "similar",
+ "walkdir",
 ]
 
 [[package]]
@@ -1202,7 +1405,7 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.0",
  "libc",
  "windows-sys 0.59.0",
 ]
@@ -1212,6 +1415,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1308,6 +1520,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-col"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e69cdf6b85b5c8dce514f694089a2cf8b1a702f6cd28607bcb3cf296c9778db"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,20 +1578,29 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 name = "mcp-apollo-registry"
 version = "0.1.0"
 dependencies = [
+ "derivative",
+ "derive_more 2.0.1",
  "futures",
  "graphql_client",
+ "insta",
  "notify",
  "parking_lot",
  "reqwest",
  "secrecy",
  "serde",
  "serde_json",
+ "test-log",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tower",
  "tracing",
+ "tracing-core",
+ "tracing-futures",
+ "tracing-subscriber",
  "url",
+ "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -1382,10 +1609,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "apollo-compiler",
- "base64 0.22.1",
+ "apollo-federation",
  "buildstructor",
  "clap",
  "derive-new",
+ "futures",
  "insta",
  "lz-str",
  "mcp-apollo-registry",
@@ -1395,6 +1623,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "webbrowser",
@@ -1411,6 +1640,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1431,6 +1666,21 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "multi_try"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42256e8ab5f19108cf42e2762786052ae4660635f6fe76134d2cab37068ee8a"
+
+[[package]]
+name = "multimap"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1455,6 +1705,27 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom_locate"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom",
+]
 
 [[package]]
 name = "notify"
@@ -1492,12 +1763,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1671,6 +1967,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,6 +2015,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1923,6 +2257,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,6 +2410,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2103,6 +2452,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -2155,6 +2505,18 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "shape"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27e114fc498dd1dcc20b12a9571a7b9b78396760e44b7a9024afa3a04ce26763"
+dependencies = [
+ "apollo-compiler",
+ "indexmap",
+ "serde_json",
+ "serde_json_bytes",
 ]
 
 [[package]]
@@ -2233,6 +2595,25 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "subtle"
@@ -2317,6 +2698,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-log"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f46083d221181166e5b6f6b1e5f1d499f3a76888826e6cb1d057554157cd0f"
+dependencies = [
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "888d0c3c6db53c0fdab160d2ed5e12ba745383d3e85813f2ea0f2b1475ab553f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "text-size"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2371,6 +2773,27 @@ dependencies = [
  "cfg-if",
  "once_cell",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "tinystr"
@@ -2516,6 +2939,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "futures",
+ "futures-task",
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2523,6 +2958,16 @@ checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
  "tracing-core",
 ]
 
@@ -2536,12 +2981,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2611,6 +3059,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2644,6 +3098,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom 0.3.2",
+ "serde",
+]
 
 [[package]]
 name = "valuable"
@@ -3116,6 +3580,30 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wiremock"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "101681b74cd87b5899e87bcf5a64e83334dd313fcd3053ea72e6dba18928e301"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ apollo-compiler = "1.27.0"
 apollo-federation = "2.1.3"
 futures = { version = "0.3.31", features = ["thread-pool"] }
 insta = { version = "1.43.1", features = [
-    "json",
-    "redactions",
-    "yaml",
-    "glob",
+  "json",
+  "redactions",
+  "yaml",
+  "glob",
 ] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,20 @@ package.version = "0.1.0"
 
 [workspace.dependencies]
 apollo-compiler = "1.27.0"
+apollo-federation = "2.1.3"
+futures = { version = "0.3.31", features = ["thread-pool"] }
+insta = { version = "1.43.1", features = [
+    "json",
+    "redactions",
+    "yaml",
+    "glob",
+] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 thiserror = "2.0.12"
 tracing = "0.1.41"
+tracing-core = "0.1.33"
+tracing-subscriber = { version = "0.3.19", features = ["json"] }
 
 [workspace.metadata]
 crane.name = "mcp-apollo"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can run the MCP inspector with the stdio transport as follows:
 npx @modelcontextprotocol/inspector \
   target/debug/mcp-apollo-server \
   --directory <absolute path to this git repo> \
-  -s graphql/weather/api.graphql \
+  -s graphql/weather/supergraph.graphql \
   -o graphql/weather/operations/forecast.graphql graphql/weather/operations/alerts.graphql graphql/weather/operations/all.graphql
 ```
 
@@ -43,7 +43,7 @@ To use the SSE transport with MCP Inspector, first start the MCP server in SEE m
 ```sh
 target/debug/mcp-apollo-server \
   --directory <absolute path to this git repo> \
-  --sse-port 5000 -s graphql/weather/api.graphql \
+  --sse-port 5000 -s graphql/weather/supergraph.graphql \
   -o graphql/weather/operations/forecast.graphql graphql/weather/operations/alerts.graphql graphql/weather/operations/all.graphql
 ```
 
@@ -82,7 +82,7 @@ To use the stdio transport, add the following to the MCP configuration file for 
             "--directory",
             "<absolute path to repo>",
             "--schema",
-            "graphql/weather/api.graphql",
+            "graphql/weather/supergraph.graphql",
             "--operations",
             "graphql/weather/operations/forecast.graphql",
             "graphql/weather/operations/alerts.graphql",
@@ -146,7 +146,7 @@ An example is included in `graphql/weather/persisted_queries`.
 ```sh
 target/debug/mcp-apollo-server \
   --directory <absolute path to this git repo> \
-  -s graphql/weather/api.graphql \
+  -s graphql/weather/supergraph.graphql \
   --header "apollographql-client-name:my-web-app" \
   --manifest graphql/weather/persisted_queries/apollo.json
 ```
@@ -172,7 +172,7 @@ persisted queries are available to the MCP server.
 ```sh
 target/debug/mcp-apollo-server \
   --directory <absolute path to this git repo> \
-  -s graphql/weather/api.graphql \
+  -s graphql/weather/supergraph.graphql \
   --header "apollographql-client-name:my-web-app" \
   --uplink
 ```

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,3 @@
 allow-expect-in-tests = true
+allow-panic-in-tests = true
 allow-unwrap-in-tests = true

--- a/crates/mcp-apollo-registry/Cargo.toml
+++ b/crates/mcp-apollo-registry/Cargo.toml
@@ -8,15 +8,21 @@ repository = "https://github.com/apollographql/mcp-apollo"
 description = "Registry providing schema and operations to the MCP Server"
 
 [dependencies]
-futures = "0.3"
+derive_more = { version = "2.0.1", default-features = false, features = [
+  "from",
+  "display",
+] }
+derivative = "2.2.0"
+futures.workspace = true
 graphql_client = "0.14.0"
+insta.workspace = true
 notify = "8.0.0"
 parking_lot = "0.12"
 reqwest = { version = "0.12.15", features = ["json", "gzip"] }
 secrecy = "0.10.3"
-serde = { workspace = true }
-serde_json = { workspace = true }
-thiserror = { workspace = true }
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
 tokio = { version = "1.0", features = [
   "fs",
   "sync",
@@ -26,8 +32,18 @@ tokio = { version = "1.0", features = [
 ] }
 tokio-stream = "0.1"
 tower = "0.5.2"
-tracing = { workspace = true }
+tracing.workspace = true
 url = "2.4"
+uuid = { version = "1.16.0", features = ["serde", "v4"] }
+tracing-core.workspace = true
+tracing-subscriber.workspace = true
+
+[dev-dependencies]
+test-log = { version = "0.2.16", default-features = false, features = [
+  "trace",
+] }
+tracing-futures = { version = "0.2.5", features = ["futures-03"] }
+wiremock = "0.6.3"
 
 [lints]
 workspace = true

--- a/crates/mcp-apollo-registry/src/files.rs
+++ b/crates/mcp-apollo-registry/src/files.rs
@@ -94,9 +94,51 @@ fn watch_with_duration(path: &Path, duration: Duration) -> impl Stream<Item = ()
             // This exists to give the stream ownership of the hotwatcher.
             // Without it hotwatch will get dropped and the stream will terminate.
             // This code never actually gets run.
-            // The ideal would be that hotwatch implements a stream and
+            // The ideal would be that hotwatch implements a stream, and
             // therefore we don't need this hackery.
             drop(watcher);
         }))
         .boxed()
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use std::env::temp_dir;
+    use std::fs::File;
+    use std::io::Seek;
+    use std::io::Write;
+    use std::path::PathBuf;
+
+    use test_log::test;
+
+    use super::*;
+
+    #[test(tokio::test)]
+    async fn basic_watch() {
+        let (path, mut file) = create_temp_file();
+        let mut watch = watch_with_duration(&path, Duration::from_millis(100));
+        // This test can be very racy. Without synchronisation, all
+        // we can hope is that if we wait long enough between each
+        // write/flush then the future will become ready.
+        // Signal telling us we are ready
+        assert!(futures::poll!(watch.next()).is_ready());
+        write_and_flush(&mut file, "Some data 1").await;
+        assert!(futures::poll!(watch.next()).is_ready());
+        write_and_flush(&mut file, "Some data 2").await;
+        assert!(futures::poll!(watch.next()).is_ready())
+    }
+
+    pub(crate) fn create_temp_file() -> (PathBuf, File) {
+        let path = temp_dir().join(format!("{}", uuid::Uuid::new_v4()));
+        let file = File::create(&path).unwrap();
+        (path, file)
+    }
+
+    pub(crate) async fn write_and_flush(file: &mut File, contents: &str) {
+        file.rewind().unwrap();
+        file.set_len(0).unwrap();
+        file.write_all(contents.as_bytes()).unwrap();
+        file.flush().unwrap();
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
 }

--- a/crates/mcp-apollo-registry/src/lib.rs
+++ b/crates/mcp-apollo-registry/src/lib.rs
@@ -1,2 +1,3 @@
 pub(crate) mod files;
+pub(crate) mod logging;
 pub mod uplink;

--- a/crates/mcp-apollo-registry/src/logging.rs
+++ b/crates/mcp-apollo-registry/src/logging.rs
@@ -1,0 +1,116 @@
+#[macro_export]
+/// This is a really simple macro to assert a snapshot of the logs.
+/// To use it call `.with_subscriber(assert_snapshot_subscriber!())` in your test just before calling `await`.
+/// This will assert a snapshot of the logs in pretty yaml format.
+/// You can also use subscriber::with_default(assert_snapshot_subscriber!(), || { ... }) to assert the logs in non async code.
+macro_rules! assert_snapshot_subscriber {
+    () => {
+        $crate::assert_snapshot_subscriber!(tracing_core::LevelFilter::INFO, {})
+    };
+
+    ($redactions:tt) => {
+        $crate::assert_snapshot_subscriber!(tracing_core::LevelFilter::INFO, $redactions)
+    };
+
+    ($level:expr) => {
+        $crate::assert_snapshot_subscriber!($level, {})
+    };
+
+    ($level:expr, $redactions:tt) => {
+        $crate::logging::test::SnapshotSubscriber::create_subscriber($level, |yaml| {
+            insta::with_settings!({sort_maps => true}, {
+                // the tests here will force maps to sort
+                let mut settings = insta::Settings::clone_current();
+                settings.set_snapshot_suffix("logs");
+                settings.set_sort_maps(true);
+                settings.bind(|| {
+                    insta::assert_yaml_snapshot!(yaml, $redactions);
+                });
+            });
+        })
+    };
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    use serde_json::Value;
+    use tracing_core::LevelFilter;
+    use tracing_core::Subscriber;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    pub(crate) struct SnapshotSubscriber {
+        buffer: Arc<Mutex<Vec<u8>>>,
+        assertion: fn(Value),
+    }
+
+    impl std::io::Write for SnapshotSubscriber {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let buf_len = buf.len();
+            self.buffer.lock().unwrap().append(&mut buf.to_vec());
+            Ok(buf_len)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl Drop for SnapshotSubscriber {
+        fn drop(&mut self) {
+            let log = String::from_utf8(self.buffer.lock().unwrap().to_vec()).unwrap();
+            let parsed: Value = if log.is_empty() {
+                serde_json::json!([])
+            } else {
+                let parsed_log: Vec<Value> = log
+                    .lines()
+                    .map(|line| {
+                        let mut line: Value = serde_json::from_str(line).unwrap();
+                        // move the message field to the top level
+                        let fields = line
+                            .as_object_mut()
+                            .unwrap()
+                            .get_mut("fields")
+                            .unwrap()
+                            .as_object_mut()
+                            .unwrap();
+                        let message = fields.remove("message").unwrap_or_default();
+                        line.as_object_mut()
+                            .unwrap()
+                            .insert("message".to_string(), message);
+                        line
+                    })
+                    .collect();
+                serde_json::json!(parsed_log)
+            };
+
+            (self.assertion)(parsed)
+        }
+    }
+
+    impl SnapshotSubscriber {
+        pub(crate) fn create_subscriber(
+            level: LevelFilter,
+            assertion: fn(Value),
+        ) -> impl Subscriber {
+            let collector = Self {
+                buffer: Arc::new(Mutex::new(Vec::new())),
+                assertion,
+            };
+
+            tracing_subscriber::registry::Registry::default()
+                .with(level)
+                .with(
+                    tracing_subscriber::fmt::Layer::default()
+                        .json()
+                        .without_time()
+                        .with_target(false)
+                        .with_file(false)
+                        .with_line_number(false)
+                        .with_writer(Mutex::new(collector)),
+                )
+        }
+    }
+}

--- a/crates/mcp-apollo-registry/src/testdata/minimal_supergraph.graphql
+++ b/crates/mcp-apollo-registry/src/testdata/minimal_supergraph.graphql
@@ -1,0 +1,64 @@
+schema
+@link(url: "https://specs.apollo.dev/link/v1.0")
+@link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+    query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+    graph: join__Graph
+    requires: join__FieldSet
+    provides: join__FieldSet
+    type: String
+    external: Boolean
+    override: String
+    usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(
+    graph: join__Graph!
+    key: join__FieldSet
+    extension: Boolean! = false
+    resolvable: Boolean! = true
+    isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+    graph: join__Graph!
+    member: String!
+) repeatable on UNION
+
+directive @link(
+    url: String
+    as: String
+    for: link__Purpose
+    import: [link__Import]
+) repeatable on SCHEMA
+
+directive @join__implements(
+    graph: join__Graph!
+    interface: String!
+) repeatable on OBJECT | INTERFACE
+
+scalar join__FieldSet
+scalar link__Import
+
+enum join__Graph {
+    SUBGRAPH_A
+    @join__graph(
+        name: "subgraph-a"
+        url: "http://graphql.subgraph-a.svc.cluster.local:4000"
+    )
+}
+
+enum link__Purpose {
+    SECURITY
+    EXECUTION
+}
+
+type Query @join__type(graph: SUBGRAPH_A) {
+    me: String @join__field(graph: SUBGRAPH_A)
+}

--- a/crates/mcp-apollo-registry/src/testdata/supergraph.graphql
+++ b/crates/mcp-apollo-registry/src/testdata/supergraph.graphql
@@ -1,0 +1,111 @@
+schema
+@link(url: "https://specs.apollo.dev/link/v1.0")
+@link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+    query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+    graph: join__Graph
+    requires: join__FieldSet
+    provides: join__FieldSet
+    type: String
+    external: Boolean
+    override: String
+    usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+    graph: join__Graph!
+    interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+    graph: join__Graph!
+    key: join__FieldSet
+    extension: Boolean! = false
+    resolvable: Boolean! = true
+    isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+    graph: join__Graph!
+    member: String!
+) repeatable on UNION
+
+directive @link(
+    url: String
+    as: String
+    for: link__Purpose
+    import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+    ACCOUNTS
+    @join__graph(name: "accounts", url: "https://accounts.demo.starstuff.dev/")
+    INVENTORY
+    @join__graph(
+        name: "inventory"
+        url: "https://inventory.demo.starstuff.dev/"
+    )
+    PRODUCTS
+    @join__graph(name: "products", url: "https://products.demo.starstuff.dev/")
+    REVIEWS
+    @join__graph(name: "reviews", url: "https://reviews.demo.starstuff.dev/")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+    SECURITY
+    EXECUTION
+}
+
+type Product
+@join__type(graph: INVENTORY, key: "upc")
+@join__type(graph: PRODUCTS, key: "upc")
+@join__type(graph: REVIEWS, key: "upc") {
+    upc: String!
+    weight: Int
+    @join__field(graph: INVENTORY, external: true)
+    @join__field(graph: PRODUCTS)
+    price: Int
+    @join__field(graph: INVENTORY, external: true)
+    @join__field(graph: PRODUCTS)
+    inStock: Boolean @join__field(graph: INVENTORY)
+    shippingEstimate: Int @join__field(graph: INVENTORY, requires: "price weight")
+    name: String @join__field(graph: PRODUCTS)
+    reviews: [Review] @join__field(graph: REVIEWS)
+}
+
+type Query
+@join__type(graph: ACCOUNTS)
+@join__type(graph: INVENTORY)
+@join__type(graph: PRODUCTS)
+@join__type(graph: REVIEWS) {
+    me: User @join__field(graph: ACCOUNTS)
+    topProducts(first: Int = 5): [Product] @join__field(graph: PRODUCTS)
+}
+
+type Review @join__type(graph: REVIEWS, key: "id") {
+    id: ID!
+    body: String
+    author: User @join__field(graph: REVIEWS, provides: "username")
+    product: Product @join__field(graph: REVIEWS)
+}
+
+type User
+@join__type(graph: ACCOUNTS, key: "id")
+@join__type(graph: REVIEWS, key: "id") {
+    id: ID!
+    name: String @join__field(graph: ACCOUNTS)
+    username: String
+    @join__field(graph: ACCOUNTS)
+    @join__field(graph: REVIEWS, external: true)
+    reviews: [Review] @join__field(graph: REVIEWS)
+}

--- a/crates/mcp-apollo-registry/src/uplink.rs
+++ b/crates/mcp-apollo-registry/src/uplink.rs
@@ -10,7 +10,9 @@ use tokio_stream::wrappers::ReceiverStream;
 use tower::BoxError;
 use url::Url;
 
+pub mod event;
 pub mod persisted_queries;
+pub mod schema;
 
 const GCP_URL: &str = "https://uplink.api.apollographql.com";
 const AWS_URL: &str = "https://aws.uplink.api.apollographql.com";

--- a/crates/mcp-apollo-registry/src/uplink/event.rs
+++ b/crates/mcp-apollo-registry/src/uplink/event.rs
@@ -1,0 +1,31 @@
+use crate::uplink::schema::SchemaState;
+use std::fmt::Debug;
+use std::fmt::Formatter;
+
+/// Messages that are broadcast across the app.
+pub enum Event {
+    /// The schema was updated.
+    UpdateSchema(SchemaState),
+
+    /// There are no more updates to the schema
+    NoMoreSchema,
+
+    /// The server should gracefully shut down.
+    Shutdown,
+}
+
+impl Debug for Event {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Event::UpdateSchema(_) => {
+                write!(f, "UpdateSchema(<redacted>)")
+            }
+            Event::NoMoreSchema => {
+                write!(f, "NoMoreSchema")
+            }
+            Event::Shutdown => {
+                write!(f, "Shutdown")
+            }
+        }
+    }
+}

--- a/crates/mcp-apollo-registry/src/uplink/persisted_queries/manifest_poller.rs
+++ b/crates/mcp-apollo-registry/src/uplink/persisted_queries/manifest_poller.rs
@@ -258,8 +258,9 @@ async fn poll_manifest_stream(
 
                         if let Some(sender) = ready_sender.take() {
                             let _ = sender.send(ManifestPollResultOnStartup::LoadedOperations).await;
+                        } else {
+                            let _ = change_sender.send(ManifestChanged).await;
                         }
-                        let _ = change_sender.send(ManifestChanged).await;
                     }
                     Some(Err(e)) => {
                         tracing::error!("Error polling manifest: {}", e);
@@ -323,7 +324,7 @@ fn create_uplink_stream(
     .filter_map(|result| async move {
         match result {
             Ok(Some(manifest)) => Some(Ok(manifest)),
-            Ok(None) => None,
+            Ok(None) => Some(Ok(PersistedQueryManifest::default())),
             Err(e) => Some(Err(e.into())),
         }
     })

--- a/crates/mcp-apollo-registry/src/uplink/persisted_queries/manifest_poller.rs
+++ b/crates/mcp-apollo-registry/src/uplink/persisted_queries/manifest_poller.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -38,9 +38,9 @@ pub enum ManifestPollResultOnStartup {
 pub struct ManifestChanged;
 
 #[derive(Debug)]
-pub enum ManifestSource<P: 'static + AsRef<Path> + Sync + Send + Clone> {
-    LocalStatic(Vec<P>),
-    LocalHotReload(Vec<P>),
+pub enum ManifestSource {
+    LocalStatic(Vec<PathBuf>),
+    LocalHotReload(Vec<PathBuf>),
     Uplink(UplinkConfig),
 }
 
@@ -55,8 +55,8 @@ impl PersistedQueryManifestPoller {
     /// Create a new [`PersistedQueryManifestPoller`] from an UplinkConfig.
     /// Starts polling immediately and this function only returns after all chunks have been fetched
     /// and the [`PersistedQueryManifest`] has been fully populated.
-    pub async fn new<P: 'static + AsRef<Path> + Sync + Send + Clone>(
-        manifest_source: ManifestSource<P>,
+    pub async fn new(
+        manifest_source: ManifestSource,
         change_sender: mpsc::Sender<ManifestChanged>,
     ) -> Result<Self, BoxError> {
         let manifest_stream = create_manifest_stream(manifest_source).await?;
@@ -220,8 +220,8 @@ async fn fetch_chunk(http_client: Client, chunk_url: &String) -> Result<SignedUr
 /// A stream of manifest updates
 type ManifestStream = dyn Stream<Item = Result<PersistedQueryManifest, BoxError>> + Send + 'static;
 
-async fn create_manifest_stream<P: 'static + AsRef<Path> + Sync + Send + Clone>(
-    source: ManifestSource<P>,
+async fn create_manifest_stream(
+    source: ManifestSource,
 ) -> Result<Pin<Box<ManifestStream>>, BoxError> {
     match source {
         ManifestSource::LocalStatic(paths) => Ok(stream::once(load_local_manifests(paths)).boxed()),
@@ -275,13 +275,10 @@ async fn poll_manifest_stream(
     }
 }
 
-async fn load_local_manifests<P: AsRef<Path> + Sync + Send>(
-    paths: Vec<P>,
-) -> Result<PersistedQueryManifest, BoxError> {
+async fn load_local_manifests(paths: Vec<PathBuf>) -> Result<PersistedQueryManifest, BoxError> {
     let mut complete_manifest = PersistedQueryManifest::default();
 
     for path in paths.iter() {
-        let path = path.as_ref();
         let raw_file_contents = read_to_string(path).await.map_err(|e| -> BoxError {
             format!(
                 "Failed to read persisted query list file at path: {}, {}",
@@ -332,8 +329,8 @@ fn create_uplink_stream(
     })
 }
 
-fn create_hot_reload_stream<P: 'static + AsRef<Path> + Clone + Sync + Send>(
-    paths: Vec<P>,
+fn create_hot_reload_stream(
+    paths: Vec<PathBuf>,
 ) -> impl Stream<Item = Result<PersistedQueryManifest, BoxError>> {
     // Create file watchers for each path
     let file_watchers = paths.into_iter().map(|raw_path| {
@@ -361,7 +358,6 @@ fn create_hot_reload_stream<P: 'static + AsRef<Path> + Clone + Sync + Send>(
     // Combine all watchers into a single stream
     stream::select_all(file_watchers).map(move |result| {
         result.map(|(path, chunk)| {
-            let path = path.as_ref();
             tracing::info!(
                 "hot reloading persisted query manifest file at path: {}",
                 path.to_string_lossy()

--- a/crates/mcp-apollo-registry/src/uplink/schema.rs
+++ b/crates/mcp-apollo-registry/src/uplink/schema.rs
@@ -1,0 +1,391 @@
+mod schema_stream;
+
+use std::convert::Infallible;
+use std::str::FromStr;
+
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::time::Duration;
+
+use crate::uplink::UplinkConfig;
+use crate::uplink::event::Event;
+use crate::uplink::event::Event::{NoMoreSchema, UpdateSchema};
+use crate::uplink::schema::schema_stream::SupergraphSdlQuery;
+use crate::uplink::stream_from_uplink;
+use derivative::Derivative;
+use derive_more::Display;
+use derive_more::From;
+use futures::prelude::*;
+use url::Url;
+
+/// Represents the new state of a schema after an update.
+#[derive(Eq, PartialEq, Debug)]
+pub struct SchemaState {
+    pub sdl: String,
+    pub(crate) launch_id: Option<String>,
+}
+
+impl FromStr for SchemaState {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self {
+            sdl: s.to_string(),
+            launch_id: None,
+        })
+    }
+}
+
+type SchemaStream = Pin<Box<dyn Stream<Item = String> + Send>>;
+
+/// The user supplied schema. Either a static string or a stream for hot reloading.
+#[derive(From, Display, Derivative)]
+#[derivative(Debug)]
+#[non_exhaustive]
+pub enum SchemaSource {
+    /// A static schema.
+    #[display("String")]
+    Static { schema_sdl: String },
+
+    /// A stream of schema.
+    #[display("Stream")]
+    Stream(#[derivative(Debug = "ignore")] SchemaStream),
+
+    /// A YAML file that may be watched for changes.
+    #[display("File")]
+    File {
+        /// The path of the schema file.
+        path: PathBuf,
+
+        /// `true` to watch the file for changes and hot apply them.
+        watch: bool,
+    },
+
+    /// Apollo managed federation.
+    #[display("Registry")]
+    Registry(UplinkConfig),
+
+    /// A list of URLs to fetch the schema from.
+    #[display("URLs")]
+    URLs {
+        /// The URLs to fetch the schema from.
+        urls: Vec<Url>,
+    },
+}
+
+impl From<&'_ str> for SchemaSource {
+    fn from(s: &'_ str) -> Self {
+        Self::Static {
+            schema_sdl: s.to_owned(),
+        }
+    }
+}
+
+impl SchemaSource {
+    /// Convert this schema into a stream regardless of if is static or not. Allows for unified handling later.
+    pub fn into_stream(self) -> impl Stream<Item = Event> {
+        match self {
+            SchemaSource::Static { schema_sdl: schema } => {
+                let update_schema = UpdateSchema(SchemaState {
+                    sdl: schema,
+                    launch_id: None,
+                });
+                stream::once(future::ready(update_schema)).boxed()
+            }
+            SchemaSource::Stream(stream) => stream
+                .map(|sdl| {
+                    UpdateSchema(SchemaState {
+                        sdl,
+                        launch_id: None,
+                    })
+                })
+                .boxed(),
+            SchemaSource::File {
+                path,
+                watch,
+            } => {
+                // Sanity check, does the schema file exists, if it doesn't then bail.
+                if !path.exists() {
+                    tracing::error!(
+                        "Supergraph schema at path '{}' does not exist.",
+                        path.to_string_lossy()
+                    );
+                    stream::empty().boxed()
+                } else {
+                    //The schema file exists try and load it
+                    match std::fs::read_to_string(&path) {
+                        Ok(schema) => {
+                            if watch {
+                                crate::files::watch(&path)
+                                    .filter_map(move |_| {
+                                        let path = path.clone();
+                                        async move {
+                                            match tokio::fs::read_to_string(&path).await {
+                                                Ok(schema) => {
+                                                    let update_schema = UpdateSchema(SchemaState {
+                                                        sdl: schema,
+                                                        launch_id: None,
+                                                    });
+                                                    Some(update_schema)
+                                                }
+                                                Err(err) => {
+                                                    tracing::error!(reason = %err, "failed to read supergraph schema");
+                                                    None
+                                                }
+                                            }
+                                        }
+                                    })
+                                    .boxed()
+                            } else {
+                                let update_schema = UpdateSchema(SchemaState {
+                                    sdl: schema,
+                                    launch_id: None,
+                                });
+                                stream::once(future::ready(update_schema)).boxed()
+                            }
+                        }
+                        Err(err) => {
+                            tracing::error!(reason = %err, "failed to read supergraph schema");
+                            stream::empty().boxed()
+                        }
+                    }
+                }
+            }
+            SchemaSource::Registry(uplink_config) => {
+                stream_from_uplink::<SupergraphSdlQuery, SchemaState>(uplink_config)
+                    .filter_map(|res| {
+                        future::ready(match res {
+                            Ok(schema) => {
+                                let update_schema = UpdateSchema(schema);
+                                Some(update_schema)
+                            }
+                            Err(e) => {
+                                tracing::error!("{}", e);
+                                None
+                            }
+                        })
+                    })
+                    .boxed()
+            }
+            SchemaSource::URLs { urls } => {
+                futures::stream::once(async move {
+                    fetch_supergraph_from_first_viable_url(&urls).await
+                })
+                    .filter_map(|s| async move { s.map(Event::UpdateSchema) })
+                    .boxed()
+            }
+        }
+            .chain(stream::iter(vec![NoMoreSchema]))
+            .boxed()
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+enum FetcherError {
+    #[error("failed to build http client")]
+    InitializationError(#[from] reqwest::Error),
+}
+
+// Encapsulates fetching the schema from the first viable url.
+// It will try each url in order until it finds one that works.
+#[allow(clippy::unwrap_used)] // TODO - existing unwrap from router code
+async fn fetch_supergraph_from_first_viable_url(urls: &[Url]) -> Option<SchemaState> {
+    let Ok(client) = reqwest::Client::builder()
+        .no_gzip()
+        .timeout(Duration::from_secs(10))
+        .build()
+    else {
+        tracing::error!("failed to create HTTP client to fetch supergraph schema");
+        return None;
+    };
+    for url in urls {
+        match client.get(Url::parse(url.as_ref()).unwrap()).send().await {
+            Ok(res) if res.status().is_success() => match res.text().await {
+                Ok(schema) => {
+                    return Some(SchemaState {
+                        sdl: schema,
+                        launch_id: None,
+                    });
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        url.full = %url,
+                        reason = %err,
+                        "failed to fetch supergraph schema"
+                    )
+                }
+            },
+            Ok(res) => tracing::warn!(
+                http.response.status_code = res.status().as_u16(),
+                url.full = %url,
+                "failed to fetch supergraph schema"
+            ),
+            Err(err) => tracing::warn!(
+                url.full = %url,
+                reason = %err,
+                "failed to fetch supergraph schema"
+            ),
+        }
+    }
+    tracing::error!("failed to fetch supergraph schema from all urls");
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env::temp_dir;
+
+    use test_log::test;
+    use tracing_futures::WithSubscriber;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    use super::*;
+    use crate::assert_snapshot_subscriber;
+    use crate::files::tests::create_temp_file;
+    use crate::files::tests::write_and_flush;
+
+    #[test(tokio::test)]
+    async fn schema_by_file_watching() {
+        let (path, mut file) = create_temp_file();
+        let schema = include_str!("../testdata/supergraph.graphql");
+        write_and_flush(&mut file, schema).await;
+        let mut stream = SchemaSource::File { path, watch: true }
+            .into_stream()
+            .boxed();
+
+        // First update is guaranteed
+        assert!(matches!(stream.next().await.unwrap(), UpdateSchema(_)));
+
+        // Need different contents, since we won't get an event if content is the same
+        let schema_minimal = include_str!("../testdata/minimal_supergraph.graphql");
+        // Modify the file and try again
+        write_and_flush(&mut file, schema_minimal).await;
+        assert!(matches!(stream.next().await.unwrap(), UpdateSchema(_)));
+    }
+
+    #[test(tokio::test)]
+    async fn schema_by_file_no_watch() {
+        let (path, mut file) = create_temp_file();
+        let schema = include_str!("../testdata/supergraph.graphql");
+        write_and_flush(&mut file, schema).await;
+
+        let mut stream = SchemaSource::File { path, watch: false }.into_stream();
+        assert!(matches!(stream.next().await.unwrap(), UpdateSchema(_)));
+        assert!(matches!(stream.next().await.unwrap(), NoMoreSchema));
+    }
+
+    #[test(tokio::test)]
+    async fn schema_by_file_missing() {
+        let mut stream = SchemaSource::File {
+            path: temp_dir().join("does_not_exist"),
+            watch: true,
+        }
+        .into_stream();
+
+        // First update fails because the file is invalid.
+        assert!(matches!(stream.next().await.unwrap(), NoMoreSchema));
+    }
+
+    const SCHEMA_1: &str = "schema1";
+    const SCHEMA_2: &str = "schema2";
+    #[test(tokio::test)]
+    async fn schema_by_url() {
+        async {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/schema1"))
+                .respond_with(ResponseTemplate::new(200).set_body_string(SCHEMA_1))
+                .mount(&mock_server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/schema2"))
+                .respond_with(ResponseTemplate::new(200).set_body_string(SCHEMA_2))
+                .mount(&mock_server)
+                .await;
+
+            let mut stream = SchemaSource::URLs {
+                urls: vec![
+                    Url::parse(&format!("http://{}/schema1", mock_server.address())).unwrap(),
+                    Url::parse(&format!("http://{}/schema2", mock_server.address())).unwrap(),
+                ],
+            }
+                .into_stream();
+
+            assert!(
+                matches!(stream.next().await.unwrap(), UpdateSchema(schema) if schema.sdl == SCHEMA_1)
+            );
+            assert!(matches!(stream.next().await.unwrap(), NoMoreSchema));
+        }
+            .with_subscriber(assert_snapshot_subscriber!())
+            .await;
+    }
+
+    #[test(tokio::test)]
+    async fn schema_by_url_fallback() {
+        async {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/schema1"))
+                .respond_with(ResponseTemplate::new(400))
+                .mount(&mock_server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/schema2"))
+                .respond_with(ResponseTemplate::new(200).set_body_string(SCHEMA_2))
+                .mount(&mock_server)
+                .await;
+
+            let mut stream = SchemaSource::URLs {
+                urls: vec![
+                    Url::parse(&format!("http://{}/schema1", mock_server.address())).unwrap(),
+                    Url::parse(&format!("http://{}/schema2", mock_server.address())).unwrap(),
+                ],
+            }
+                .into_stream();
+
+            assert!(
+                matches!(stream.next().await.unwrap(), UpdateSchema(schema) if schema.sdl == SCHEMA_2)
+            );
+            assert!(matches!(stream.next().await.unwrap(), NoMoreSchema));
+        }
+            .with_subscriber(assert_snapshot_subscriber!({
+            "[].fields[\"url.full\"]" => "[url.full]"
+        }))
+            .await;
+    }
+
+    #[test(tokio::test)]
+    async fn schema_by_url_all_fail() {
+        async {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/schema1"))
+                .respond_with(ResponseTemplate::new(400))
+                .mount(&mock_server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/schema2"))
+                .respond_with(ResponseTemplate::new(400))
+                .mount(&mock_server)
+                .await;
+
+            let mut stream = SchemaSource::URLs {
+                urls: vec![
+                    Url::parse(&format!("http://{}/schema1", mock_server.address())).unwrap(),
+                    Url::parse(&format!("http://{}/schema2", mock_server.address())).unwrap(),
+                ],
+            }
+            .into_stream();
+
+            assert!(matches!(stream.next().await.unwrap(), NoMoreSchema));
+        }
+        .with_subscriber(assert_snapshot_subscriber!({
+            "[].fields[\"url.full\"]" => "[url.full]"
+        }))
+        .await;
+    }
+}

--- a/crates/mcp-apollo-registry/src/uplink/schema/schema_query.graphql
+++ b/crates/mcp-apollo-registry/src/uplink/schema/schema_query.graphql
@@ -11,7 +11,7 @@ query SupergraphSdlQuery(
         __typename
         ... on RouterConfigResult {
             id
-            supergraphSdl
+            supergraphSDL
             minDelaySeconds
         }
         ... on Unchanged {

--- a/crates/mcp-apollo-registry/src/uplink/schema/schema_stream.rs
+++ b/crates/mcp-apollo-registry/src/uplink/schema/schema_stream.rs
@@ -1,0 +1,145 @@
+// tonic does not derive `Eq` for the gRPC message types, which causes a warning from Clippy. The
+// current suggestion is to explicitly allow the lint in the module that imports the protos.
+// Read more: https://github.com/hyperium/tonic/issues/1056
+#![allow(clippy::derive_partial_eq_without_eq)]
+
+use crate::uplink::UplinkRequest;
+use crate::uplink::UplinkResponse;
+use crate::uplink::schema::SchemaState;
+use crate::uplink::schema::schema_stream::supergraph_sdl_query::FetchErrorCode;
+use crate::uplink::schema::schema_stream::supergraph_sdl_query::SupergraphSdlQueryRouterConfig;
+use graphql_client::GraphQLQuery;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "src/uplink/schema/schema_query.graphql",
+    schema_path = "src/uplink/uplink.graphql",
+    request_derives = "Debug",
+    response_derives = "PartialEq, Debug, Deserialize",
+    deprecated = "warn"
+)]
+pub(crate) struct SupergraphSdlQuery;
+
+impl From<UplinkRequest> for supergraph_sdl_query::Variables {
+    fn from(req: UplinkRequest) -> Self {
+        supergraph_sdl_query::Variables {
+            api_key: req.api_key,
+            graph_ref: req.graph_ref,
+            if_after_id: req.id,
+        }
+    }
+}
+
+impl From<supergraph_sdl_query::ResponseData> for UplinkResponse<String> {
+    fn from(response: supergraph_sdl_query::ResponseData) -> Self {
+        match response.router_config {
+            SupergraphSdlQueryRouterConfig::RouterConfigResult(result) => UplinkResponse::New {
+                response: result.supergraph_sdl,
+                id: result.id,
+                // this will truncate the number of seconds to under u64::MAX, which should be
+                // a large enough delay anyway
+                delay: result.min_delay_seconds as u64,
+            },
+            SupergraphSdlQueryRouterConfig::Unchanged(response) => UplinkResponse::Unchanged {
+                id: Some(response.id),
+                delay: Some(response.min_delay_seconds as u64),
+            },
+            SupergraphSdlQueryRouterConfig::FetchError(err) => UplinkResponse::Error {
+                retry_later: err.code == FetchErrorCode::RETRY_LATER,
+                code: match err.code {
+                    FetchErrorCode::AUTHENTICATION_FAILED => "AUTHENTICATION_FAILED".to_string(),
+                    FetchErrorCode::ACCESS_DENIED => "ACCESS_DENIED".to_string(),
+                    FetchErrorCode::UNKNOWN_REF => "UNKNOWN_REF".to_string(),
+                    FetchErrorCode::RETRY_LATER => "RETRY_LATER".to_string(),
+                    FetchErrorCode::NOT_IMPLEMENTED_ON_THIS_INSTANCE => {
+                        "NOT_IMPLEMENTED_ON_THIS_INSTANCE".to_string()
+                    }
+                    FetchErrorCode::Other(other) => other,
+                },
+                message: err.message,
+            },
+        }
+    }
+}
+
+impl From<supergraph_sdl_query::ResponseData> for UplinkResponse<SchemaState> {
+    fn from(response: supergraph_sdl_query::ResponseData) -> Self {
+        match response.router_config {
+            SupergraphSdlQueryRouterConfig::RouterConfigResult(result) => UplinkResponse::New {
+                response: SchemaState {
+                    sdl: result.supergraph_sdl,
+                    launch_id: Some(result.id.clone()),
+                },
+                id: result.id,
+                // this will truncate the number of seconds to under u64::MAX, which should be
+                // a large enough delay anyway
+                delay: result.min_delay_seconds as u64,
+            },
+            SupergraphSdlQueryRouterConfig::Unchanged(response) => UplinkResponse::Unchanged {
+                id: Some(response.id),
+                delay: Some(response.min_delay_seconds as u64),
+            },
+            SupergraphSdlQueryRouterConfig::FetchError(err) => UplinkResponse::Error {
+                retry_later: err.code == FetchErrorCode::RETRY_LATER,
+                code: match err.code {
+                    FetchErrorCode::AUTHENTICATION_FAILED => "AUTHENTICATION_FAILED".to_string(),
+                    FetchErrorCode::ACCESS_DENIED => "ACCESS_DENIED".to_string(),
+                    FetchErrorCode::UNKNOWN_REF => "UNKNOWN_REF".to_string(),
+                    FetchErrorCode::RETRY_LATER => "RETRY_LATER".to_string(),
+                    FetchErrorCode::NOT_IMPLEMENTED_ON_THIS_INSTANCE => {
+                        "NOT_IMPLEMENTED_ON_THIS_INSTANCE".to_string()
+                    }
+                    FetchErrorCode::Other(other) => other,
+                },
+                message: err.message,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+    use std::time::Duration;
+
+    use futures::stream::StreamExt;
+    use secrecy::SecretString;
+    use url::Url;
+
+    use crate::uplink::AWS_URL;
+    use crate::uplink::Endpoints;
+    use crate::uplink::GCP_URL;
+    use crate::uplink::UplinkConfig;
+    use crate::uplink::schema::schema_stream::SupergraphSdlQuery;
+    use crate::uplink::stream_from_uplink;
+
+    #[tokio::test]
+    async fn integration_test() {
+        for url in &[GCP_URL, AWS_URL] {
+            if let (Ok(apollo_key), Ok(apollo_graph_ref)) = (
+                std::env::var("TEST_APOLLO_KEY"),
+                std::env::var("TEST_APOLLO_GRAPH_REF"),
+            ) {
+                let results = stream_from_uplink::<SupergraphSdlQuery, String>(UplinkConfig {
+                    apollo_key: SecretString::from(apollo_key),
+                    apollo_graph_ref,
+                    endpoints: Some(Endpoints::fallback(vec![
+                        Url::from_str(url).expect("url must be valid"),
+                    ])),
+                    poll_interval: Duration::from_secs(1),
+                    timeout: Duration::from_secs(5),
+                })
+                .take(1)
+                .collect::<Vec<_>>()
+                .await;
+
+                let schema = results
+                    .first()
+                    .unwrap_or_else(|| panic!("expected one result from {}", url))
+                    .as_ref()
+                    .unwrap_or_else(|_| panic!("schema should be OK from {}", url));
+                assert!(schema.contains("type Product"))
+            }
+        }
+    }
+}

--- a/crates/mcp-apollo-registry/src/uplink/snapshots/mcp_apollo_registry__uplink__schema__tests__schema_by_url@logs.snap
+++ b/crates/mcp-apollo-registry/src/uplink/snapshots/mcp_apollo_registry__uplink__schema__tests__schema_by_url@logs.snap
@@ -1,0 +1,5 @@
+---
+source: crates/mcp-apollo-registry/src/uplink/schema.rs
+expression: yaml
+---
+[]

--- a/crates/mcp-apollo-registry/src/uplink/snapshots/mcp_apollo_registry__uplink__schema__tests__schema_by_url_all_fail@logs.snap
+++ b/crates/mcp-apollo-registry/src/uplink/snapshots/mcp_apollo_registry__uplink__schema__tests__schema_by_url_all_fail@logs.snap
@@ -1,0 +1,17 @@
+---
+source: crates/mcp-apollo-registry/src/uplink/schema.rs
+expression: yaml
+---
+- fields:
+    http.response.status_code: 400
+    url.full: "[url.full]"
+  level: WARN
+  message: failed to fetch supergraph schema
+- fields:
+    http.response.status_code: 400
+    url.full: "[url.full]"
+  level: WARN
+  message: failed to fetch supergraph schema
+- fields: {}
+  level: ERROR
+  message: failed to fetch supergraph schema from all urls

--- a/crates/mcp-apollo-registry/src/uplink/snapshots/mcp_apollo_registry__uplink__schema__tests__schema_by_url_fallback@logs.snap
+++ b/crates/mcp-apollo-registry/src/uplink/snapshots/mcp_apollo_registry__uplink__schema__tests__schema_by_url_fallback@logs.snap
@@ -1,0 +1,9 @@
+---
+source: crates/mcp-apollo-registry/src/uplink/schema.rs
+expression: yaml
+---
+- fields:
+    http.response.status_code: 400
+    url.full: "[url.full]"
+  level: WARN
+  message: failed to fetch supergraph schema

--- a/crates/mcp-apollo-registry/src/uplink/uplink.graphql
+++ b/crates/mcp-apollo-registry/src/uplink/uplink.graphql
@@ -3,82 +3,126 @@ Schema for requests to Apollo Uplink
 """
 
 type Query {
-  """
-  Persisted queries endpoint
-  """
-  persistedQueries(
     """
-    the Apollo Graph ID to load persisted queries for
+    Fetch schema through router configuration
     """
-    ref: String!
+    routerConfig(
+        """
+        The reference to a graph variant, like `engine@prod` or `engine` (i.e. `engine@current`).
+        """
+        ref: String!,
+
+        """
+        the API key to authenticate with
+        """
+        apiKey: String!,
+
+        """
+        When specified and the result is not newer, `Unchanged` is returned rather than `RouterConfigResult`.
+        """
+        ifAfterId: ID
+    ): RouterConfigResponse!
 
     """
-    the API key to authenticate with
+    Fetch persisted queries
     """
-    apiKey: String!
+    persistedQueries(
+        """
+        The reference to a graph variant, like `engine@prod` or `engine` (i.e. `engine@current`).
+        """
+        ref: String!
 
-    """
-    If passed, only returns changes after the given ID
-    """
-    ifAfterId: ID
-  ): PersistedQueriesResponse!
+        """
+        the API key to authenticate with
+        """
+        apiKey: String!
+
+        """
+        When specified and the result is not newer, `Unchanged` is returned rather than `PersistedQueriesResult`.
+        """
+        ifAfterId: ID
+    ): PersistedQueriesResponse!
+}
+
+union RouterConfigResponse = RouterConfigResult | Unchanged | FetchError
+
+type RouterConfigResult {
+    "Variant-unique identifier."
+    id: ID!
+    "The configuration as core schema."
+    supergraphSDL: String!
+    "Messages that should be reported back to the operators of this router, eg through logs and/or monitoring."
+    messages: [Message!]!
+    "Minimum delay before the next fetch should occur, in seconds."
+    minDelaySeconds: Float!
+}
+
+type Message {
+    level: MessageLevel!
+    body: String!
+}
+
+enum MessageLevel {
+    ERROR
+    WARN
+    INFO
 }
 
 union PersistedQueriesResponse = PersistedQueriesResult | Unchanged | FetchError
 
 type PersistedQueriesResult {
-  """
-  Uniquely identifies this version. Must be passed via ifAfterId for incremental updates.
-  """
-  id: ID!
+    """
+    Uniquely identifies this version. Must be passed via ifAfterId for incremental updates.
+    """
+    id: ID!
 
-  """
-  Minimum seconds to wait before checking again on 'unchanged'
-  """
-  minDelaySeconds: Float!
+    """
+    Minimum seconds to wait before checking again on 'unchanged'
+    """
+    minDelaySeconds: Float!
 
-  """
-  Chunks of operations
-  """
-  chunks: [PersistedQueriesResultChunks!]
+    """
+    Chunks of operations
+    """
+    chunks: [PersistedQueriesResultChunks!]
 }
 
 """
 A sublist of the persisted query result which can be fetched directly from a content-addressed storage
 """
 type PersistedQueriesResultChunks {
-  """
-  Chunk ID
-  """
-  id: ID!
+    """
+    Chunk ID
+    """
+    id: ID!
 
-  """
-  Locations to find the operations from
-  """
-  urls: [String!]!
+    """
+    Locations to find the operations from
+    """
+    urls: [String!]!
 }
 
 type Unchanged {
-  """
-  Uniquely identifies this version. Must be passed via ifAfterId for subsequent checks.
-  """
-  id: ID!
-  
-  """
-  Minimum seconds to wait before checking again
-  """
-  minDelaySeconds: Float!
+    """
+    Uniquely identifies this version. Must be passed via ifAfterId for subsequent checks.
+    """
+    id: ID!
+
+    """
+    Minimum seconds to wait before checking again
+    """
+    minDelaySeconds: Float!
 }
 
 enum FetchErrorCode {
-  AUTHENTICATION_FAILED
-  ACCESS_DENIED
-  UNKNOWN_REF
-  RETRY_LATER
-  NOT_IMPLEMENTED_ON_THIS_INSTANCE
+    AUTHENTICATION_FAILED
+    ACCESS_DENIED
+    UNKNOWN_REF
+    RETRY_LATER
+    NOT_IMPLEMENTED_ON_THIS_INSTANCE
 }
 
 type FetchError {
-  code: FetchErrorCode!
-  message: String!
+    code: FetchErrorCode!
+    message: String!
 }

--- a/crates/mcp-apollo-server/Cargo.toml
+++ b/crates/mcp-apollo-server/Cargo.toml
@@ -7,11 +7,14 @@ license = "Elastic-2.0"
 [dependencies]
 anyhow = "1.0.98"
 apollo-compiler.workspace = true
+apollo-federation.workspace = true
 buildstructor = "0.6.0"
 clap = { version = "4.5.36", features = ["derive"] }
 derive-new = "0.7.0"
+futures.workspace = true
 lz-str = "0.2.1"
 mcp-apollo-registry = { path = "../mcp-apollo-registry" }
+regex = "1.11.1"
 reqwest = "0.12.15"
 rmcp = { version = "0.1", features = [
   "server",
@@ -32,12 +35,11 @@ tokio = { version = "1.44.2", features = [
 ] }
 tracing.workspace = true
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-regex = "1.11.1"
+tokio-util = "0.7.15"
 webbrowser = "1.0.4"
-base64 = "0.22.1"
 
 [dev-dependencies]
-insta = "1.42.2"
+insta = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mcp-apollo-server/src/custom_scalar_map.rs
+++ b/crates/mcp-apollo-server/src/custom_scalar_map.rs
@@ -48,7 +48,7 @@ impl TryFrom<&PathBuf> for CustomScalarMap {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CustomScalarMap(HashMap<String, SchemaObject>);
 
 impl CustomScalarMap {
@@ -162,16 +162,16 @@ mod tests {
         .unwrap();
 
         insta::assert_debug_snapshot!(result, @r###"
-            CustomScalarJsonSchema(
-                Object {
-                    "properties": Object {
-                        "test": Object {
-                            "test": Bool(true),
-                        },
+        CustomScalarJsonSchema(
+            Object {
+                "type": String("object"),
+                "properties": Object {
+                    "test": Object {
+                        "test": Bool(true),
                     },
-                    "type": String("object"),
                 },
-            )
+            },
+        )
         "###)
     }
 

--- a/crates/mcp-apollo-server/src/errors.rs
+++ b/crates/mcp-apollo-server/src/errors.rs
@@ -1,6 +1,8 @@
 use apollo_compiler::{Schema, ast::Document, validation::WithErrors};
+use apollo_federation::error::FederationError;
 use reqwest::header::{InvalidHeaderName, InvalidHeaderValue};
 use rmcp::serde_json;
+use tokio::task::JoinError;
 
 /// An error in operation parsing
 #[derive(Debug, thiserror::Error)]
@@ -36,6 +38,9 @@ pub enum ServerError {
     #[error("Could not parse GraphQL schema: {0}")]
     GraphQLSchema(Box<WithErrors<Schema>>),
 
+    #[error("Federation error in GraphQL schema: {0}")]
+    Federation(FederationError),
+
     #[error("Invalid JSON: {0}")]
     Json(#[from] serde_json::Error),
 
@@ -65,6 +70,12 @@ pub enum ServerError {
 
     #[error("No operations defined")]
     NoOperations,
+
+    #[error("No valid schema was supplied")]
+    NoSchema,
+
+    #[error("Failed to start server")]
+    StartupError(#[from] JoinError),
 }
 
 /// An MCP tool error

--- a/crates/mcp-apollo-server/src/errors.rs
+++ b/crates/mcp-apollo-server/src/errors.rs
@@ -68,7 +68,7 @@ pub enum ServerError {
     #[error("Missing environment variable: {0}")]
     EnvironmentVariable(String),
 
-    #[error("No operations defined")]
+    #[error("You must define operations or enable introspection")]
     NoOperations,
 
     #[error("No valid schema was supplied")]

--- a/crates/mcp-apollo-server/src/explorer.rs
+++ b/crates/mcp-apollo-server/src/explorer.rs
@@ -1,11 +1,11 @@
 use crate::errors::McpError;
 use crate::schema_from_type;
-use base64::Engine;
 use rmcp::model::{CallToolResult, Content, ErrorCode, Tool};
 use rmcp::schemars::JsonSchema;
 use rmcp::serde_json::Value;
 use rmcp::{schemars, serde_json};
 use serde::Deserialize;
+use tracing::info;
 
 pub(crate) const EXPLORER_TOOL_NAME: &str = "explorer";
 
@@ -36,24 +36,77 @@ impl Explorer {
             variant,
             tool: Tool::new(
                 EXPLORER_TOOL_NAME,
-                "Open a GraphQL operation in Apollo Explorer",
+                "Open a GraphQL operation in Apollo Explorer. The input fields must be in the order document, variables, headers. All fields must be present, but if they are not set, set them to a string containing just `{}`",
                 schema_from_type!(Input),
             ),
         }
     }
 
     fn create_explorer_url(&self, input: &Value) -> String {
-        let compressed = lz_str::compress_to_uint8_array(input.to_string().as_str());
-        let encoded = base64::engine::general_purpose::STANDARD.encode(compressed);
+        let compressed = lz_str::compress_to_encoded_uri_component(input.to_string().as_str());
         format!(
-            "https://studio.apollographql.com/graph/{graph_id}/variant/{variant}/explorer?explorerURLState={encoded}",
+            "https://studio.apollographql.com/graph/{graph_id}/variant/{variant}/explorer?explorerURLState={compressed}",
             graph_id = self.graph_id,
             variant = self.variant
         )
     }
 
     pub async fn execute(&self, input: Value) -> Result<CallToolResult, McpError> {
-        webbrowser::open(self.create_explorer_url(&input).as_str())
+        // Validate field order: must be ["document", "variables", "headers"]
+        if let Value::Object(map) = &input {
+            let mut keys = map.keys();
+            if !(keys.next() == Some(&"document".to_string())
+                && keys.next() == Some(&"variables".to_string())
+                && keys.next() == Some(&"headers".to_string())
+                && keys.next().is_none())
+            {
+                return Err(McpError::new(
+                    ErrorCode::INVALID_PARAMS,
+                    "Input fields must be in order: document, variables, headers",
+                    None,
+                ));
+            }
+        } else {
+            return Err(McpError::new(
+                ErrorCode::INVALID_PARAMS,
+                "Input must be a JSON object",
+                None,
+            ));
+        }
+
+        let document = input.get("document").and_then(|v| v.as_str());
+        let variables = input.get("variables").and_then(|v| v.as_str());
+        let headers = input.get("headers").and_then(|v| v.as_str());
+
+        if document.is_none() || document == Some("") {
+            return Err(McpError::new(
+                ErrorCode::INVALID_PARAMS,
+                "Missing or empty 'document' field in input",
+                None,
+            ));
+        }
+        if variables.is_none() || variables == Some("") {
+            return Err(McpError::new(
+                ErrorCode::INVALID_PARAMS,
+                "Missing or empty 'variables' field in input",
+                None,
+            ));
+        }
+        if headers.is_none() || headers == Some("") {
+            return Err(McpError::new(
+                ErrorCode::INVALID_PARAMS,
+                "Missing or empty 'headers' field in input",
+                None,
+            ));
+        }
+
+        let url = self.create_explorer_url(&input);
+        info!(
+            "Opening Apollo Explorer URL: {} for input operation: {}",
+            url,
+            serde_json::to_string_pretty(&input).unwrap_or("<unable to serialize>".into())
+        );
+        webbrowser::open(url.as_str())
             .map(|_| CallToolResult {
                 content: vec![Content::text("success")],
                 is_error: None,
@@ -72,14 +125,14 @@ mod tests {
         let explorer = Explorer::new(String::from("mcp-example@mcp"));
         let input = json!({
             "document": "query GetWeatherAlerts($state: String!) {\n  alerts(state: $state) {\n    severity\n    description\n    instruction\n  }\n}",
-            "headers": "{}",
-            "variables": "{\"state\": \"CA\"}"
+            "variables": "{\"state\": \"CA\"}",
+            "headers": "{}"
         });
 
         let url = explorer.create_explorer_url(&input);
         assert_eq!(
             url,
-            "https://studio.apollographql.com/graph/mcp-example/variant/mcp/explorer?explorerURLState=N4IgJg9gxgrgtgUwHYBcQC4QEcYIE4CeABAOIIoDqCAhigBb4CCANvigM4AUAJOyrQnREAyijwBLJAHMAhAEoiwADpIiRaqzwdOfAUN78UCBctVqi7BADd84lARXmiYBOygSADinEQkj85J8eDBQ3r7+AL4qESAANCAM1C547BggwDHxVtQS1ABGrKmYyiC6RkoYRBUAwowVMRFAAAA="
+            "https://studio.apollographql.com/graph/mcp-example/variant/mcp/explorer?explorerURLState=N4IgJg9gxgrgtgUwHYBcQC4QEcYIE4CeABAOIIoDqCAhigBb4CCANvigM4AUAJOyrQnREAyijwBLJAHMAhAEoiwADpIiRaqzwdOfAUN78UCBctVqi7BADd84lARXmiYBOygSADinEQkj85J8eDBQ3r7+AL4qESAANCBW1BLUAEas7BggyiC6RkoYRPkAwoz5MfEM1C54GZjAMRFAA"
         );
     }
 }

--- a/crates/mcp-apollo-server/src/introspection.rs
+++ b/crates/mcp-apollo-server/src/introspection.rs
@@ -10,13 +10,15 @@ use rmcp::schemars::JsonSchema;
 use rmcp::serde_json::Value;
 use rmcp::{schemars, serde_json};
 use serde::Deserialize;
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 pub(crate) const GET_SCHEMA_TOOL_NAME: &str = "schema";
 pub(crate) const EXECUTE_TOOL_NAME: &str = "execute";
 
 #[derive(Clone)]
 pub struct GetSchema {
-    pub schema: Valid<Schema>,
+    pub schema: Arc<Mutex<Valid<Schema>>>,
     pub tool: Tool,
 }
 
@@ -24,7 +26,7 @@ pub struct GetSchema {
 pub struct GetSchemaInput {}
 
 impl GetSchema {
-    pub fn new(schema: Valid<Schema>) -> Self {
+    pub fn new(schema: Arc<Mutex<Valid<Schema>>>) -> Self {
         Self {
             schema,
             tool: Tool::new(

--- a/crates/mcp-apollo-server/src/main.rs
+++ b/crates/mcp-apollo-server/src/main.rs
@@ -32,39 +32,39 @@ const STYLES: Styles = Styles::styled()
 )]
 struct Args {
     /// The working directory to use
-    #[clap(long, short = 'd')]
+    #[arg(long, short = 'd')]
     directory: PathBuf,
 
     /// The path to the GraphQL API schema file
-    #[clap(long, short = 's')]
+    #[arg(long, short = 's')]
     schema: Option<PathBuf>,
 
     /// The path to the GraphQL custom_scalars_config file
-    #[clap(long, short = 'c', required = false)]
+    #[arg(long, short = 'c', required = false)]
     custom_scalars_config: Option<PathBuf>,
 
     /// The GraphQL endpoint the server will invoke
-    #[clap(long, short = 'e', default_value = "http://127.0.0.1:4000")]
+    #[arg(long, short = 'e', default_value = "http://127.0.0.1:4000")]
     endpoint: String,
 
     /// Headers to send to the endpoint
-    #[clap(long = "header", action = clap::ArgAction::Append)]
+    #[arg(long = "header", action = clap::ArgAction::Append)]
     headers: Vec<String>,
 
     /// Start the server using the SSE transport on the given port
-    #[clap(long)]
+    #[arg(long)]
     sse_port: Option<u16>,
 
     /// Expose the schema to the MCP client through `schema` and `execute` tools
-    #[clap(long, short = 'i')]
+    #[arg(long, short = 'i')]
     introspection: bool,
 
     /// Enable use of uplink to get the schema and persisted queries (requires APOLLO_KEY and APOLLO_GRAPH_REF)
-    #[clap(long, short = 'u')]
+    #[arg(long, short = 'u')]
     uplink: bool,
 
     /// Expose a tool to open queries in Apollo Explorer (requires APOLLO_KEY and APOLLO_GRAPH_REF)
-    #[clap(long, short = 'x')]
+    #[arg(long, short = 'x')]
     explorer: bool,
 
     /// Operation files to expose as MCP tools

--- a/crates/mcp-apollo-server/src/main.rs
+++ b/crates/mcp-apollo-server/src/main.rs
@@ -101,8 +101,13 @@ async fn main() -> anyhow::Result<()> {
         OperationSource::Manifest(ManifestSource::LocalHotReload(vec![manifest]))
     } else if args.uplink {
         OperationSource::Manifest(ManifestSource::Uplink(uplink_config()?))
-    } else {
+    } else if !args.operations.is_empty() {
         OperationSource::Files(args.operations)
+    } else {
+        if !args.introspection {
+            bail!(ServerError::NoOperations);
+        }
+        OperationSource::None
     };
 
     let mut default_headers = HeaderMap::new();

--- a/crates/mcp-apollo-server/src/operations.rs
+++ b/crates/mcp-apollo-server/src/operations.rs
@@ -74,7 +74,9 @@ impl OperationPoller {
         }
         .inspect(|operations| {
             if operations.is_empty() {
-                warn!("No operations found - only introspection tools will be available");
+                if !matches!(self, OperationPoller::None) {
+                    warn!("No operations found");
+                }
             } else {
                 info!(
                     "Loaded {} operations:\n{}",
@@ -415,7 +417,7 @@ fn type_to_schema(
     match variable_type {
         Type::NonNullNamed(named) | Type::Named(named) => match named.as_str() {
             "String" | "ID" => schema_factory(
-                description,
+                None,
                 Some(InstanceType::String),
                 None,
                 None,
@@ -423,7 +425,7 @@ fn type_to_schema(
                 None,
             ),
             "Int" | "Float" => schema_factory(
-                description,
+                None,
                 Some(InstanceType::Number),
                 None,
                 None,
@@ -431,7 +433,7 @@ fn type_to_schema(
                 None,
             ),
             "Boolean" => schema_factory(
-                description,
+                None,
                 Some(InstanceType::Boolean),
                 None,
                 None,

--- a/crates/mcp-apollo-server/src/operations.rs
+++ b/crates/mcp-apollo-server/src/operations.rs
@@ -416,13 +416,30 @@ fn type_to_schema(
 ) -> Schema {
     match variable_type {
         Type::NonNullNamed(named) | Type::Named(named) => match named.as_str() {
-            "String" | "ID" => {
-                schema_factory(None, Some(InstanceType::String), None, None, None, None)
-            }
-            "Int" | "Float" => {
-                schema_factory(None, Some(InstanceType::Number), None, None, None, None)
-            }
-            "Boolean" => schema_factory(None, Some(InstanceType::Boolean), None, None, None, None),
+            "String" | "ID" => schema_factory(
+                description,
+                Some(InstanceType::String),
+                None,
+                None,
+                None,
+                None,
+            ),
+            "Int" | "Float" => schema_factory(
+                description,
+                Some(InstanceType::Number),
+                None,
+                None,
+                None,
+                None,
+            ),
+            "Boolean" => schema_factory(
+                description,
+                Some(InstanceType::Boolean),
+                None,
+                None,
+                None,
+                None,
+            ),
             _ => {
                 if let Some(input_type) = graphql_schema.get_input_object(named) {
                     let mut obj = ObjectValidation::default();

--- a/crates/mcp-apollo-server/src/operations.rs
+++ b/crates/mcp-apollo-server/src/operations.rs
@@ -416,30 +416,13 @@ fn type_to_schema(
 ) -> Schema {
     match variable_type {
         Type::NonNullNamed(named) | Type::Named(named) => match named.as_str() {
-            "String" | "ID" => schema_factory(
-                None,
-                Some(InstanceType::String),
-                None,
-                None,
-                None,
-                None,
-            ),
-            "Int" | "Float" => schema_factory(
-                None,
-                Some(InstanceType::Number),
-                None,
-                None,
-                None,
-                None,
-            ),
-            "Boolean" => schema_factory(
-                None,
-                Some(InstanceType::Boolean),
-                None,
-                None,
-                None,
-                None,
-            ),
+            "String" | "ID" => {
+                schema_factory(None, Some(InstanceType::String), None, None, None, None)
+            }
+            "Int" | "Float" => {
+                schema_factory(None, Some(InstanceType::Number), None, None, None, None)
+            }
+            "Boolean" => schema_factory(None, Some(InstanceType::Boolean), None, None, None, None),
             _ => {
                 if let Some(input_type) = graphql_schema.get_input_object(named) {
                     let mut obj = ObjectValidation::default();

--- a/crates/mcp-apollo-server/src/operations.rs
+++ b/crates/mcp-apollo-server/src/operations.rs
@@ -73,7 +73,7 @@ impl OperationPoller {
             OperationPoller::None => Ok(Vec::default()),
         }
         .inspect(|operations| {
-            if  operations.is_empty() {
+            if operations.is_empty() {
                 warn!("No operations found - only introspection tools will be available");
             } else {
                 info!(

--- a/crates/mcp-apollo-server/src/operations.rs
+++ b/crates/mcp-apollo-server/src/operations.rs
@@ -1,11 +1,16 @@
+use crate::custom_scalar_map::CustomScalarMap;
 use crate::errors::{McpError, OperationError};
 use crate::graphql;
 use crate::tree_shake::TreeShaker;
 use apollo_compiler::ast::{FragmentDefinition, Selection};
+use apollo_compiler::validation::Valid;
 use apollo_compiler::{
     Name, Node, Schema as GraphqlSchema,
     ast::{Definition, OperationDefinition, Type},
     parser::Parser,
+};
+use mcp_apollo_registry::uplink::persisted_queries::{
+    ManifestSource, PersistedQueryManifestPoller,
 };
 use regex::Regex;
 use rmcp::{
@@ -17,8 +22,59 @@ use rmcp::{
     serde_json::{self, Value},
 };
 use serde::Serialize;
+use std::path::PathBuf;
+use tracing::info;
 
-use crate::custom_scalar_map::CustomScalarMap;
+/// The source of the operations exposed as MCP tools
+pub enum OperationSource {
+    /// Static GraphQL document files (no hot reloading)
+    Files(Vec<PathBuf>),
+
+    /// Persisted Query manifest (including sources that support hot reloading)
+    Manifest(ManifestSource),
+}
+
+#[derive(Clone)]
+pub enum OperationPoller {
+    /// Static GraphQL document files (no hot reloading)
+    Files(Vec<PathBuf>),
+
+    /// Persisted Query manifest (including sources that support hot reloading)
+    Manifest(PersistedQueryManifestPoller),
+}
+
+impl OperationPoller {
+    pub async fn operations(
+        &self,
+        schema: &Valid<apollo_compiler::Schema>,
+        custom_scalars: Option<&CustomScalarMap>,
+    ) -> Result<Vec<Operation>, OperationError> {
+        match self {
+            OperationPoller::Files(paths) => paths
+                .iter()
+                .map(|operation| {
+                    let operation = std::fs::read_to_string(operation)?;
+                    Operation::from_document(&operation, schema, None, custom_scalars)
+                })
+                .collect::<Result<Vec<Operation>, OperationError>>(),
+            OperationPoller::Manifest(manifest_poller) => manifest_poller
+                .get_all_operations()
+                .into_iter()
+                .map(|(pq_id, operation)| {
+                    Operation::from_document(&operation, schema, Some(pq_id), custom_scalars)
+                })
+                .collect::<Result<Vec<Operation>, OperationError>>(),
+        }
+        .inspect(|operations| {
+            info!(
+                "Loaded {} operations:\n{}",
+                operations.len(),
+                serde_json::to_string_pretty(&operations)
+                    .unwrap_or(String::from("<unable to serialize>"))
+            );
+        })
+    }
+}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Operation {
@@ -570,23 +626,23 @@ mod tests {
             name: "QueryName",
             description: "The returned value is optional and has type `String`",
             input_schema: {
+                "type": String("object"),
                 "properties": Object {
                     "id": Object {
                         "type": String("string"),
                     },
                 },
-                "type": String("object"),
             },
         }
         "###);
         insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
         {
+          "type": "object",
           "properties": {
             "id": {
               "type": "string"
             }
-          },
-          "type": "object"
+          }
         }
         "###);
     }
@@ -603,29 +659,29 @@ mod tests {
             name: "QueryName",
             description: "The returned value is optional and has type `String`",
             input_schema: {
+                "type": String("object"),
+                "required": Array [
+                    String("id"),
+                ],
                 "properties": Object {
                     "id": Object {
                         "type": String("string"),
                     },
                 },
-                "required": Array [
-                    String("id"),
-                ],
-                "type": String("object"),
             },
         }
         "###);
         insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
         {
+          "type": "object",
+          "required": [
+            "id"
+          ],
           "properties": {
             "id": {
               "type": "string"
             }
-          },
-          "required": [
-            "id"
-          ],
-          "type": "object"
+          }
         }
         "###);
     }
@@ -642,8 +698,13 @@ mod tests {
             name: "QueryName",
             description: "The returned value is optional and has type `String`",
             input_schema: {
+                "type": String("object"),
+                "required": Array [
+                    String("id"),
+                ],
                 "properties": Object {
                     "id": Object {
+                        "type": String("array"),
                         "oneOf": Array [
                             Object {
                                 "type": String("string"),
@@ -652,20 +713,20 @@ mod tests {
                                 "type": String("null"),
                             },
                         ],
-                        "type": String("array"),
                     },
                 },
-                "required": Array [
-                    String("id"),
-                ],
-                "type": String("object"),
             },
         }
         "###);
         insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
         {
+          "type": "object",
+          "required": [
+            "id"
+          ],
           "properties": {
             "id": {
+              "type": "array",
               "oneOf": [
                 {
                   "type": "string"
@@ -673,14 +734,9 @@ mod tests {
                 {
                   "type": "null"
                 }
-              ],
-              "type": "array"
+              ]
             }
-          },
-          "required": [
-            "id"
-          ],
-          "type": "object"
+          }
         }
         "###);
     }
@@ -697,35 +753,35 @@ mod tests {
             name: "QueryName",
             description: "The returned value is optional and has type `String`",
             input_schema: {
-                "properties": Object {
-                    "id": Object {
-                        "items": Object {
-                            "type": String("string"),
-                        },
-                        "type": String("array"),
-                    },
-                },
+                "type": String("object"),
                 "required": Array [
                     String("id"),
                 ],
-                "type": String("object"),
+                "properties": Object {
+                    "id": Object {
+                        "type": String("array"),
+                        "items": Object {
+                            "type": String("string"),
+                        },
+                    },
+                },
             },
         }
         "###);
         insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
         {
-          "properties": {
-            "id": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
+          "type": "object",
           "required": [
             "id"
           ],
-          "type": "object"
+          "properties": {
+            "id": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         }
         "###);
     }
@@ -742,8 +798,10 @@ mod tests {
             name: "QueryName",
             description: "The returned value is optional and has type `String`",
             input_schema: {
+                "type": String("object"),
                 "properties": Object {
                     "id": Object {
+                        "type": String("array"),
                         "oneOf": Array [
                             Object {
                                 "type": String("string"),
@@ -752,17 +810,17 @@ mod tests {
                                 "type": String("null"),
                             },
                         ],
-                        "type": String("array"),
                     },
                 },
-                "type": String("object"),
             },
         }
         "###);
         insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
         {
+          "type": "object",
           "properties": {
             "id": {
+              "type": "array",
               "oneOf": [
                 {
                   "type": "string"
@@ -770,11 +828,9 @@ mod tests {
                 {
                   "type": "null"
                 }
-              ],
-              "type": "array"
+              ]
             }
-          },
-          "type": "object"
+          }
         }
         "###);
     }
@@ -791,29 +847,29 @@ mod tests {
             name: "QueryName",
             description: "The returned value is optional and has type `String`",
             input_schema: {
+                "type": String("object"),
                 "properties": Object {
                     "id": Object {
+                        "type": String("array"),
                         "items": Object {
                             "type": String("string"),
                         },
-                        "type": String("array"),
                     },
                 },
-                "type": String("object"),
             },
         }
         "###);
         insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
         {
+          "type": "object",
           "properties": {
             "id": {
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
-          },
-          "type": "object"
+          }
         }
         "###);
     }
@@ -830,10 +886,13 @@ mod tests {
             name: "QueryName",
             description: "The returned value is optional and has type `String`",
             input_schema: {
+                "type": String("object"),
                 "properties": Object {
                     "id": Object {
+                        "type": String("array"),
                         "oneOf": Array [
                             Object {
+                                "type": String("array"),
                                 "oneOf": Array [
                                     Object {
                                         "type": String("string"),
@@ -842,25 +901,25 @@ mod tests {
                                         "type": String("null"),
                                     },
                                 ],
-                                "type": String("array"),
                             },
                             Object {
                                 "type": String("null"),
                             },
                         ],
-                        "type": String("array"),
                     },
                 },
-                "type": String("object"),
             },
         }
         "###);
         insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
         {
+          "type": "object",
           "properties": {
             "id": {
+              "type": "array",
               "oneOf": [
                 {
+                  "type": "array",
                   "oneOf": [
                     {
                       "type": "string"
@@ -868,17 +927,14 @@ mod tests {
                     {
                       "type": "null"
                     }
-                  ],
-                  "type": "array"
+                  ]
                 },
                 {
                   "type": "null"
                 }
-              ],
-              "type": "array"
+              ]
             }
-          },
-          "type": "object"
+          }
         }
         "###);
     }
@@ -899,8 +955,13 @@ mod tests {
             name: "QueryName",
             description: "The returned value is optional and has type `String`",
             input_schema: {
+                "type": String("object"),
                 "properties": Object {
                     "id": Object {
+                        "type": String("object"),
+                        "required": Array [
+                            String("required"),
+                        ],
                         "properties": Object {
                             "optional": Object {
                                 "description": String("optional is a input field that is optional"),
@@ -911,20 +972,20 @@ mod tests {
                                 "type": String("string"),
                             },
                         },
-                        "required": Array [
-                            String("required"),
-                        ],
-                        "type": String("object"),
                     },
                 },
-                "type": String("object"),
             },
         }
         "###);
         insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
         {
+          "type": "object",
           "properties": {
             "id": {
+              "type": "object",
+              "required": [
+                "required"
+              ],
               "properties": {
                 "optional": {
                   "description": "optional is a input field that is optional",
@@ -934,14 +995,9 @@ mod tests {
                   "description": "required is a input field that is required",
                   "type": "string"
                 }
-              },
-              "required": [
-                "required"
-              ],
-              "type": "object"
+              }
             }
-          },
-          "type": "object"
+          }
         }
         "###);
     }
@@ -962,39 +1018,39 @@ mod tests {
             name: "QueryName",
             description: "The returned value is optional and has type `String`",
             input_schema: {
+                "type": String("object"),
+                "required": Array [
+                    String("id"),
+                ],
                 "properties": Object {
                     "id": Object {
                         "description": String("the description for the enum\n\nValues:\nENUM_VALUE_1: ENUM_VALUE_1 is a value\nENUM_VALUE_2: ENUM_VALUE_2 is a value"),
+                        "type": String("string"),
                         "enum": Array [
                             String("ENUM_VALUE_1"),
                             String("ENUM_VALUE_2"),
                         ],
-                        "type": String("string"),
                     },
                 },
-                "required": Array [
-                    String("id"),
-                ],
-                "type": String("object"),
             },
         }
         "###);
         insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
         {
-          "properties": {
-            "id": {
-              "description": "the description for the enum\n\nValues:\nENUM_VALUE_1: ENUM_VALUE_1 is a value\nENUM_VALUE_2: ENUM_VALUE_2 is a value",
-              "enum": [
-                "ENUM_VALUE_1",
-                "ENUM_VALUE_2"
-              ],
-              "type": "string"
-            }
-          },
+          "type": "object",
           "required": [
             "id"
           ],
-          "type": "object"
+          "properties": {
+            "id": {
+              "description": "the description for the enum\n\nValues:\nENUM_VALUE_1: ENUM_VALUE_1 is a value\nENUM_VALUE_2: ENUM_VALUE_2 is a value",
+              "type": "string",
+              "enum": [
+                "ENUM_VALUE_1",
+                "ENUM_VALUE_2"
+              ]
+            }
+          }
         }
         "###);
     }
@@ -1062,10 +1118,10 @@ mod tests {
             name: "QueryName",
             description: "The returned value is optional and has type `String`",
             input_schema: {
+                "type": String("object"),
                 "properties": Object {
                     "id": Object {},
                 },
-                "type": String("object"),
             },
         }
         "###);
@@ -1088,10 +1144,10 @@ mod tests {
             name: "QueryName",
             description: "The returned value is optional and has type `String`",
             input_schema: {
+                "type": String("object"),
                 "properties": Object {
                     "id": Object {},
                 },
-                "type": String("object"),
             },
         }
         "###);
@@ -1114,12 +1170,12 @@ mod tests {
             name: "QueryName",
             description: "The returned value is optional and has type `String`",
             input_schema: {
+                "type": String("object"),
                 "properties": Object {
                     "id": Object {
                         "description": String("RealCustomScalar exists"),
                     },
                 },
-                "type": String("object"),
             },
         }
         "###);
@@ -1144,25 +1200,25 @@ mod tests {
             name: "QueryName",
             description: "The returned value is optional and has type `String`",
             input_schema: {
+                "type": String("object"),
                 "properties": Object {
                     "id": Object {
                         "description": String("RealCustomScalar exists"),
                         "type": String("string"),
                     },
                 },
-                "type": String("object"),
             },
         }
         "###);
         insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
         {
+          "type": "object",
           "properties": {
             "id": {
               "description": "RealCustomScalar exists",
               "type": "string"
             }
-          },
-          "type": "object"
+          }
         }
         "###);
     }

--- a/crates/mcp-apollo-server/src/server.rs
+++ b/crates/mcp-apollo-server/src/server.rs
@@ -3,9 +3,9 @@ use crate::errors::{McpError, OperationError, ServerError};
 use crate::graphql;
 use crate::graphql::Executable;
 use crate::introspection::{EXECUTE_TOOL_NAME, Execute, GET_SCHEMA_TOOL_NAME, GetSchema};
-use crate::operations::Operation;
+use crate::operations::{Operation, OperationPoller, OperationSource};
 use buildstructor::buildstructor;
-use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
+use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderValue};
 use rmcp::model::{
     CallToolRequestParam, CallToolResult, Content, ErrorCode, ListToolsResult,
     PaginatedRequestParam, ServerCapabilities, ServerInfo,
@@ -13,202 +13,402 @@ use rmcp::model::{
 use rmcp::serde_json::Value;
 use rmcp::service::RequestContext;
 use rmcp::{Peer, RoleServer, ServerHandler, ServiceError, serde_json};
-use std::path::Path;
-use std::str::FromStr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
-use std::time::Duration;
 use tracing::{error, info};
 
 use crate::explorer::{EXPLORER_TOOL_NAME, Explorer};
-pub use apollo_compiler::Schema;
-pub use apollo_compiler::validation::Valid;
+use apollo_compiler::Schema;
+use apollo_compiler::validation::Valid;
+use apollo_federation::{ApiSchemaOptions, Supergraph};
+use futures::{FutureExt, Stream, StreamExt, future, stream};
+use mcp_apollo_registry::uplink::event::Event;
 use mcp_apollo_registry::uplink::persisted_queries::{
-    ManifestChanged, ManifestSource, PersistedQueryManifestPoller,
+    ManifestChanged, PersistedQueryManifestPoller,
 };
-use mcp_apollo_registry::uplink::{SecretString, UplinkConfig};
+pub use mcp_apollo_registry::uplink::schema::SchemaSource;
+use mcp_apollo_registry::uplink::schema::SchemaState;
 pub use rmcp::ServiceExt;
 pub use rmcp::transport::SseServer;
 pub use rmcp::transport::sse_server::SseServerConfig;
 pub use rmcp::transport::stdio;
-use tokio::sync::{RwLock, mpsc};
+use tokio::sync::{Mutex, RwLock, mpsc};
+use tokio_util::sync::CancellationToken;
 
-/// An MCP Server for Apollo GraphQL operations
-#[derive(Clone)]
+/// An Apollo MCP Server
 pub struct Server {
-    schema: Valid<Schema>,
-    operations: Vec<Operation>,
+    transport: Transport,
+    schema_source: SchemaSource,
+    operation_source: OperationSource,
     endpoint: String,
-    default_headers: HeaderMap,
-    execute_tool: Option<Execute>,
-    get_schema_tool: Option<GetSchema>,
-    explorer_tool: Option<Explorer>,
-    manifest_poller: Option<PersistedQueryManifestPoller>,
-    peers: Arc<RwLock<Vec<Peer<RoleServer>>>>,
+    headers: HeaderMap,
+    introspection: bool,
+    explorer: bool,
+    custom_scalar_map: Option<CustomScalarMap>,
 }
+
+#[derive(Clone)]
+pub enum Transport {
+    Stdio,
+    SSE { port: u16 },
+}
+
+/// Types ending with Map cause incorrect assumptions by buildstructor, so use an alias
+type Headers = HeaderMap;
 
 #[buildstructor]
 impl Server {
     #[builder]
-    pub async fn new<P: 'static + AsRef<Path> + Sync + Send + Clone>(
-        schema: Valid<Schema>,
-        operations: Vec<P>,
+    pub fn new(
+        transport: Transport,
+        schema_source: SchemaSource,
+        operation_source: OperationSource,
         endpoint: String,
-        headers: Vec<String>,
+        headers: Headers,
         introspection: bool,
-        uplink: bool,
         explorer: bool,
-        manifests: Vec<P>,
         custom_scalar_map: Option<CustomScalarMap>,
-    ) -> Result<Self, ServerError> {
-        // Load operations from static files
-        let operations = operations
-            .into_iter()
-            .map(|operation| {
-                info!(operation_path=?operation.as_ref(), "Loading operation");
-                let operation = std::fs::read_to_string(operation)?;
-                Operation::from_document(&operation, &schema, None, custom_scalar_map.as_ref())
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        if !operations.is_empty() {
-            info!(
-                "Loaded {} operations from local operations files:\n{}",
-                operations.len(),
-                serde_json::to_string_pretty(&operations)?
-            );
-        }
-
-        if operations.is_empty() && manifests.is_empty() && !uplink {
-            return Err(ServerError::NoOperations);
-        }
-
-        // Set up the manifest poller to pull operations from uplink or a manifest file
-        let manifest_source =
-            if !manifests.is_empty() {
-                Some(ManifestSource::LocalHotReload(manifests))
-            } else if uplink {
-                Some(ManifestSource::Uplink(UplinkConfig {
-                    apollo_key: SecretString::from(std::env::var("APOLLO_KEY").map_err(|_| {
-                        ServerError::EnvironmentVariable(String::from("APOLLO_KEY"))
-                    })?),
-                    apollo_graph_ref: std::env::var("APOLLO_GRAPH_REF").map_err(|_| {
-                        ServerError::EnvironmentVariable(String::from("APOLLO_GRAPH_REF"))
-                    })?,
-                    poll_interval: Duration::from_secs(10),
-                    timeout: Duration::from_secs(30),
-                    endpoints: None, // Use the default endpoints
-                }))
-            } else {
-                None
-            };
-        let (manifest_poller, change_receiver) = if let Some(manifest_source) = manifest_source {
-            let (change_sender, change_receiver) = mpsc::channel::<ManifestChanged>(1);
-            (
-                PersistedQueryManifestPoller::new(manifest_source, change_sender)
-                    .await
-                    .ok(),
-                Some(change_receiver),
-            )
-        } else {
-            (None, None)
+    ) -> Self {
+        let headers = {
+            let mut headers = headers.clone();
+            headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+            headers
         };
-
-        // Load headers
-        let mut default_headers = HeaderMap::new();
-        default_headers.append(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-        for header in headers {
-            let parts: Vec<&str> = header.split(':').collect();
-            match (parts.first(), parts.get(1), parts.get(2)) {
-                (Some(key), Some(value), None) => {
-                    default_headers
-                        .append(HeaderName::from_str(key)?, HeaderValue::from_str(value)?);
-                }
-                _ => return Err(ServerError::Header(header)),
-            }
-        }
-
-        let execute_tool = introspection.then(Execute::new);
-        let get_schema_tool = introspection.then(|| GetSchema::new(schema.clone()));
-        let explorer_tool = explorer
-            .then(|| std::env::var("APOLLO_GRAPH_REF").ok())
-            .flatten()
-            .map(Explorer::new);
-
-        let peers = Arc::new(RwLock::new(vec![]));
-
-        if let Some(change_receiver) = change_receiver {
-            Self::spawn_change_listener(change_receiver, peers.clone());
-        }
-
-        Ok(Self {
-            schema,
-            operations,
+        Self {
+            transport,
+            schema_source,
+            operation_source,
             endpoint,
-            default_headers,
-            execute_tool,
-            get_schema_tool,
-            explorer_tool,
-            manifest_poller,
-            peers,
-        })
+            headers,
+            introspection,
+            explorer,
+            custom_scalar_map,
+        }
     }
 
-    fn spawn_change_listener(
-        mut change_receiver: mpsc::Receiver<ManifestChanged>,
-        peers: Arc<RwLock<Vec<Peer<RoleServer>>>>,
-    ) {
-        tokio::spawn(async move {
-            while change_receiver.recv().await.is_some() {
-                let mut peers = peers.write().await;
-                if !peers.is_empty() {
-                    info!(
-                        "Persisted query manifest changed, notifying {} peers of tool change",
-                        peers.len()
-                    );
-                }
-                let mut retained_peers = Vec::new();
-                for peer in peers.iter() {
-                    match peer.notify_tool_list_changed().await {
-                        Ok(_) => retained_peers.push(peer.clone()),
-                        Err(ServiceError::Transport(e)) if e.get_ref().is_some() => {
-                            if e.to_string() == *"disconnected" {
-                                // TODO: this always gets a "disconnected" error due to a bug in the SDK, but it actually works
-                                retained_peers.push(peer.clone());
-                            } else {
-                                error!(
-                                    "Failed to notify peer of tool list change: {:?} - dropping peer",
-                                    e
-                                );
-                            }
-                        }
-                        Err(e) => {
-                            error!("Failed to notify peer of tool list change {:?}", e);
-                            retained_peers.push(peer.clone());
-                        }
-                    }
-                }
-                *peers = retained_peers;
-            }
-        });
+    pub async fn start(self) -> Result<(), ServerError> {
+        StateMachine {}.start(self).await
     }
+}
 
-    /// Get the current set of operations from the manifest, if any
-    fn manifest_operations(&self) -> Result<Vec<Operation>, McpError> {
-        if let Some(manifest_poller) = self.manifest_poller.as_ref() {
-            manifest_poller
-                .get_all_operations()
-                .into_iter()
-                .map(|(pq_id, operation)| {
-                    Operation::from_document(&operation, &self.schema, Some(pq_id), None)
-                })
-                .collect::<Result<Vec<Operation>, OperationError>>()
-                .map_err(|e| McpError::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))
-        } else {
-            Ok(vec![])
+#[allow(clippy::large_enum_variant)]
+enum State {
+    Starting(Starting),
+    Running(Running),
+    Error(ServerError),
+    Stopping,
+}
+
+impl From<Starting> for State {
+    fn from(starting: Starting) -> Self {
+        State::Starting(starting)
+    }
+}
+
+impl From<Result<Running, ServerError>> for State {
+    fn from(result: Result<Running, ServerError>) -> Self {
+        match result {
+            Ok(running) => State::Running(running),
+            Err(error) => State::Error(error),
         }
     }
 }
 
-impl ServerHandler for Server {
+impl From<ServerError> for State {
+    fn from(error: ServerError) -> Self {
+        State::Error(error)
+    }
+}
+
+struct Starting {
+    transport: Transport,
+    operation_source: OperationSource,
+    endpoint: String,
+    headers: HeaderMap,
+    introspection: bool,
+    explorer: bool,
+    custom_scalar_map: Option<CustomScalarMap>,
+}
+
+impl Starting {
+    /// Run the MCP server once the schema is ready
+    async fn run(self, schema: Valid<Schema>) -> Result<Running, ServerError> {
+        info!("Running with schema:\n{}", schema);
+
+        let peers = Arc::new(RwLock::new(vec![]));
+
+        let (operation_poller, change_receiver) = match self.operation_source {
+            OperationSource::Files(paths) => (OperationPoller::Files(paths), None),
+            OperationSource::Manifest(manifest_source) => {
+                let (change_sender, change_receiver) = mpsc::channel::<ManifestChanged>(1);
+                (
+                    OperationPoller::Manifest(
+                        PersistedQueryManifestPoller::new(manifest_source, change_sender)
+                            .await
+                            .map_err(|e| {
+                                ServerError::Operation(OperationError::Internal(e.to_string()))
+                            })?,
+                    ),
+                    Some(change_receiver),
+                )
+            }
+        };
+        let operations = operation_poller
+            .operations(&schema, self.custom_scalar_map.as_ref())
+            .await?;
+
+        let schema = Arc::new(Mutex::new(schema));
+
+        let execute_tool = self.introspection.then(Execute::new);
+        let get_schema_tool = self.introspection.then(|| GetSchema::new(schema.clone()));
+        let explorer_tool = self
+            .explorer
+            .then(|| std::env::var("APOLLO_GRAPH_REF").ok())
+            .flatten()
+            .map(Explorer::new);
+
+        let cancellation_token = CancellationToken::new();
+
+        let running = Running {
+            schema,
+            operations: Arc::new(Mutex::new(operations)),
+            operation_poller,
+            headers: self.headers,
+            endpoint: self.endpoint,
+            execute_tool,
+            get_schema_tool,
+            explorer_tool,
+            custom_scalar_map: self.custom_scalar_map,
+            peers,
+            cancellation_token: cancellation_token.clone(),
+        };
+
+        if let Some(change_receiver) = change_receiver {
+            running.spawn_change_listener(change_receiver);
+        }
+
+        if let Transport::SSE { port } = self.transport {
+            info!(port = ?port, "Starting MCP server in SSE mode");
+            let running = running.clone();
+            let listen_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+            SseServer::serve_with_config(SseServerConfig {
+                bind: listen_address,
+                sse_path: "/sse".to_string(),
+                post_path: "/message".to_string(),
+                ct: cancellation_token,
+            })
+            .await?
+            .with_service(move || running.clone());
+        } else {
+            info!("Starting MCP server in stdio mode");
+            let service = running.clone().serve(stdio()).await.inspect_err(|e| {
+                error!("serving error: {:?}", e);
+            })?;
+            service.waiting().await.map_err(ServerError::StartupError)?;
+        }
+
+        Ok(running)
+    }
+}
+
+#[derive(Clone)]
+struct Running {
+    schema: Arc<Mutex<Valid<Schema>>>,
+    operations: Arc<Mutex<Vec<Operation>>>,
+    operation_poller: OperationPoller,
+    headers: HeaderMap,
+    endpoint: String,
+    execute_tool: Option<Execute>,
+    get_schema_tool: Option<GetSchema>,
+    explorer_tool: Option<Explorer>,
+    custom_scalar_map: Option<CustomScalarMap>,
+    peers: Arc<RwLock<Vec<Peer<RoleServer>>>>,
+    cancellation_token: CancellationToken,
+}
+
+impl Running {
+    /// Update a running server with a new schema.
+    async fn update_schema(self, schema: Valid<Schema>) -> Result<Running, ServerError> {
+        info!("Schema updated:\n{}", schema);
+
+        // Update the operations based on the new schema. This is necessary because the MCP tool
+        // input schemas and description are derived from the schema.
+        let operations = self
+            .operation_poller
+            .operations(&schema, self.custom_scalar_map.as_ref())
+            .await?;
+        info!(
+            "Updated {} operations:\n{}",
+            operations.len(),
+            serde_json::to_string_pretty(&operations)?
+        );
+        *self.operations.lock().await = operations;
+
+        // Update the schema itself
+        *self.schema.lock().await = schema;
+
+        // Notify MCP clients that tools have changed
+        Self::notify_tool_list_changed(self.peers.clone()).await;
+        Ok(self)
+    }
+
+    /// Notify any peers that tools have changed. Drops unreachable peers from the list.
+    async fn notify_tool_list_changed(peers: Arc<RwLock<Vec<Peer<RoleServer>>>>) {
+        let mut peers = peers.write().await;
+        if !peers.is_empty() {
+            info!(
+                "Persisted query manifest changed, notifying {} peers of tool change",
+                peers.len()
+            );
+        }
+        let mut retained_peers = Vec::new();
+        for peer in peers.iter() {
+            match peer.notify_tool_list_changed().await {
+                Ok(_) => retained_peers.push(peer.clone()),
+                Err(ServiceError::Transport(e)) if e.get_ref().is_some() => {
+                    if e.to_string() == *"disconnected" {
+                        // This always gets a "disconnected" error due to a bug in the SDK, but it actually works
+                        retained_peers.push(peer.clone());
+                    } else {
+                        error!(
+                            "Failed to notify peer of tool list change: {:?} - dropping peer",
+                            e
+                        );
+                    }
+                }
+                Err(e) => {
+                    error!("Failed to notify peer of tool list change {:?}", e);
+                    retained_peers.push(peer.clone());
+                }
+            }
+        }
+        *peers = retained_peers;
+    }
+
+    /// Spawn a listener for any changes to the operation manifest.
+    fn spawn_change_listener(&self, mut change_receiver: mpsc::Receiver<ManifestChanged>) {
+        let peers = self.peers.clone();
+        let operations = self.operations.clone();
+        let operation_poller = self.operation_poller.clone();
+        let custom_scalars = self.custom_scalar_map.clone();
+        let schema = self.schema.clone();
+        tokio::spawn(async move {
+            while change_receiver.recv().await.is_some() {
+                match operation_poller
+                    .operations(&*schema.lock().await, custom_scalars.as_ref())
+                    .await
+                {
+                    Ok(new_operations) => *operations.lock().await = new_operations,
+                    // TODO: ideally, we'd send the server to the error state here because it's
+                    //  no longer configured correctly. To do this, we'd have to receive the PQ
+                    //  updates through the same stream where schema changes are tracked. However,
+                    //  the router code ported into mcp-apollo-registry does not work that way -
+                    //  it has a separate PQ update mechanism. That will need to be rewritten, or
+                    //  maybe there's some way to bridge the PQ changes into the same stream.
+                    Err(e) => error!("Failed to update operations: {:?}", e),
+                }
+
+                Self::notify_tool_list_changed(peers.clone()).await;
+            }
+        });
+    }
+}
+
+struct StateMachine {}
+
+impl StateMachine {
+    pub(crate) async fn start(self, server: Server) -> Result<(), ServerError> {
+        let mut stream = stream::select_all(vec![
+            server.schema_source.into_stream().boxed(),
+            Self::ctrl_c_stream().boxed(),
+        ])
+        .take_while(|msg| future::ready(!matches!(msg, Event::Shutdown)))
+        .chain(stream::iter(vec![Event::Shutdown]))
+        .boxed();
+        let mut state = State::Starting(Starting {
+            transport: server.transport,
+            operation_source: server.operation_source,
+            endpoint: server.endpoint,
+            headers: server.headers,
+            introspection: server.introspection,
+            explorer: server.explorer,
+            custom_scalar_map: server.custom_scalar_map,
+        });
+        while let Some(event) = stream.next().await {
+            state = match event {
+                Event::UpdateSchema(schema_state) => {
+                    let schema = Self::sdl_to_api_schema(schema_state)?;
+                    match state {
+                        State::Starting(starting) => starting.run(schema).await.into(),
+                        State::Running(running) => running.update_schema(schema).await.into(),
+                        other => other,
+                    }
+                }
+                Event::NoMoreSchema => match state {
+                    State::Starting { .. } => State::Error(ServerError::NoSchema),
+                    _ => state,
+                },
+                Event::Shutdown => match state {
+                    State::Running(running) => {
+                        running.cancellation_token.cancel();
+                        State::Stopping
+                    }
+                    _ => State::Stopping,
+                },
+            };
+            if matches!(&state, State::Error(_) | State::Stopping) {
+                break;
+            }
+        }
+        match state {
+            State::Error(e) => Err(e),
+            _ => Ok(()),
+        }
+    }
+
+    fn sdl_to_api_schema(schema_state: SchemaState) -> Result<Valid<Schema>, ServerError> {
+        let schema = Schema::parse_and_validate(schema_state.sdl, "schema.graphql")
+            .map_err(|e| ServerError::GraphQLSchema(e.into()))?;
+        Ok(Supergraph::from_schema(schema)
+            .map_err(ServerError::Federation)?
+            .to_api_schema(ApiSchemaOptions::default())
+            .map_err(ServerError::Federation)?
+            .schema()
+            .clone())
+    }
+
+    #[allow(clippy::expect_used)]
+    fn ctrl_c_stream() -> impl Stream<Item = Event> {
+        #[cfg(not(unix))]
+        {
+            async {
+                tokio::signal::ctrl_c()
+                    .await
+                    .expect("Failed to install CTRL+C signal handler");
+            }
+            .map(|_| Event::Shutdown)
+            .into_stream()
+            .boxed()
+        }
+
+        #[cfg(unix)]
+        future::select(
+            tokio::signal::ctrl_c().map(|s| s.ok()).boxed(),
+            async {
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                    .expect("Failed to install SIGTERM signal handler")
+                    .recv()
+                    .await
+            }
+            .boxed(),
+        )
+        .map(|_| Event::Shutdown)
+        .into_stream()
+        .boxed()
+    }
+}
+
+impl ServerHandler for Running {
     async fn call_tool(
         &self,
         request: CallToolRequestParam,
@@ -220,7 +420,7 @@ impl ServerHandler for Server {
                 .as_ref()
                 .ok_or(tool_not_found(&request.name))?;
             Ok(CallToolResult {
-                content: vec![Content::text(get_schema.schema.to_string())],
+                content: vec![Content::text(get_schema.schema.lock().await.to_string())],
                 is_error: None,
             })
         } else if request.name == EXPLORER_TOOL_NAME {
@@ -233,7 +433,7 @@ impl ServerHandler for Server {
             let graphql_request = graphql::Request {
                 input: Value::from(request.arguments.clone()),
                 endpoint: &self.endpoint,
-                headers: self.default_headers.clone(),
+                headers: self.headers.clone(),
             };
             if request.name == EXECUTE_TOOL_NAME {
                 self.execute_tool
@@ -243,8 +443,9 @@ impl ServerHandler for Server {
                     .await
             } else {
                 self.operations
+                    .lock()
+                    .await
                     .iter()
-                    .chain(self.manifest_operations()?.iter())
                     .find(|op| op.as_ref().name == request.name)
                     .ok_or(tool_not_found(&request.name))?
                     .execute(graphql_request)
@@ -262,8 +463,9 @@ impl ServerHandler for Server {
             next_cursor: None,
             tools: self
                 .operations
+                .lock()
+                .await
                 .iter()
-                .chain(self.manifest_operations()?.iter())
                 .map(|op| op.as_ref().clone())
                 .chain(
                     self.execute_tool

--- a/crates/mcp-apollo-server/src/server.rs
+++ b/crates/mcp-apollo-server/src/server.rs
@@ -152,7 +152,7 @@ impl Starting {
                     Some(change_receiver),
                 )
             }
-            OperationSource::None => (OperationPoller::None, None)
+            OperationSource::None => (OperationPoller::None, None),
         };
         let operations = operation_poller
             .operations(&schema, self.custom_scalar_map.as_ref())

--- a/crates/mcp-apollo-server/src/server.rs
+++ b/crates/mcp-apollo-server/src/server.rs
@@ -152,6 +152,7 @@ impl Starting {
                     Some(change_receiver),
                 )
             }
+            OperationSource::None => (OperationPoller::None, None)
         };
         let operations = operation_poller
             .operations(&schema, self.custom_scalar_map.as_ref())

--- a/crates/mcp-apollo-server/src/server.rs
+++ b/crates/mcp-apollo-server/src/server.rs
@@ -22,13 +22,13 @@ use apollo_compiler::Schema;
 use apollo_compiler::validation::Valid;
 use apollo_federation::{ApiSchemaOptions, Supergraph};
 use futures::{FutureExt, Stream, StreamExt, future, stream};
+pub use mcp_apollo_registry::uplink::UplinkConfig;
 use mcp_apollo_registry::uplink::event::Event;
+pub use mcp_apollo_registry::uplink::persisted_queries::ManifestSource;
 use mcp_apollo_registry::uplink::persisted_queries::{
     ManifestChanged, PersistedQueryManifestPoller,
 };
-pub use mcp_apollo_registry::uplink::UplinkConfig;
 pub use mcp_apollo_registry::uplink::schema::SchemaSource;
-pub use mcp_apollo_registry::uplink::persisted_queries::ManifestSource;
 use mcp_apollo_registry::uplink::schema::SchemaState;
 pub use rmcp::ServiceExt;
 pub use rmcp::transport::SseServer;

--- a/crates/mcp-apollo-server/src/server.rs
+++ b/crates/mcp-apollo-server/src/server.rs
@@ -26,6 +26,7 @@ use mcp_apollo_registry::uplink::event::Event;
 use mcp_apollo_registry::uplink::persisted_queries::{
     ManifestChanged, PersistedQueryManifestPoller,
 };
+pub use mcp_apollo_registry::uplink::UplinkConfig;
 pub use mcp_apollo_registry::uplink::schema::SchemaSource;
 pub use mcp_apollo_registry::uplink::persisted_queries::ManifestSource;
 use mcp_apollo_registry::uplink::schema::SchemaState;

--- a/crates/mcp-apollo-server/src/server.rs
+++ b/crates/mcp-apollo-server/src/server.rs
@@ -27,6 +27,7 @@ use mcp_apollo_registry::uplink::persisted_queries::{
     ManifestChanged, PersistedQueryManifestPoller,
 };
 pub use mcp_apollo_registry::uplink::schema::SchemaSource;
+pub use mcp_apollo_registry::uplink::persisted_queries::ManifestSource;
 use mcp_apollo_registry::uplink::schema::SchemaState;
 pub use rmcp::ServiceExt;
 pub use rmcp::transport::SseServer;

--- a/graphql/weather/supergraph.graphql
+++ b/graphql/weather/supergraph.graphql
@@ -1,0 +1,124 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/tag/v0.3")
+  @link(url: "https://specs.apollo.dev/connect/v0.1", for: EXECUTION)
+  @join__directive(graphs: [WEATHER], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
+  @join__directive(graphs: [WEATHER], name: "source", args: {name: "NWS", http: {baseURL: "https://api.weather.gov", headers: [{name: "User-Agent", value: "weather-app/1.0"}, {name: "Accept", value: "application/geo+json"}]}})
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+"""A weather alert"""
+type Alert
+  @join__type(graph: WEATHER)
+  @tag(name: "mcp")
+{
+  """The severity of this alert"""
+  severity: String
+
+  """A description of the alert"""
+  description: String
+
+  """Information about how people should respond to the alert"""
+  instruction: String
+}
+
+"""A coordinate, consisting of a latitude and longitude"""
+type Coordinate
+  @join__type(graph: WEATHER)
+{
+  """The latitude of this coordinate"""
+  latitude: String!
+
+  """The longitude of this coordinate"""
+  longitude: String!
+}
+
+"""A weather forecast"""
+type Forecast
+  @join__type(graph: WEATHER)
+{
+  """The coordinate associated with this forecast"""
+  coordinate: Coordinate!
+
+  """
+  The National Weather Service (NWS) URL where the forecast data can be read
+  """
+  forecastURL: String!
+
+  """A detailed weather forecast from the National Weather Service (NWS)"""
+  detailed: String! @join__directive(graphs: [WEATHER], name: "connect", args: {http: {GET: "https://api.weather.gov/gridpoints/FFC/51,87/forecast", headers: [{name: "foo", value: "{$this.forecastURL}"}, {name: "Accept", value: "application/geo+json"}, {name: "User-Agent", value: "weather-app/1.0"}]}, selection: "$.properties.periods->first.detailedForecast"})
+}
+
+"""A coordinate, consisting of a latitude and longitude"""
+input InputCoordinate
+  @join__type(graph: WEATHER)
+{
+  """The latitude of this coordinate"""
+  latitude: String!
+
+  """The longitude of this coordinate"""
+  longitude: String!
+}
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  WEATHER @join__graph(name: "weather", url: "http://localhost")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: WEATHER)
+{
+  """Get the weather forecast for a coordinate"""
+  forecast(coordinate: InputCoordinate!): Forecast @join__directive(graphs: [WEATHER], name: "connect", args: {source: "NWS", http: {GET: "/points/{$args.coordinate.latitude},{$args.coordinate.longitude}"}, selection: "coordinate: {\n  latitude: $args.coordinate.latitude\n  longitude: $args.coordinate.longitude\n}\nforecastURL: properties.forecast", entity: true})
+
+  """
+  Get the weather alerts for a state, using the two-letter abbreviation for the state - for example, CO for Colorado
+  """
+  alerts(state: String!): [Alert] @join__directive(graphs: [WEATHER], name: "connect", args: {source: "NWS", http: {GET: "/alerts/active/area/{$args.state}"}, selection: "$.features.properties {\n  severity\n  description\n  instruction\n}"}) @tag(name: "mcp")
+}


### PR DESCRIPTION
Significant rewrite of the server to support loading the supergraph schema from Uplink. Supports hot reloading the schema. A local schema file can also be used, and also supports hot reloading as the file changes.

**Important Note** - with this change, the MCP server requires the supergraph schema SDL, similarly to Apollo Router. It will no longer work with an API or subgraph schema. To use with a local schema file, this can be composed locally (with `rover supergraph compose`) or downloaded from GraphOS (with `rover graph fetch`). The weather example has been updated with a `supergraph.graphql` file.

Changes:

* Use a state machine to run the server. This is similar to Apollo Router. The server is only ready to serve requests once the schema and operations have been loaded.
* Add code to pull the schema from Uplink to `mcp-server-registry`. This code is borrowed directly from router, and should be shared long-term.
* Fix the `explorer` tool - this was using the wrong method to generate the URL, and needed more validation to prevent the AI model sending incorrect input.