### PR TITLE
Fix tool to open Apollo Explorer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "buildstructor"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +761,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
 name = "graphql-introspection-query"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,8 +1209,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
 dependencies = [
  "console",
+ "globset",
  "once_cell",
+ "pest",
+ "pest_derive",
+ "serde",
  "similar",
+ "walkdir",
 ]
 
 [[package]]
@@ -1382,7 +1410,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "apollo-compiler",
- "base64 0.22.1",
  "buildstructor",
  "clap",
  "derive-new",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +765,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "globset"
@@ -1419,6 +1431,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rmcp",
+ "rstest",
  "serde",
  "thiserror 2.0.12",
  "tokio",
@@ -1725,6 +1738,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1829,6 +1851,12 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
@@ -1938,6 +1966,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.101",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,6 +2006,15 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2092,6 +2159,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -2479,6 +2552,23 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -3143,6 +3233,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ package.version = "0.1.0"
 [workspace.dependencies]
 apollo-compiler = "1.27.0"
 insta = { version = "1.43.1", features = [
-    "json",
-    "redactions",
-    "yaml",
-    "glob",
+  "json",
+  "redactions",
+  "yaml",
+  "glob",
 ] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,12 @@ package.version = "0.1.0"
 
 [workspace.dependencies]
 apollo-compiler = "1.27.0"
+insta = { version = "1.43.1", features = [
+    "json",
+    "redactions",
+    "yaml",
+    "glob",
+] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 thiserror = "2.0.12"

--- a/crates/mcp-apollo-server/Cargo.toml
+++ b/crates/mcp-apollo-server/Cargo.toml
@@ -37,6 +37,7 @@ webbrowser = "1.0.4"
 
 [dev-dependencies]
 insta = { workspace = true }
+rstest = "0.25.0"
 
 [lints]
 workspace = true

--- a/crates/mcp-apollo-server/Cargo.toml
+++ b/crates/mcp-apollo-server/Cargo.toml
@@ -34,10 +34,9 @@ tracing.workspace = true
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 regex = "1.11.1"
 webbrowser = "1.0.4"
-base64 = "0.22.1"
 
 [dev-dependencies]
-insta = "1.42.2"
+insta = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mcp-apollo-server/src/explorer.rs
+++ b/crates/mcp-apollo-server/src/explorer.rs
@@ -4,8 +4,10 @@ use rmcp::model::{CallToolResult, Content, ErrorCode, Tool};
 use rmcp::schemars::JsonSchema;
 use rmcp::serde_json::Value;
 use rmcp::{schemars, serde_json};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tracing::info;
+use tracing::log::Level::Info;
+use tracing::log::log_enabled;
 
 pub(crate) const EXPLORER_TOOL_NAME: &str = "explorer";
 
@@ -16,17 +18,23 @@ pub struct Explorer {
     pub tool: Tool,
 }
 
-#[derive(JsonSchema, Deserialize)]
-#[allow(dead_code)] // This is only used to generate the JSON schema
+#[derive(JsonSchema, Deserialize, Serialize)]
 pub struct Input {
     /// The GraphQL document
+    #[serde(default = "default_input")]
     document: String,
 
     /// Any variables used in the document
+    #[serde(default = "default_input")]
     variables: String,
 
     /// Headers to be sent with the operation
+    #[serde(default = "default_input")]
     headers: String,
+}
+
+fn default_input() -> String {
+    "{}".to_string()
 }
 
 impl Explorer {
@@ -46,42 +54,33 @@ impl Explorer {
         }
     }
 
-    fn create_explorer_url(&self, input: &Value) -> String {
-        let mut input = input.clone();
-
-        let document = input.get("document").and_then(|v| v.as_str());
-        if document.is_none() || document == Some("") {
-            if let Some(obj) = input.as_object_mut() {
-                obj.insert("document".to_string(), Value::String("{}".to_string()));
-            }
-        }
-        let variables = input.get("variables").and_then(|v| v.as_str());
-        if variables.is_none() || variables == Some("") {
-            if let Some(obj) = input.as_object_mut() {
-                obj.insert("variables".to_string(), Value::String("{}".to_string()));
-            }
-        }
-        let headers = input.get("headers").and_then(|v| v.as_str());
-        if headers.is_none() || headers == Some("") {
-            if let Some(obj) = input.as_object_mut() {
-                obj.insert("headers".to_string(), Value::String("{}".to_string()));
-            }
-        }
-        let compressed = lz_str::compress_to_encoded_uri_component(input.to_string().as_str());
-        format!(
-            "https://studio.apollographql.com/graph/{graph_id}/variant/{variant}/explorer?explorerURLState={compressed}",
-            graph_id = self.graph_id,
-            variant = self.variant
-        )
+    fn create_explorer_url(&self, input: Input) -> Result<String, McpError> {
+        serde_json::to_string(&input)
+            .map(|serialized| lz_str::compress_to_encoded_uri_component(serialized.as_str()))
+            .map(|compressed| {
+                format!(
+                    "https://studio.apollographql.com/graph/{graph_id}/variant/{variant}/explorer?explorerURLState={compressed}",
+                    graph_id = self.graph_id,
+                    variant = self.variant,
+                )
+            })
+            .map_err(|e| {
+                McpError::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Unable to serialize input: {e}"),
+                    None,
+                )
+            })
     }
 
-    pub async fn execute(&self, input: Value) -> Result<CallToolResult, McpError> {
-        let url = self.create_explorer_url(&input);
-        info!(
-            "Opening Apollo Explorer URL: {} for input operation: {}",
-            url,
-            serde_json::to_string_pretty(&input).unwrap_or("<unable to serialize>".into())
-        );
+    pub async fn execute(&self, input: Input) -> Result<CallToolResult, McpError> {
+        let pretty = if log_enabled!(Info) {
+            Some(serde_json::to_string_pretty(&input).unwrap_or("<unable to serialize>".into()))
+        } else {
+            None
+        };
+        let url = self.create_explorer_url(input)?;
+        info!(?url, input=?pretty, "Opening Apollo Explorer");
         webbrowser::open(url.as_str())
             .map(|_| CallToolResult {
                 content: vec![Content::text("success")],
@@ -103,14 +102,16 @@ mod tests {
         let explorer = Explorer::new(String::from("mcp-example@mcp"));
         let input = json!({
             "document": "query GetWeatherAlerts($state: String!) {\n  alerts(state: $state) {\n    severity\n    description\n    instruction\n  }\n}",
-            "variables": "{\"state\": \"CA\"}",
-            "headers": "{}"
+            "variables": "{\"state\": \"CO\"}",
+            "headers": "{\"x-foo\": \"bar\"}",
         });
 
-        let url = explorer.create_explorer_url(&input);
+        let input: Input = serde_json::from_value(input).unwrap();
+
+        let url = explorer.create_explorer_url(input).unwrap();
         assert_snapshot!(
             url,
-            @"https://studio.apollographql.com/graph/mcp-example/variant/mcp/explorer?explorerURLState=N4IgJg9gxgrgtgUwHYBcQC4QEcYIE4CeABAOIIoDqCAhigBb4CCANvigM4AUAJOyrQnREAyijwBLJAHMAhAEoiwADpIiRaqzwdOfAUN78UCBctVqi7BADd84lARXmiYBOygSADinEQkj85J8eDBQ3r7+AL4qESAANCAM1C547BggwDHxVtQS1ABGrKmYyiC6RkoYRBUAwowVMRFAA"
+            @"https://studio.apollographql.com/graph/mcp-example/variant/mcp/explorer?explorerURLState=N4IgJg9gxgrgtgUwHYBcQC4QEcYIE4CeABAOIIoDqCAhigBb4CCANvigM4AUAJOyrQnREAyijwBLJAHMAhAEoiwADpIiRaqzwdOfAUN78UCBctVqi7BADd84lARXmiYBOygSADinEQkj85J8eDBQ3r7+AL4qESAANCBW1BLUAEas7BggyiC6RkoYRPkAwgDy+THxDNQueBmY2QAeALQAZhAQ+UL5KUnlIBFAA"
         );
     }
 
@@ -119,38 +120,34 @@ mod tests {
     #[case(json!({
         "variables": "{\"state\": \"CA\"}",
         "headers": "{}"
-    }), "document")]
+    }), json!({
+        "document": "{}",
+        "variables": "{\"state\": \"CA\"}",
+        "headers": "{}"
+    }))]
     #[case(json!({
         "document": "query GetWeatherAlerts($state: String!) {\n  alerts(state: $state) {\n    severity\n    description\n    instruction\n  }\n}",
         "headers": "{}"
