### PR TITLE
fix(release): add x86_64-apple-darwin

### DIFF
--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -34,7 +34,7 @@ jobs:
           # machines, so we run that bundle on a macOS runner
           - os: macos-latest
             bundle: darwin
-            targets: cross-aarch64-apple-darwin
+            targets: cross-aarch64-apple-darwin cross-x86_64-apple-darwin
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write

--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -4,6 +4,15 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to publish
+        required: true
+        type: string
+
+env:
+  VERSION: ${{ inputs.version || github.ref_name }}
 
 jobs:
   build:
@@ -80,7 +89,6 @@ jobs:
 
           KEYCHAIN_NAME: "apollo-mcp-server-keychain"
           ENTITLEMENTS_PATH: "macos-entitlements.plist"
-          VERSION: ${{ github.ref_name }}
         run: |
           echo "Pre-check: Valid Codesigning Identify"
           security find-identity -v -p codesigning
@@ -163,8 +171,6 @@ jobs:
           rm -rf $EPHEMERAL_KEYCHAIN/
 
       - name: Create release bundles
-        env:
-          VERSION: ${{ github.ref_name }}
         run: |
           mkdir artifacts
           for RELEASE in release/*/; do
@@ -182,7 +188,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: artifacts/*
-          prerelease: ${{ contains(github.ref_name, '-rc.') }}
+          prerelease: ${{ contains(env.VERSION, '-rc.') }}
           make_latest: false # this runs for each combination in the matrix - don't mark as latest until all are done
 
       - name: Generate artifact attestation
@@ -198,4 +204,4 @@ jobs:
       - name: Make latest
         uses: softprops/action-gh-release@v2
         with:
-          prerelease: ${{ contains(github.ref_name, '-rc.') }}
+          prerelease: ${{ contains(env.VERSION, '-rc.') }}

--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,7 @@
             "aarch64-pc-windows-gnullvm"
             "aarch64-unknown-linux-gnu"
             "aarch64-unknown-linux-musl"
+            "x86_64-apple-darwin"
             "x86_64-pc-windows-gnullvm"
             "x86_64-unknown-linux-gnu"
             "x86_64-unknown-linux-musl"

--- a/nix/apollo-mcp.nix
+++ b/nix/apollo-mcp.nix
@@ -113,7 +113,14 @@ in {
 
           # Use zig for both CC and linker since it actually supports cross-compilation
           # nicely.
-          cargoExtraArgs = "--release --target ${zig-target}";
+          cargoExtraArgs = lib.strings.concatStringsSep " " ([
+              "--target ${zig-target}"
+            ]
+            # x86_64-apple-darwin compilation has a bug that causes release builds to
+            # fail with "bad relocation", so we build debug targets for it instead.
+            # See: https://github.com/rust-cross/cargo-zigbuild/issues/338
+            ++ (lib.optionals (target != "x86_64-apple-darwin") ["--release"]));
+
           cargoCheckCommand = mkCmd "check";
           cargoBuildCommand = mkCmd "zigbuild";
 

--- a/nix/cargo-zigbuild.patch
+++ b/nix/cargo-zigbuild.patch
@@ -19,7 +19,7 @@ index 9890768..354246c 100644
                  sdkroot
              } else {
                  Path::new("/")
-@@ -1282,6 +1282,26 @@ pub fn prepare_zig_linker(target: &str) -> Result<ZigWrapper> {
+@@ -1282,6 +1282,27 @@ pub fn prepare_zig_linker(target: &str) -> Result<ZigWrapper> {
              } else {
                  cc_args.push(format!("-target {arch}-macos-gnu{abi_suffix}"));
              }
@@ -41,6 +41,7 @@ index 9890768..354246c 100644
 +                            .join("Frameworks")
 +                            .display()
 +                    ),
++                    "-headerpad_max_install_names".to_string(),
 +                ]);
 +            }
          }


### PR DESCRIPTION
This PR adds support for building x86_64-apple-darwin builds to the release process. This target is currently built as a debug release until a bug is fixed in the underlying cross compiler.

See [the corresponding issue](https://github.com/rust-cross/cargo-zigbuild/issues/338) for more information relating to the bug.

<!-- [GT-153] -->