### PR TITLE
Add install scripts

### DIFF
--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -17,7 +17,7 @@ BINARY_DOWNLOAD_PREFIX="${APOLLO_MCP_SERVER_BINARY_DOWNLOAD_PREFIX:="https://git
 
 # Apollo MCP Server version defined in apollo-mcp-server's Cargo.toml
 # Note: Change this line manually during the release steps.
-PACKAGE_VERSION="v0.0.1"
+PACKAGE_VERSION="v0.1.0-rc.0"
 
 download_binary_and_run_installer() {
     downloader --check
@@ -59,7 +59,7 @@ download_binary_and_run_installer() {
     local _url="$BINARY_DOWNLOAD_PREFIX/$DOWNLOAD_VERSION/${_tardir}.tar.gz"
     local _dir="$(mktemp -d 2>/dev/null || ensure mktemp -d -t apollo-mcp-server)"
     local _file="$_dir/input.tar.gz"
-    local _apollo_mcp_server="$_dir/apollo_mcp_server$_ext"
+    local _apollo_mcp_server="$_dir/apollo-mcp-server$_ext"
     local _safe_url
 
     # Remove credentials from the URL for logging
@@ -84,8 +84,7 @@ download_binary_and_run_installer() {
     say "Moving $_apollo_mcp_server to $outfile ..."
     mv "$_apollo_mcp_server" "$outfile"
 
-    _version="$($outfile --version)"
-    _retval=$?
+    local _retval=$?
 
     say ""
     say "You can now run the Apollo MCP Server using '$outfile'"

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+#
+# Licensed under the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+# Installs the latest version of the Apollo MCP Server.
+# Specify a specific version to install with the $VERSION variable.
+
+# Example to bypass binary overwrite [y/N] prompt
+# curl -sSL https://mcp.apollo.dev/nix/latest | sh -s -- --force
+
+set -u
+
+BINARY_DOWNLOAD_PREFIX="${APOLLO_MCP_SERVER_BINARY_DOWNLOAD_PREFIX:="https://github.com/apollographql/apollo-mcp-server/releases/download"}"
+
+# Apollo MCP Server version defined in apollo-mcp-server's Cargo.toml
+# Note: Change this line manually during the release steps.
+PACKAGE_VERSION="v0.0.1"
+
+download_binary_and_run_installer() {
+    downloader --check
+    need_cmd mktemp
+    need_cmd chmod
+    need_cmd mkdir
+    need_cmd rm
+    need_cmd rmdir
+    need_cmd tar
+    need_cmd which
+    need_cmd dirname
+    need_cmd awk
+    need_cmd cut
+
+    # if $VERSION isn't provided or has 0 length, use version from Rover cargo.toml
+    # ${VERSION:-} checks if version exists, and if doesn't uses the default
+    # which is after the :-, which in this case is empty. -z checks for empty str
+    if [ -z ${VERSION:-} ]; then
+        # VERSION is either not set or empty
+        DOWNLOAD_VERSION=$PACKAGE_VERSION
+    else
+        # VERSION set and not empty
+        DOWNLOAD_VERSION=$VERSION
+    fi
+
+
+    get_architecture || return 1
+    local _arch="$RETVAL"
+    assert_nz "$_arch" "arch"
+
+    local _ext=""
+    case "$_arch" in
+        *windows*)
+            _ext=".exe"
+            ;;
+    esac
+
+    local _tardir="apollo-mcp-server-$DOWNLOAD_VERSION-${_arch}"
+    local _url="$BINARY_DOWNLOAD_PREFIX/$DOWNLOAD_VERSION/${_tardir}.tar.gz"
+    local _dir="$(mktemp -d 2>/dev/null || ensure mktemp -d -t apollo-mcp-server)"
+    local _file="$_dir/input.tar.gz"
+    local _apollo_mcp_server="$_dir/apollo_mcp_server$_ext"
+    local _safe_url
+
+    # Remove credentials from the URL for logging
+    _safe_url=$(echo "$_url" | awk '{sub("https://[^@]+@","https://");}1')
+    say "downloading apollo-mcp-server from $_safe_url" 1>&2
+
+    ensure mkdir -p "$_dir"
+    downloader "$_url" "$_file"
+    if [ $? != 0 ]; then
+      say "failed to download $_safe_url"
+      say "this may be a standard network error, but it may also indicate"
+      say "that the MCP Server's release process is not working. When in doubt"
+      say "please feel free to open an issue!"
+      say "https://github.com/apollographql/apollo-mcp-server/issues/new/choose"
+      exit 1
+    fi
+
+    ensure tar xf "$_file" --strip-components 1 -C "$_dir"
+
+    outfile="./apollo-mcp-server"
+
+    say "Moving $_apollo_mcp_server to $outfile ..."
+    mv "$_apollo_mcp_server" "$outfile"
+
+    _version="$($outfile --version)"
+    _retval=$?
+
+    say ""
+    say "You can now run the Apollo MCP Server using '$outfile'"
+
+    ignore rm -rf "$_dir"
+
+    return "$_retval"
+}
+
+get_architecture() {
+    local _ostype="$(uname -s)"
+    local _cputype="$(uname -m)"
+
+    if [ "$_ostype" = Darwin -a "$_cputype" = i386 ]; then
+        # Darwin `uname -s` lies
+        if sysctl hw.optional.x86_64 | grep -q ': 1'; then
+            local _cputype=x86_64
+        fi
+    fi
+
+    if [ "$_ostype" = Darwin -a "$_cputype" = arm64 ]; then
+        # Darwin `uname -s` doesn't seem to lie on Big Sur
+        # but the cputype we want is called aarch64, not arm64 (they are equivalent)
+        local _cputype=aarch64
+    fi
+
+    case "$_ostype" in
+        Linux)
+            if has_required_glibc; then
+                local _ostype=unknown-linux-gnu
+            else
+                local _ostype=unknown-linux-musl
+
+                # We do not currently release builds for aarch64-unknown-linux-musl
+                if [ "$_cputype" = aarch64 ]; then
+                    err "Unsupported platform: aarch64-$_ostype"
+                fi
+
+                say "Downloading musl binary"
+            fi
+            ;;
+
+        Darwin)
+            local _ostype=apple-darwin
+            ;;
+
+        MINGW* | MSYS* | CYGWIN*)
+            local _ostype=pc-windows-msvc
+            ;;
+
+        *)
+            err "no precompiled binaries available for OS: $_ostype"
+            ;;
+    esac
+
+    case "$_cputype" in
+        # these are the only two acceptable values for cputype
+        x86_64 | aarch64 )
+            ;;
+        *)
+            err "no precompiled binaries available for CPU architecture: $_cputype"
+
+    esac
+
+    local _arch="$_cputype-$_ostype"
+
+    RETVAL="$_arch"
+}
+
+say() {
+    local green=`tput setaf 2 2>/dev/null || echo ''`
+    local reset=`tput sgr0 2>/dev/null || echo ''`
+    echo "$1"
+}
+
+err() {
+    local red=`tput setaf 1 2>/dev/null || echo ''`
+    local reset=`tput sgr0 2>/dev/null || echo ''`
+    say "${red}ERROR${reset}: $1" >&2
+    exit 1
+}
+
+has_required_glibc() {
+    local _ldd_version="$(ldd --version 2>&1 | head -n1)"
+    # glibc version string is inconsistent across distributions
+    # instead check if the string does not contain musl (case insensitive)
+    if echo "${_ldd_version}" | grep -iv musl >/dev/null; then
+        local _glibc_version=$(echo "${_ldd_version}" | awk 'NR==1 { print $NF }')
+        local _glibc_major_version=$(echo "${_glibc_version}" | cut -d. -f1)
+        local _glibc_min_version=$(echo "${_glibc_version}" | cut -d. -f2)
+        local _min_major_version=2
+        local _min_minor_version=17
+        if [ "${_glibc_major_version}" -gt "${_min_major_version}" ] \
+            || { [ "${_glibc_major_version}" -eq "${_min_major_version}" ] \
+            && [ "${_glibc_min_version}" -ge "${_min_minor_version}" ]; }; then
+            return 0
+        else
+            say "This operating system needs glibc >= ${_min_major_version}.${_min_minor_version}, but only has ${_libc_version} installed."
+        fi
+    else
+        say "This operating system does not support dynamic linking to glibc."
+    fi
+
+    return 1
+}
+
+need_cmd() {
+    if ! check_cmd "$1"
+    then err "need '$1' (command not found)"
+    fi
+}
+
+check_cmd() {
+    command -v "$1" > /dev/null 2>&1
+    return $?
+}
+
+need_ok() {
+    if [ $? != 0 ]; then err "$1"; fi
+}
+
+assert_nz() {
+    if [ -z "$1" ]; then err "assert_nz $2"; fi
+}
+
+# Run a command that should never fail. If the command fails execution
+# will immediately terminate with an error showing the failing
+# command.
+ensure() {
+    "$@"
+    need_ok "command failed: $*"
+}
+
+# This is just for indicating that commands' results are being
+# intentionally ignored. Usually, because it's being executed
+# as part of error handling.
+ignore() {
+    "$@"
+}
+
+# This wraps curl or wget. Try curl first, if not installed,
+# use wget instead.
+downloader() {
+    if check_cmd curl
+    then _dld=curl
+    elif check_cmd wget
+    then _dld=wget
+    else _dld='curl or wget' # to be used in error message of need_cmd
+    fi
+
+    if [ "$1" = --check ]
+    then need_cmd "$_dld"
+    elif [ "$_dld" = curl ]
+    then curl -sSfL "$1" -o "$2"
+    elif [ "$_dld" = wget ]
+    then wget "$1" -O "$2"
+    else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+download_binary_and_run_installer "$@" || exit 1

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -1,0 +1,93 @@
+# Licensed under the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+# Installs the latest version of the Apollo MCP Server.
+# Specify a specific version to install with the $VERSION variable.
+
+# Example to bypass binary overwrite [y/N] prompt
+# iwr https://mcp.apollo.dev/win/latest | iex --force
+
+# Apollo MCP Server version defined in apollo-mcp-server's Cargo.toml
+# Note: Change this line manually during the release steps.
+$package_version = 'v0.0.1'
+
+function Install-Binary($apollo_mcp_server_install_args) {
+  $old_erroractionpreference = $ErrorActionPreference
+  $ErrorActionPreference = 'stop'
+
+  Initialize-Environment
+
+  # If the VERSION env var is set, we use it instead
+  # of the version defined in Apollo MCP Server's cargo.toml
+  $download_version = if (Test-Path env:VERSION) {
+    $Env:VERSION
+  } else {
+    $package_version
+  }
+
+  $exe = Download($download_version)
+
+  $ErrorActionPreference = $old_erroractionpreference
+}
+
+function Download($version) {
+  $binary_download_prefix = $env:APOLLO_ROVER_BINARY_DOWNLOAD_PREFIX
+  if (-not $binary_download_prefix) {
+    $binary_download_prefix = "https://github.com/apollographql/apollo-mcp-server/releases/download"
+  }
+  $url = "$binary_download_prefix/$version/apollo-mcp-server-$version-x86_64-pc-windows-msvc.tar.gz"
+
+  # Remove credentials from the URL for logging
+  $safe_url = $url -replace "https://[^@]+@", "https://"
+
+  "Downloading Rover from $safe_url" | Out-Host
+  $tmp = New-Temp-Dir
+  $dir_path = "$tmp\apollo_mcp_server.tar.gz"
+  $wc = New-Object Net.Webclient
+  $wc.downloadFile($url, $dir_path)
+  tar -xkf $dir_path -C "$tmp"
+  return "$tmp\dist\apollo_mcp_server.exe"
+}
+
+function Initialize-Environment() {
+  If (($PSVersionTable.PSVersion.Major) -lt 5) {
+    Write-Error "PowerShell 5 or later is required to install Apollo MCP Server."
+    Write-Error "Upgrade PowerShell: https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell"
+    break
+  }
+
+  # show notification to change execution policy:
+  $allowedExecutionPolicy = @('Unrestricted', 'RemoteSigned', 'ByPass')
+  If ((Get-ExecutionPolicy).ToString() -notin $allowedExecutionPolicy) {
+    Write-Error "PowerShell requires an execution policy in [$($allowedExecutionPolicy -join ", ")] to run Apollo MCP Server."
+    Write-Error "For example, to set the execution policy to 'RemoteSigned' please run :"
+    Write-Error "'Set-ExecutionPolicy RemoteSigned -scope CurrentUser'"
+    break
+  }
+
+  # GitHub requires TLS 1.2
+  If ([System.Enum]::GetNames([System.Net.SecurityProtocolType]) -notcontains 'Tls12') {
+    Write-Error "Installing Apollo MCP Server requires at least .NET Framework 4.5"
+    Write-Error "Please download and install it first:"
+    Write-Error "https://www.microsoft.com/net/download"
+    break
+  }
+
+  If (-Not (Get-Command 'tar')) {
+    Write-Error "The tar command is not installed on this machine. Please install tar before installing Apollo MCP Server"
+    # don't abort if invoked with iex that would close the PS session
+    If ($myinvocation.mycommand.commandtype -eq 'Script') { return } else { exit 1 }
+  }
+}
+
+function New-Temp-Dir() {
+  [CmdletBinding(SupportsShouldProcess)]
+  param()
+  $parent = [System.IO.Path]::GetTempPath()
+  [string] $name = [System.Guid]::NewGuid()
+  New-Item -ItemType Directory -Path (Join-Path $parent $name)
+}
+
+Install-Binary "$Args"

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -11,7 +11,7 @@
 
 # Apollo MCP Server version defined in apollo-mcp-server's Cargo.toml
 # Note: Change this line manually during the release steps.
-$package_version = 'v0.0.1'
+$package_version = 'v0.1.0-rc.0'
 
 function Install-Binary($apollo_mcp_server_install_args) {
   $old_erroractionpreference = $ErrorActionPreference


### PR DESCRIPTION
These scripts are taken from rover and router, and modified for the MCP Server.

Tested on macOS with Apple silicon:

```console
> install.sh
downloading apollo-mcp-server from https://github.com/apollographql/apollo-mcp-server/releases/download/v0.1.0-rc.0/apollo-mcp-server-v0.1.0-rc.0-aarch64-apple-darwin.tar.gz
Moving /var/folders/yj/8v8glqls4215vyy2jddl3x_40000gp/T/tmp.B8dVOAHlzH/apollo-mcp-server to ./apollo-mcp-server ...

You can now run the Apollo MCP Server using './apollo-mcp-server'
>  ./apollo-mcp-server --help                                                                                                                                                                  (matthewhawkins@current)[ 4:33PM]
2025-05-13T22:41:08.525006Z  INFO apollo_mcp_server: Apollo MCP Server v0.1.0 // (c) Apollo Graph, Inc. // Licensed as ELv2 (https://go.apollo.dev/elv2)
Apollo MCP Server - invoke GraphQL operations from an AI agent

Usage: apollo-mcp-server [OPTIONS] --directory <DIRECTORY>
...
```