-    }), "variables")]
+    }), json!({
+        "document": "query GetWeatherAlerts($state: String!) {\n  alerts(state: $state) {\n    severity\n    description\n    instruction\n  }\n}",
+        "variables": "{}",
+        "headers": "{}"
+    }))]
     #[case(json!({
         "document": "query GetWeatherAlerts($state: String!) {\n  alerts(state: $state) {\n    severity\n    description\n    instruction\n  }\n}",
-        "variables": "{\"state\": \"CA\"}"
-    }), "headers")]
-    async fn test_input_missing_fields(#[case] input: Value, #[case] missing_field: &str) {
+        "variables": "{\"state\": \"CA\"}",
+    }), json!({
+        "document": "query GetWeatherAlerts($state: String!) {\n  alerts(state: $state) {\n    severity\n    description\n    instruction\n  }\n}",
+        "variables": "{\"state\": \"CA\"}",
+        "headers": "{}"
+    }))]
+    async fn test_input_missing_fields(#[case] input: Value, #[case] input_with_default: Value) {
+        let input = serde_json::from_value::<Input>(input).unwrap();
+        let input_with_default = serde_json::from_value::<Input>(input_with_default).unwrap();
         let explorer = Explorer::new(String::from("mcp-example@mcp"));
-        let url = explorer.create_explorer_url(&input);
-        let filled_input = {
-            let mut input = input;
-            if missing_field == "document" {
-                if let Some(obj) = input.as_object_mut() {
-                    obj.insert("document".to_string(), Value::String("{}".to_string()));
-                }
-            }
-            if missing_field == "variables" {
-                if let Some(obj) = input.as_object_mut() {
-                    obj.insert("variables".to_string(), Value::String("{}".to_string()));
-                }
-            }
-            if missing_field == "headers" {
-                if let Some(obj) = input.as_object_mut() {
-                    obj.insert("headers".to_string(), Value::String("{}".to_string()));
-                }
-            }
-            input
-        };
-        let expected_url = explorer.create_explorer_url(&filled_input);
-        assert_eq!(url, expected_url);
+        assert_eq!(
+            explorer.create_explorer_url(input),
+            explorer.create_explorer_url(input_with_default)
+        );
     }
 }

