### PR TITLE
docs: fix links in best practices documentation

### DIFF
--- a/docs/source/best-practices.mdx
+++ b/docs/source/best-practices.mdx
@@ -16,8 +16,8 @@ GraphOS [contract variants](/graphos/platform/schema-management/delivery/contrac
 When running Apollo MCP Server with GraphOS, use contract variants whenever possible. This allows you to control which parts of your graph are accessible to AI by exposing only the necessary subsets.
 
 In particular, we strongly recommend contract variants when using:
-- [GraphOS-managed persisted queries](/apollo-mcp-server/guides#graphos-managed-persisted-queries)
-- [Introspection](/apollo-mcp-server/guides#introspection)
+- [GraphOS-managed persisted queries](/apollo-mcp-server/guides#from-graphos-managed-persisted-queries)
+- [Introspection](/apollo-mcp-server/guides#from-schema-introspection)
 
 ## Send client name header when using persisted queries
 


### PR DESCRIPTION
This PR fixes the links for "GraphOS-managed persisted queries" and "Introspection" to direct to the correct anchors.