### PR TITLE
simplify CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,8 @@ env:
     keep-outputs = true
 
 jobs:
-  # Cache the nix store so that subsequent runs are almost instantaneous
-  # See https://github.com/marketplace/actions/restore-and-save-nix-store#inputs
-  cache:
-    name: Cache nix store
+  test:
+    name: Run checks and tests
     runs-on: ubuntu-24.04
     permissions:
       actions: write
@@ -33,93 +31,7 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v30
         with:
           nix_conf: ${{ env.nix_conf }}
-      - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: build-${{ runner.os }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'flake.nix', 'flake.lock', 'rust-toolchain.toml') }}
-          restore-prefixes-first-match: build-${{ runner.os }}-
-          purge: true
-          purge-prefixes: build-${{ runner.os }}-
-          purge-created: 0
-          purge-primary-key: never
-          gc-max-store-size: 5G
-      - name: Save flake attributes from garbage collection
-        run: nix profile install .#saveFromGC
-
-  check:
-    name: Run checks
-    runs-on: ubuntu-24.04
-    needs: cache
-    permissions:
-      actions: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - uses: nixbuild/nix-quick-install-action@v30
-        with:
-          nix_conf: ${{ env.nix_conf }}
-      - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: build-${{ runner.os }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'flake.nix', 'flake.lock', 'rust-toolchain.toml') }}
-          purge: true
-          purge-prefixes: build-${{ runner.os }}-
-          purge-created: 0
-          purge-primary-key: never
-          gc-max-store-size: 5G
       - name: Run checks
         run: nix flake check
-
-  build:
-    name: Build
-    runs-on: ubuntu-24.04
-    needs: cache
-    permissions:
-      actions: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - uses: nixbuild/nix-quick-install-action@v30
-        with:
-          nix_conf: ${{ env.nix_conf }}
-      - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: build-${{ runner.os }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'flake.nix', 'flake.lock', 'rust-toolchain.toml') }}
-          purge: true
-          purge-prefixes: build-${{ runner.os }}-
-          purge-created: 0
-          purge-primary-key: never
-          gc-max-store-size: 5G
-      - name: Build
-        run: nix build .#mcp-apollo-server
-
-  test:
-    name: Run Tests
-    runs-on: ubuntu-24.04
-    needs: cache
-    permissions:
-      actions: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - uses: nixbuild/nix-quick-install-action@v30
-        with:
-          nix_conf: ${{ env.nix_conf }}
-      - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: build-${{ runner.os }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'flake.nix', 'flake.lock', 'rust-toolchain.toml') }}
-          purge: true
-          purge-prefixes: build-${{ runner.os }}-
-          purge-created: 0
-          purge-primary-key: never
-          gc-max-store-size: 5G
-      - name: Run Tests
+      - name: Run tests
         run: 'nix develop --command bash -c "cargo test"'

--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "cache-nix-action": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1745008660,
-        "narHash": "sha256-JZzo8Uvhi7isp/OjLdcpzIvrSJ7auqjK83S8F+pFujU=",
-        "owner": "nix-community",
-        "repo": "cache-nix-action",
-        "rev": "764d5f335e9690876db8f44c35a3edbcde5dc948",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "cache-nix-action",
-        "type": "github"
-      }
-    },
     "crane": {
       "locked": {
         "lastModified": 1744386647,
@@ -28,27 +12,6 @@
       "original": {
         "owner": "ipetkov",
         "repo": "crane",
-        "type": "github"
-      }
-    },
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1742452566,
-        "narHash": "sha256-sVuLDQ2UIWfXUBbctzrZrXM2X05YjX08K7XHMztt36E=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "7d9ba794daf5e8cc7ee728859bc688d8e26d5f06",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
         "type": "github"
       }
     },
@@ -88,28 +51,10 @@
     },
     "root": {
       "inputs": {
-        "cache-nix-action": "cache-nix-action",
         "crane": "crane",
-        "fenix": "fenix",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
-      }
-    },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1742296961,
-        "narHash": "sha256-gCpvEQOrugHWLimD1wTFOJHagnSEP6VYBDspq96Idu0=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "15d87419f1a123d8f888d608129c3ce3ff8f13d4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
+        "nixpkgs": "nixpkgs",
+        "unstable-pkgs": "unstable-pkgs"
       }
     },
     "systems": {
@@ -124,6 +69,22 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "unstable-pkgs": {
+      "locked": {
+        "lastModified": 1746152631,
+        "narHash": "sha256-zBuvmL6+CUsk2J8GINpyy8Hs1Zp4PP6iBWSmZ4SCQ/s=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "032bc6539bd5f14e9d0c51bd79cfe9a055b094c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
         "type": "github"
       }
     }


### PR DESCRIPTION
This commit simplifies the nix CI pipeline by depending on upstream nixpkgs version of rust and cargo. This no longer requires us to manually compile rust and then cache that build.