--- a/crates/mcp-apollo-server/src/explorer.rs
+++ b/crates/mcp-apollo-server/src/explorer.rs
@@ -1,11 +1,11 @@
 use crate::errors::McpError;
 use crate::schema_from_type;
-use base64::Engine;
 use rmcp::model::{CallToolResult, Content, ErrorCode, Tool};
 use rmcp::schemars::JsonSchema;
 use rmcp::serde_json::Value;
 use rmcp::{schemars, serde_json};
 use serde::Deserialize;
+use tracing::info;
 
 pub(crate) const EXPLORER_TOOL_NAME: &str = "explorer";
 
@@ -36,24 +36,77 @@ impl Explorer {
             variant,
             tool: Tool::new(
                 EXPLORER_TOOL_NAME,
-                "Open a GraphQL operation in Apollo Explorer",
+                "Open a GraphQL operation in Apollo Explorer. The input fields must be in the order document, variables, headers. All fields must be present, but if they are not set, set them to a string containing just `{}`",
                 schema_from_type!(Input),
             ),
         }
     }
 
     fn create_explorer_url(&self, input: &Value) -> String {
-        let compressed = lz_str::compress_to_uint8_array(input.to_string().as_str());
-        let encoded = base64::engine::general_purpose::STANDARD.encode(compressed);
+        let compressed = lz_str::compress_to_encoded_uri_component(input.to_string().as_str());
         format!(
-            "https://studio.apollographql.com/graph/{graph_id}/variant/{variant}/explorer?explorerURLState={encoded}",
+            "https://studio.apollographql.com/graph/{graph_id}/variant/{variant}/explorer?explorerURLState={compressed}",
             graph_id = self.graph_id,
             variant = self.variant
         )
     }
 
     pub async fn execute(&self, input: Value) -> Result<CallToolResult, McpError> {
-        webbrowser::open(self.create_explorer_url(&input).as_str())
+        // Validate field order: must be ["document", "variables", "headers"]
+        if let Value::Object(map) = &input {
+            let mut keys = map.keys();
+            if !(keys.next() == Some(&"document".to_string())
+                && keys.next() == Some(&"variables".to_string())
+                && keys.next() == Some(&"headers".to_string())
+                && keys.next().is_none())
+            {
+                return Err(McpError::new(
+                    ErrorCode::INVALID_PARAMS,
+                    "Input fields must be in order: document, variables, headers",
+                    None,
+                ));
+            }
+        } else {
+            return Err(McpError::new(
+                ErrorCode::INVALID_PARAMS,
+                "Input must be a JSON object",
+                None,
+            ));
+        }
+
+        let document = input.get("document").and_then(|v| v.as_str());
+        let variables = input.get("variables").and_then(|v| v.as_str());
+        let headers = input.get("headers").and_then(|v| v.as_str());
+
+        if document.is_none() || document == Some("") {
+            return Err(McpError::new(
+                ErrorCode::INVALID_PARAMS,
+                "Missing or empty 'document' field in input",
+                None,
+            ));
+        }
+        if variables.is_none() || variables == Some("") {
+            return Err(McpError::new(
+                ErrorCode::INVALID_PARAMS,
+                "Missing or empty 'variables' field in input",
+                None,
+            ));
+        }
+        if headers.is_none() || headers == Some("") {
+            return Err(McpError::new(
+                ErrorCode::INVALID_PARAMS,
+                "Missing or empty 'headers' field in input",
+                None,
+            ));
+        }
+
+        let url = self.create_explorer_url(&input);
+        info!(
+            "Opening Apollo Explorer URL: {} for input operation: {}",
+            url,
+            serde_json::to_string_pretty(&input).unwrap_or("<unable to serialize>".into())
+        );
+        webbrowser::open(url.as_str())
             .map(|_| CallToolResult {
                 content: vec![Content::text("success")],
                 is_error: None,
@@ -65,6 +118,7 @@ impl Explorer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use insta::assert_snapshot;
     use rmcp::serde_json::json;
 
     #[test]
@@ -72,14 +126,14 @@ mod tests {
         let explorer = Explorer::new(String::from("mcp-example@mcp"));
         let input = json!({
             "document": "query GetWeatherAlerts($state: String!) {\n  alerts(state: $state) {\n    severity\n    description\n    instruction\n  }\n}",
-            "headers": "{}",
-            "variables": "{\"state\": \"CA\"}"
+            "variables": "{\"state\": \"CA\"}",
+            "headers": "{}"
         });
 
         let url = explorer.create_explorer_url(&input);
-        assert_eq!(
+        assert_snapshot!(
             url,
-            "https://studio.apollographql.com/graph/mcp-example/variant/mcp/explorer?explorerURLState=N4IgJg9gxgrgtgUwHYBcQC4QEcYIE4CeABAOIIoDqCAhigBb4CCANvigM4AUAJOyrQnREAyijwBLJAHMAhAEoiwADpIiRaqzwdOfAUN78UCBctVqi7BADd84lARXmiYBOygSADinEQkj85J8eDBQ3r7+AL4qESAANCAM1C547BggwDHxVtQS1ABGrKmYyiC6RkoYRBUAwowVMRFAAAA="
+            @"https://studio.apollographql.com/graph/mcp-example/variant/mcp/explorer?explorerURLState=N4IgJg9gxgrgtgUwHYBcQC4QEcYIE4CeABAOIIoDqCAhigBb4CCANvigM4AUAJOyrQnREAyijwBLJAHMAhAEoiwADpIiRaqzwdOfAUN78UCBctVqi7BADd84lARXmiYBOygSADinEQkj85J8eDBQ3r7+AL4qESAANCAM1C547BggwDHxVtQS1ABGrKmYyiC6RkoYRBUAwowVMRFAA"
         );
     }
 }

--- a/crates/mcp-apollo-server/src/server.rs
+++ b/crates/mcp-apollo-server/src/server.rs
@@ -227,7 +227,11 @@ impl ServerHandler for Server {
             self.explorer_tool
                 .as_ref()
                 .ok_or(tool_not_found(&request.name))?
-                .execute(Value::from(request.arguments.clone()))
+                .execute(
+                    serde_json::from_value(Value::from(request.arguments)).map_err(|_| {
+                        McpError::new(ErrorCode::INVALID_PARAMS, "Invalid input".to_string(), None)
+                    })?,
+                )
                 .await
         } else {
             let graphql_request = graphql::Request {


### PR DESCRIPTION
Fixes:
* There were intermittent encoding problems with the URL, due to use of the wrong compression method
* If the LLM sent invalid input, it would try to use it and fail. The input is now validated. Missing fields are defaulted.