### PR TITLE
Hot reload operation files and directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### 🚀 Features
-- The `--operations` argument now supports hot reloading and directory paths. If a directory is specified, all .graphql files in the directory will be loaded as operations. The running server will update when files are added to or removed from the directory.
+- The `--operations` argument now supports hot reloading and directory paths. If a directory is specified, all .graphql files in the directory will be loaded as operations. The running server will update when files are added to or removed from the directory. (#69)
 - Add an optional `--sse-address` argument to set the bind address of the MCP server. Defaults to 127.0.0.1. (#63)
 
 ### 🐛 Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### 🚀 Features
+- The `--operations` argument now supports hot reloading and directory paths. If a directory is specified, all .graphql files in the directory will be loaded as operations. The running server will update when files are added to or removed from the directory.
 - Add an optional `--sse-address` argument to set the bind address of the MCP server. Defaults to 127.0.0.1. (#63)
 
 ### 🐛 Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,6 @@ dependencies = [
  "graphql_client",
  "insta",
  "notify",
- "parking_lot",
  "reqwest",
  "secrecy",
  "serde",
@@ -206,7 +205,6 @@ dependencies = [
  "apollo-mcp-registry",
  "buildstructor",
  "clap",
- "derive-new",
  "futures",
  "insta",
  "lz-str",
@@ -660,17 +658,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive-new"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -1537,16 +1524,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,29 +1816,6 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "paste"
@@ -2339,12 +2293,6 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.101",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secrecy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,18 @@ reqwest = { version = "0.12.15", default-features = false, features = [
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 thiserror = "2.0.12"
+tokio = { version = "1.45.0", features = [
+  "fs",
+  "io-std",
+  "macros",
+  "net",
+  "rt",
+  "rt-multi-thread",
+  "signal",
+  "sync",
+  "time",
+] }
+tokio-stream = "0.1"
 tracing = "0.1.41"
 tracing-core = "0.1.33"
 tracing-subscriber = { version = "0.3.19", features = ["json"] }

--- a/crates/apollo-mcp-registry/Cargo.toml
+++ b/crates/apollo-mcp-registry/Cargo.toml
@@ -17,20 +17,13 @@ futures.workspace = true
 graphql_client = "0.14.0"
 insta.workspace = true
 notify = "8.0.0"
-parking_lot = "0.12"
 reqwest.workspace = true
 secrecy = "0.10.3"
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { version = "1.0", features = [
-  "fs",
-  "sync",
-  "time",
-  "rt-multi-thread",
-  "macros",
-] }
-tokio-stream = "0.1"
+tokio.workspace = true
+tokio-stream.workspace = true
 tower = "0.5.2"
 tracing.workspace = true
 url = "2.4"

--- a/crates/apollo-mcp-registry/src/files.rs
+++ b/crates/apollo-mcp-registry/src/files.rs
@@ -28,14 +28,12 @@ const DEFAULT_WATCH_DURATION: Duration = Duration::from_millis(100);
 ///
 /// returns: impl Stream<Item=()>
 ///
-pub(crate) fn watch(path: &Path) -> impl Stream<Item = ()> + use<> {
+pub fn watch(path: &Path) -> impl Stream<Item = ()> + use<> {
     watch_with_duration(path, DEFAULT_WATCH_DURATION)
 }
 
 #[allow(clippy::panic)] // TODO: code copied from router contained existing panics
 fn watch_with_duration(path: &Path, duration: Duration) -> impl Stream<Item = ()> + use<> {
-    // Due to the vagaries of file watching across multiple platforms, instead of watching the
-    // supplied path (file), we are going to watch the parent (directory) of the path.
     let config_file_path = PathBuf::from(path);
     let watched_path = config_file_path.clone();
 
@@ -58,6 +56,8 @@ fn watch_with_duration(path: &Path, duration: Duration) -> impl Stream<Item = ()
                     event.kind,
                     EventKind::Modify(ModifyKind::Metadata(MetadataKind::WriteTime))
                         | EventKind::Modify(ModifyKind::Data(DataChange::Any))
+                        | EventKind::Create(_)
+                        | EventKind::Remove(_)
                 ) && event.paths.contains(&watched_path)
                 {
                     loop {

--- a/crates/apollo-mcp-registry/src/lib.rs
+++ b/crates/apollo-mcp-registry/src/lib.rs
@@ -1,3 +1,3 @@
-pub(crate) mod files;
+pub mod files;
 pub(crate) mod logging;
 pub mod uplink;

--- a/crates/apollo-mcp-registry/src/uplink.rs
+++ b/crates/apollo-mcp-registry/src/uplink.rs
@@ -10,7 +10,6 @@ use tokio_stream::wrappers::ReceiverStream;
 use tower::BoxError;
 use url::Url;
 
-pub mod event;
 pub mod persisted_queries;
 pub mod schema;
 
@@ -136,7 +135,7 @@ impl Endpoints {
 }
 
 /// Configuration for polling Apollo Uplink.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct UplinkConfig {
     /// The Apollo key: `<YOUR_GRAPH_API_KEY>`
     pub apollo_key: SecretString,

--- a/crates/apollo-mcp-registry/src/uplink/persisted_queries.rs
+++ b/crates/apollo-mcp-registry/src/uplink/persisted_queries.rs
@@ -1,5 +1,6 @@
 use graphql_client::GraphQLQuery;
 
+pub mod event;
 mod manifest;
 mod manifest_poller;
 
@@ -7,9 +8,7 @@ pub use manifest::FullPersistedQueryOperationId;
 pub use manifest::ManifestOperation;
 pub use manifest::PersistedQueryManifest;
 pub use manifest::SignedUrlChunk;
-pub use manifest_poller::ManifestChanged;
 pub use manifest_poller::ManifestSource;
-pub use manifest_poller::PersistedQueryManifestPoller;
 pub use manifest_poller::PersistedQueryManifestPollerState;
 
 use crate::uplink::UplinkRequest;

--- a/crates/apollo-mcp-registry/src/uplink/persisted_queries/event.rs
+++ b/crates/apollo-mcp-registry/src/uplink/persisted_queries/event.rs
@@ -1,0 +1,18 @@
+use std::fmt::Debug;
+use std::fmt::Formatter;
+
+/// Persisted Query events
+pub enum Event {
+    /// The persisted query manifest was updated
+    UpdateManifest(Vec<(String, String)>),
+}
+
+impl Debug for Event {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Event::UpdateManifest(_) => {
+                write!(f, "UpdateManifest(<redacted>)")
+            }
+        }
+    }
+}

--- a/crates/apollo-mcp-registry/src/uplink/schema.rs
+++ b/crates/apollo-mcp-registry/src/uplink/schema.rs
@@ -1,3 +1,4 @@
+pub mod event;
 mod schema_stream;
 
 use std::convert::Infallible;
@@ -8,13 +9,13 @@ use std::pin::Pin;
 use std::time::Duration;
 
 use crate::uplink::UplinkConfig;
-use crate::uplink::event::Event;
-use crate::uplink::event::Event::{NoMoreSchema, UpdateSchema};
 use crate::uplink::schema::schema_stream::SupergraphSdlQuery;
 use crate::uplink::stream_from_uplink;
 use derivative::Derivative;
 use derive_more::Display;
 use derive_more::From;
+use event::Event;
+use event::Event::{NoMoreSchema, UpdateSchema};
 use futures::prelude::*;
 use url::Url;
 

--- a/crates/apollo-mcp-registry/src/uplink/schema/event.rs
+++ b/crates/apollo-mcp-registry/src/uplink/schema/event.rs
@@ -2,16 +2,13 @@ use crate::uplink::schema::SchemaState;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 
-/// Messages that are broadcast across the app.
+/// Schema events
 pub enum Event {
     /// The schema was updated.
     UpdateSchema(SchemaState),
 
     /// There are no more updates to the schema
     NoMoreSchema,
-
-    /// The server should gracefully shut down.
-    Shutdown,
 }
 
 impl Debug for Event {
@@ -22,9 +19,6 @@ impl Debug for Event {
             }
             Event::NoMoreSchema => {
                 write!(f, "NoMoreSchema")
-            }
-            Event::Shutdown => {
-                write!(f, "Shutdown")
             }
         }
     }

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -8,12 +8,11 @@ license = "Elastic-2.0"
 anyhow = "1.0.98"
 apollo-compiler.workspace = true
 apollo-federation.workspace = true
+apollo-mcp-registry = { path = "../apollo-mcp-registry" }
 buildstructor = "0.6.0"
 clap = { version = "4.5.36", features = ["derive"] }
-derive-new = "0.7.0"
 futures.workspace = true
 lz-str = "0.2.1"
-apollo-mcp-registry = { path = "../apollo-mcp-registry" }
 regex = "1.11.1"
 reqwest.workspace = true
 rmcp = { version = "0.1", features = [
@@ -23,16 +22,7 @@ rmcp = { version = "0.1", features = [
 ] }
 serde.workspace = true
 thiserror.workspace = true
-tokio = { version = "1.44.2", features = [
-  "fs",
-  "io-std",
-  "macros",
-  "net",
-  "rt",
-  "rt-multi-thread",
-  "signal",
-  "time",
-] }
+tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tokio-util = "0.7.15"

--- a/crates/apollo-mcp-server/src/event.rs
+++ b/crates/apollo-mcp-server/src/event.rs
@@ -1,0 +1,32 @@
+use crate::operations::RawOperation;
+use apollo_mcp_registry::uplink::schema::event::Event as SchemaEvent;
+use std::fmt::Debug;
+use std::fmt::Formatter;
+
+/// MCP Server events
+pub enum Event {
+    /// The schema has been updated
+    SchemaUpdated(SchemaEvent),
+
+    /// The operations have been updated
+    OperationsUpdated(Vec<RawOperation>),
+
+    /// The server should gracefully shut down
+    Shutdown,
+}
+
+impl Debug for Event {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Event::SchemaUpdated(event) => {
+                write!(f, "SchemaUpdated({:?})", event)
+            }
+            Event::OperationsUpdated(operations) => {
+                write!(f, "OperationsChanged({:?})", operations)
+            }
+            Event::Shutdown => {
+                write!(f, "Shutdown")
+            }
+        }
+    }
+}

--- a/crates/apollo-mcp-server/src/introspection.rs
+++ b/crates/apollo-mcp-server/src/introspection.rs
@@ -15,6 +15,7 @@ use rmcp::serde_json::{Value, json};
 use rmcp::{schemars, serde_json};
 use serde::Deserialize;
 use std::sync::Arc;
+use tokio::sync::Mutex;
 
 /// The name of the tool to execute an ad hoc GraphQL operation
 pub(crate) const EXECUTE_TOOL_NAME: &str = "execute";
@@ -30,7 +31,7 @@ fn default_depth() -> u32 {
 /// A tool to get detailed information about specific types from the GraphQL schema.
 #[derive(Clone)]
 pub struct Introspect {
-    schema: Arc<Valid<Schema>>,
+    schema: Arc<Mutex<Valid<Schema>>>,
     pub tool: Tool,
 }
 
@@ -45,7 +46,7 @@ pub struct IntrospectInput {
 
 impl Introspect {
     pub fn new(
-        schema: Arc<Valid<Schema>>,
+        schema: Arc<Mutex<Valid<Schema>>>,
         root_query_type: Option<String>,
         root_mutation_type: Option<String>,
     ) -> Self {
@@ -68,9 +69,10 @@ impl Introspect {
     }
 
     pub async fn execute(&self, input: IntrospectInput) -> Result<CallToolResult, McpError> {
+        let schema = self.schema.lock().await;
         let type_name = input.type_name.as_str();
-        let mut tree_shaker = SchemaTreeShaker::new(&self.schema);
-        match self.schema.types.get(type_name) {
+        let mut tree_shaker = SchemaTreeShaker::new(&schema);
+        match schema.types.get(type_name) {
             Some(extended_type) => tree_shaker.retain_type(
                 extended_type,
                 if input.depth > 0 {
@@ -103,19 +105,17 @@ impl Introspect {
                                 | ExtendedType::Interface(_)
                                 | ExtendedType::Union(_)
                         )
-                        && self.schema.root_operation(OperationType::Query).is_none_or(
-                            |root_name| {
+                        && schema
+                            .root_operation(OperationType::Query)
+                            .is_none_or(|root_name| {
                                 extended_type.name() != root_name || type_name == root_name.as_str()
-                            },
-                        )
-                        && self
-                            .schema
+                            })
+                        && schema
                             .root_operation(OperationType::Mutation)
                             .is_none_or(|root_name| {
                                 extended_type.name() != root_name || type_name == root_name.as_str()
                             })
-                        && self
-                            .schema
+                        && schema
                             .root_operation(OperationType::Subscription)
                             .is_none_or(|root_name| extended_type.name() == root_name)
                 })

--- a/crates/apollo-mcp-server/src/lib.rs
+++ b/crates/apollo-mcp-server/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod custom_scalar_map;
 pub mod errors;
+pub mod event;
 mod explorer;
 mod graphql;
 mod introspection;

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -131,16 +131,18 @@ async fn main() -> anyhow::Result<()> {
 
     let schema_source = if let Some(path) = args.schema {
         SchemaSource::File { path, watch: true }
-    } else {
+    } else if args.uplink {
         SchemaSource::Registry(uplink_config()?)
+    } else {
+        bail!(ServerError::NoSchema);
     };
 
     let operation_source = if let Some(manifest) = args.manifest {
         OperationSource::from(ManifestSource::LocalHotReload(vec![manifest]))
-    } else if args.uplink {
-        OperationSource::from(ManifestSource::Uplink(uplink_config()?))
     } else if !args.operations.is_empty() {
         OperationSource::from(args.operations)
+    } else if args.uplink {
+        OperationSource::from(ManifestSource::Uplink(uplink_config()?))
     } else {
         if !args.introspection {
             bail!(ServerError::NoOperations);

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -4,8 +4,7 @@ use apollo_mcp_registry::uplink::schema::SchemaSource;
 use apollo_mcp_registry::uplink::{SecretString, UplinkConfig};
 use apollo_mcp_server::custom_scalar_map::CustomScalarMap;
 use apollo_mcp_server::errors::ServerError;
-use apollo_mcp_server::operations::MutationMode;
-use apollo_mcp_server::operations::OperationSource;
+use apollo_mcp_server::operations::{MutationMode, OperationSource};
 use apollo_mcp_server::server::Server;
 use apollo_mcp_server::server::Transport;
 use clap::Parser;
@@ -116,11 +115,11 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let operation_source = if let Some(manifest) = args.manifest {
-        OperationSource::Manifest(ManifestSource::LocalHotReload(vec![manifest]))
+        OperationSource::from(ManifestSource::LocalHotReload(vec![manifest]))
     } else if args.uplink {
-        OperationSource::Manifest(ManifestSource::Uplink(uplink_config()?))
+        OperationSource::from(ManifestSource::Uplink(uplink_config()?))
     } else if !args.operations.is_empty() {
-        OperationSource::Files(args.operations)
+        OperationSource::from(args.operations)
     } else {
         if !args.introspection {
             bail!(ServerError::NoOperations);

--- a/crates/apollo-mcp-server/src/server.rs
+++ b/crates/apollo-mcp-server/src/server.rs
@@ -504,8 +504,7 @@ impl Running {
         {
             let schema = &*self.schema.lock().await;
             let updated_operations: Vec<Operation> = operations
-                .iter()
-                .cloned()
+                .into_iter()
                 .map(|operation| {
                     operation.into_operation(
                         schema,

--- a/crates/apollo-mcp-server/src/server.rs
+++ b/crates/apollo-mcp-server/src/server.rs
@@ -1,9 +1,10 @@
 use crate::custom_scalar_map::CustomScalarMap;
 use crate::errors::{McpError, OperationError, ServerError};
+use crate::event::Event as ServerEvent;
 use crate::graphql;
 use crate::graphql::Executable;
 use crate::introspection::{EXECUTE_TOOL_NAME, Execute, INTROSPECT_TOOL_NAME, Introspect};
-use crate::operations::{MutationMode, Operation, OperationPoller, OperationSource};
+use crate::operations::{MutationMode, Operation, OperationSource, RawOperation};
 use apollo_compiler::ast::OperationType;
 use buildstructor::buildstructor;
 use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderValue};
@@ -23,19 +24,15 @@ use apollo_compiler::validation::Valid;
 use apollo_compiler::{Name, Schema};
 use apollo_federation::{ApiSchemaOptions, Supergraph};
 pub use apollo_mcp_registry::uplink::UplinkConfig;
-use apollo_mcp_registry::uplink::event::Event;
 pub use apollo_mcp_registry::uplink::persisted_queries::ManifestSource;
-use apollo_mcp_registry::uplink::persisted_queries::{
-    ManifestChanged, PersistedQueryManifestPoller,
-};
 pub use apollo_mcp_registry::uplink::schema::SchemaSource;
 use apollo_mcp_registry::uplink::schema::SchemaState;
+use apollo_mcp_registry::uplink::schema::event::Event as SchemaEvent;
 use futures::{FutureExt, Stream, StreamExt, future, stream};
 pub use rmcp::ServiceExt;
 pub use rmcp::transport::SseServer;
 pub use rmcp::transport::sse_server::SseServerConfig;
 pub use rmcp::transport::stdio;
-use tokio::sync::{Mutex, RwLock, mpsc};
 use tokio_util::sync::CancellationToken;
 
 /// An Apollo MCP Server
@@ -105,15 +102,69 @@ impl Server {
 
 #[allow(clippy::large_enum_variant)]
 enum State {
+    Configuring(Configuring),
+    SchemaConfigured(SchemaConfigured),
+    OperationsConfigured(OperationsConfigured),
     Starting(Starting),
     Running(Running),
     Error(ServerError),
     Stopping,
 }
 
+impl From<Configuring> for State {
+    fn from(starting: Configuring) -> Self {
+        State::Configuring(starting)
+    }
+}
+
+impl From<SchemaConfigured> for State {
+    fn from(schema_configured: SchemaConfigured) -> Self {
+        State::SchemaConfigured(schema_configured)
+    }
+}
+
+impl From<Result<SchemaConfigured, ServerError>> for State {
+    fn from(result: Result<SchemaConfigured, ServerError>) -> Self {
+        match result {
+            Ok(schema_configured) => State::SchemaConfigured(schema_configured),
+            Err(error) => State::Error(error),
+        }
+    }
+}
+
+impl From<OperationsConfigured> for State {
+    fn from(operations_configured: OperationsConfigured) -> Self {
+        State::OperationsConfigured(operations_configured)
+    }
+}
+
+impl From<Result<OperationsConfigured, ServerError>> for State {
+    fn from(result: Result<OperationsConfigured, ServerError>) -> Self {
+        match result {
+            Ok(operations_configured) => State::OperationsConfigured(operations_configured),
+            Err(error) => State::Error(error),
+        }
+    }
+}
+
 impl From<Starting> for State {
     fn from(starting: Starting) -> Self {
         State::Starting(starting)
+    }
+}
+
+impl From<Result<Starting, ServerError>> for State {
+    fn from(result: Result<Starting, ServerError>) -> Self {
+        match result {
+            Ok(starting) => State::Starting(starting),
+            Err(error) => State::Error(error),
+        }
+    }
+}
+
+impl From<Running> for State {
+    fn from(running: Running) -> Self {
+        State::Running(running)
     }
 }
 
@@ -132,9 +183,148 @@ impl From<ServerError> for State {
     }
 }
 
+struct Configuring {
+    transport: Transport,
+    endpoint: String,
+    headers: HeaderMap,
+    introspection: bool,
+    explorer: bool,
+    custom_scalar_map: Option<CustomScalarMap>,
+    mutation_mode: MutationMode,
+    disable_type_description: bool,
+    disable_schema_description: bool,
+}
+
+impl Configuring {
+    async fn set_schema(self, schema: Valid<Schema>) -> Result<SchemaConfigured, ServerError> {
+        info!("Received schema:\n{}", schema);
+        Ok(SchemaConfigured {
+            transport: self.transport,
+            schema,
+            endpoint: self.endpoint,
+            headers: self.headers,
+            introspection: self.introspection,
+            explorer: self.explorer,
+            custom_scalar_map: self.custom_scalar_map,
+            mutation_mode: self.mutation_mode,
+            disable_type_description: self.disable_type_description,
+            disable_schema_description: self.disable_schema_description,
+        })
+    }
+
+    async fn set_operations(
+        self,
+        operations: Vec<RawOperation>,
+    ) -> Result<OperationsConfigured, ServerError> {
+        info!(
+            "Received {} operations:\n{}",
+            operations.len(),
+            serde_json::to_string_pretty(&operations)?
+        );
+        Ok(OperationsConfigured {
+            transport: self.transport,
+            operations,
+            endpoint: self.endpoint,
+            headers: self.headers,
+            introspection: self.introspection,
+            explorer: self.explorer,
+            custom_scalar_map: self.custom_scalar_map,
+            mutation_mode: self.mutation_mode,
+            disable_type_description: self.disable_type_description,
+            disable_schema_description: self.disable_schema_description,
+        })
+    }
+}
+
+struct SchemaConfigured {
+    transport: Transport,
+    schema: Valid<Schema>,
+    endpoint: String,
+    headers: HeaderMap,
+    introspection: bool,
+    explorer: bool,
+    custom_scalar_map: Option<CustomScalarMap>,
+    mutation_mode: MutationMode,
+    disable_type_description: bool,
+    disable_schema_description: bool,
+}
+
+impl SchemaConfigured {
+    async fn set_schema(self, schema: Valid<Schema>) -> Result<SchemaConfigured, ServerError> {
+        info!("Received schema:\n{}", schema);
+        Ok(SchemaConfigured { schema, ..self })
+    }
+
+    async fn set_operations(self, operations: Vec<RawOperation>) -> Result<Starting, ServerError> {
+        info!(
+            "Received {} operations:\n{}",
+            operations.len(),
+            serde_json::to_string_pretty(&operations)?
+        );
+        Ok(Starting {
+            transport: self.transport,
+            schema: self.schema,
+            operations,
+            endpoint: self.endpoint,
+            headers: self.headers,
+            introspection: self.introspection,
+            explorer: self.explorer,
+            custom_scalar_map: self.custom_scalar_map,
+            mutation_mode: self.mutation_mode,
+            disable_type_description: self.disable_type_description,
+            disable_schema_description: self.disable_schema_description,
+        })
+    }
+}
+
+struct OperationsConfigured {
+    transport: Transport,
+    operations: Vec<RawOperation>,
+    endpoint: String,
+    headers: HeaderMap,
+    introspection: bool,
+    explorer: bool,
+    custom_scalar_map: Option<CustomScalarMap>,
+    mutation_mode: MutationMode,
+    disable_type_description: bool,
+    disable_schema_description: bool,
+}
+
+impl OperationsConfigured {
+    async fn set_schema(self, schema: Valid<Schema>) -> Result<Starting, ServerError> {
+        info!("Received schema:\n{}", schema);
+        Ok(Starting {
+            transport: self.transport,
+            schema,
+            operations: self.operations,
+            endpoint: self.endpoint,
+            headers: self.headers,
+            introspection: self.introspection,
+            explorer: self.explorer,
+            custom_scalar_map: self.custom_scalar_map,
+            mutation_mode: self.mutation_mode,
+            disable_type_description: self.disable_type_description,
+            disable_schema_description: self.disable_schema_description,
+        })
+    }
+
+    async fn set_operations(
+        self,
+        operations: Vec<RawOperation>,
+    ) -> Result<OperationsConfigured, ServerError> {
+        info!(
+            "Received {} operations:\n{}",
+            operations.len(),
+            serde_json::to_string_pretty(&operations)?
+        );
+        Ok(OperationsConfigured { operations, ..self })
+    }
+}
+
 struct Starting {
     transport: Transport,
-    operation_source: OperationSource,
+    schema: Valid<Schema>,
+    operations: Vec<RawOperation>,
     endpoint: String,
     headers: HeaderMap,
     introspection: bool,
@@ -146,45 +336,37 @@ struct Starting {
 }
 
 impl Starting {
-    /// Run the MCP server once the schema is ready
-    async fn run(self, schema: Valid<Schema>) -> Result<Running, ServerError> {
-        info!("Running with schema:\n{}", schema);
+    async fn start(self) -> Result<Running, ServerError> {
+        info!("Starting MCP Server");
 
-        let peers = Arc::new(RwLock::new(vec![]));
+        let peers = Arc::new(Vec::new());
 
-        let (operation_poller, change_receiver) = match self.operation_source {
-            OperationSource::Files(paths) => (OperationPoller::Files(paths), None),
-            OperationSource::Manifest(manifest_source) => {
-                let (change_sender, change_receiver) = mpsc::channel::<ManifestChanged>(1);
-                (
-                    OperationPoller::Manifest(
-                        PersistedQueryManifestPoller::new(manifest_source, change_sender)
-                            .await
-                            .map_err(|e| {
-                                ServerError::Operation(OperationError::Internal(e.to_string()))
-                            })?,
-                    ),
-                    Some(change_receiver),
+        let operations: Vec<_> = self
+            .operations
+            .into_iter()
+            .map(|operation| {
+                operation.into_operation(
+                    &self.schema,
+                    self.custom_scalar_map.as_ref(),
+                    self.mutation_mode,
+                    self.disable_type_description,
+                    self.disable_schema_description,
                 )
-            }
-            OperationSource::None => (OperationPoller::None, None),
-        };
-        let operations = operation_poller
-            .operations(
-                &schema,
-                self.custom_scalar_map.as_ref(),
-                self.mutation_mode,
-                self.disable_type_description,
-                self.disable_schema_description,
-            )
-            .await?;
+            })
+            .collect::<Result<_, OperationError>>()?;
+
+        info!(
+            "Loaded {} operations:\n{}",
+            operations.len(),
+            serde_json::to_string_pretty(&operations)?
+        );
 
         let execute_tool = self.introspection.then(|| Execute::new(self.mutation_mode));
 
         let root_query_type = self
             .introspection
             .then(|| {
-                schema
+                self.schema
                     .root_operation(OperationType::Query)
                     .map(Name::as_str)
                     .map(|s| s.to_string())
@@ -195,7 +377,7 @@ impl Starting {
             .then(|| {
                 matches!(self.mutation_mode, MutationMode::All)
                     .then(|| {
-                        schema
+                        self.schema
                             .root_operation(OperationType::Mutation)
                             .map(Name::as_str)
                             .map(|s| s.to_string())
@@ -203,7 +385,7 @@ impl Starting {
                     .flatten()
             })
             .flatten();
-        let schema = Arc::new(Mutex::new(schema));
+        let schema = Arc::new(self.schema);
         let introspect_tool = self
             .introspection
             .then(|| Introspect::new(schema.clone(), root_query_type, root_mutation_type));
@@ -218,8 +400,7 @@ impl Starting {
 
         let running = Running {
             schema,
-            operations: Arc::new(Mutex::new(operations)),
-            operation_poller,
+            operations: Arc::new(operations),
             headers: self.headers,
             endpoint: self.endpoint,
             execute_tool,
@@ -232,10 +413,6 @@ impl Starting {
             disable_type_description: self.disable_type_description,
             disable_schema_description: self.disable_schema_description,
         };
-
-        if let Some(change_receiver) = change_receiver {
-            running.spawn_change_listener(change_receiver);
-        }
 
         if let Transport::SSE { address, port } = self.transport {
             info!(port = ?port, address = ?address, "Starting MCP server in SSE mode");
@@ -263,16 +440,15 @@ impl Starting {
 
 #[derive(Clone)]
 struct Running {
-    schema: Arc<Mutex<Valid<Schema>>>,
-    operations: Arc<Mutex<Vec<Operation>>>,
-    operation_poller: OperationPoller,
+    schema: Arc<Valid<Schema>>,
+    operations: Arc<Vec<Operation>>,
     headers: HeaderMap,
     endpoint: String,
     execute_tool: Option<Execute>,
     introspect_tool: Option<Introspect>,
     explorer_tool: Option<Explorer>,
     custom_scalar_map: Option<CustomScalarMap>,
-    peers: Arc<RwLock<Vec<Peer<RoleServer>>>>,
+    peers: Arc<Vec<Peer<RoleServer>>>,
     cancellation_token: CancellationToken,
     mutation_mode: MutationMode,
     disable_type_description: bool,
@@ -286,34 +462,76 @@ impl Running {
 
         // Update the operations based on the new schema. This is necessary because the MCP tool
         // input schemas and description are derived from the schema.
-        let operations = self
-            .operation_poller
-            .operations(
-                &schema,
-                self.custom_scalar_map.as_ref(),
-                self.mutation_mode,
-                self.disable_type_description,
-                self.disable_schema_description,
-            )
-            .await?;
+        let operations: Vec<Operation> = self
+            .operations
+            .iter()
+            .cloned()
+            .map(|operation| operation.into_inner())
+            .map(|operation| {
+                operation.into_operation(
+                    &schema,
+                    self.custom_scalar_map.as_ref(),
+                    self.mutation_mode,
+                    self.disable_type_description,
+                    self.disable_schema_description,
+                )
+            })
+            .collect::<Result<_, OperationError>>()?;
+
         info!(
             "Updated {} operations:\n{}",
             operations.len(),
             serde_json::to_string_pretty(&operations)?
         );
-        *self.operations.lock().await = operations;
-
-        // Update the schema itself
-        *self.schema.lock().await = schema;
 
         // Notify MCP clients that tools have changed
-        Self::notify_tool_list_changed(self.peers.clone()).await;
-        Ok(self)
+        let peers = Self::notify_tool_list_changed(self.peers.clone()).await;
+        Ok(Running {
+            schema: Arc::new(schema),
+            operations: Arc::new(operations),
+            peers,
+            ..self
+        })
+    }
+
+    async fn update_operations(
+        self,
+        operations: Vec<RawOperation>,
+    ) -> Result<Running, ServerError> {
+        // Update the operations based on the current schema
+        let updated_operations: Vec<Operation> = operations
+            .iter()
+            .cloned()
+            .map(|operation| {
+                operation.into_operation(
+                    &self.schema,
+                    self.custom_scalar_map.as_ref(),
+                    self.mutation_mode,
+                    self.disable_type_description,
+                    self.disable_schema_description,
+                )
+            })
+            .collect::<Result<_, OperationError>>()?;
+
+        info!(
+            "Loaded {} operations:\n{}",
+            updated_operations.len(),
+            serde_json::to_string_pretty(&updated_operations)?
+        );
+
+        // Notify MCP clients that tools have changed
+        let peers = Self::notify_tool_list_changed(self.peers.clone()).await;
+        Ok(Running {
+            operations: Arc::new(updated_operations),
+            peers,
+            ..self
+        })
     }
 
     /// Notify any peers that tools have changed. Drops unreachable peers from the list.
-    async fn notify_tool_list_changed(peers: Arc<RwLock<Vec<Peer<RoleServer>>>>) {
-        let mut peers = peers.write().await;
+    async fn notify_tool_list_changed(
+        peers: Arc<Vec<Peer<RoleServer>>>,
+    ) -> Arc<Vec<Peer<RoleServer>>> {
         if !peers.is_empty() {
             info!(
                 "Persisted query manifest changed, notifying {} peers of tool change",
@@ -341,142 +559,7 @@ impl Running {
                 }
             }
         }
-        *peers = retained_peers;
-    }
-
-    /// Spawn a listener for any changes to the operation manifest.
-    fn spawn_change_listener(&self, mut change_receiver: mpsc::Receiver<ManifestChanged>) {
-        let peers = self.peers.clone();
-        let operations = self.operations.clone();
-        let operation_poller = self.operation_poller.clone();
-        let custom_scalars = self.custom_scalar_map.clone();
-        let schema = self.schema.clone();
-        let mutation_mode = self.mutation_mode;
-        let disable_type_description = self.disable_type_description;
-        let disable_schema_description = self.disable_schema_description;
-        tokio::spawn(async move {
-            while change_receiver.recv().await.is_some() {
-                match operation_poller
-                    .operations(
-                        &*schema.lock().await,
-                        custom_scalars.as_ref(),
-                        mutation_mode,
-                        disable_type_description,
-                        disable_schema_description,
-                    )
-                    .await
-                {
-                    Ok(new_operations) => *operations.lock().await = new_operations,
-                    // TODO: ideally, we'd send the server to the error state here because it's
-                    //  no longer configured correctly. To do this, we'd have to receive the PQ
-                    //  updates through the same stream where schema changes are tracked. However,
-                    //  the router code ported into apollo-mcp-registry does not work that way -
-                    //  it has a separate PQ update mechanism. That will need to be rewritten, or
-                    //  maybe there's some way to bridge the PQ changes into the same stream.
-                    Err(e) => error!("Failed to update operations: {:?}", e),
-                }
-
-                Self::notify_tool_list_changed(peers.clone()).await;
-            }
-        });
-    }
-}
-
-struct StateMachine {}
-
-impl StateMachine {
-    pub(crate) async fn start(self, server: Server) -> Result<(), ServerError> {
-        let mut stream = stream::select_all(vec![
-            server.schema_source.into_stream().boxed(),
-            Self::ctrl_c_stream().boxed(),
-        ])
-        .take_while(|msg| future::ready(!matches!(msg, Event::Shutdown)))
-        .chain(stream::iter(vec![Event::Shutdown]))
-        .boxed();
-        let mut state = State::Starting(Starting {
-            transport: server.transport,
-            operation_source: server.operation_source,
-            endpoint: server.endpoint,
-            headers: server.headers,
-            introspection: server.introspection,
-            explorer: server.explorer,
-            custom_scalar_map: server.custom_scalar_map,
-            mutation_mode: server.mutation_mode,
-            disable_type_description: server.disable_type_description,
-            disable_schema_description: server.disable_schema_description,
-        });
-        while let Some(event) = stream.next().await {
-            state = match event {
-                Event::UpdateSchema(schema_state) => {
-                    let schema = Self::sdl_to_api_schema(schema_state)?;
-                    match state {
-                        State::Starting(starting) => starting.run(schema).await.into(),
-                        State::Running(running) => running.update_schema(schema).await.into(),
-                        other => other,
-                    }
-                }
-                Event::NoMoreSchema => match state {
-                    State::Starting { .. } => State::Error(ServerError::NoSchema),
-                    _ => state,
-                },
-                Event::Shutdown => match state {
-                    State::Running(running) => {
-                        running.cancellation_token.cancel();
-                        State::Stopping
-                    }
-                    _ => State::Stopping,
-                },
-            };
-            if matches!(&state, State::Error(_) | State::Stopping) {
-                break;
-            }
-        }
-        match state {
-            State::Error(e) => Err(e),
-            _ => Ok(()),
-        }
-    }
-
-    fn sdl_to_api_schema(schema_state: SchemaState) -> Result<Valid<Schema>, ServerError> {
-        match Supergraph::new(&schema_state.sdl) {
-            Ok(supergraph) => Ok(supergraph
-                .to_api_schema(ApiSchemaOptions::default())
-                .map_err(ServerError::Federation)?
-                .schema()
-                .clone()),
-            Err(_) => Schema::parse_and_validate(schema_state.sdl, "schema.graphql")
-                .map_err(|e| ServerError::GraphQLSchema(e.into())),
-        }
-    }
-
-    #[allow(clippy::expect_used)]
-    fn ctrl_c_stream() -> impl Stream<Item = Event> {
-        #[cfg(not(unix))]
-        {
-            async {
-                tokio::signal::ctrl_c()
-                    .await
-                    .expect("Failed to install CTRL+C signal handler");
-            }
-            .map(|_| Event::Shutdown)
-            .into_stream()
-            .boxed()
-        }
-
-        #[cfg(unix)]
-        future::select(
-            tokio::signal::ctrl_c().map(|s| s.ok()).boxed(),
-            async {
-                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-                    .expect("Failed to install SIGTERM signal handler")
-                    .recv()
-                    .await
-            }
-            .boxed(),
-        )
-        .map(|_| Event::Shutdown)
-        .into_stream()
-        .boxed()
+        Arc::new(retained_peers)
     }
 }
 
@@ -512,8 +595,6 @@ impl ServerHandler for Running {
                     .await
             } else {
                 self.operations
-                    .lock()
-                    .await
                     .iter()
                     .find(|op| op.as_ref().name == request.name)
                     .ok_or(tool_not_found(&request.name))?
@@ -532,8 +613,6 @@ impl ServerHandler for Running {
             next_cursor: None,
             tools: self
                 .operations
-                .lock()
-                .await
                 .iter()
                 .map(|op| op.as_ref().clone())
                 .chain(
@@ -562,13 +641,13 @@ impl ServerHandler for Running {
     }
 
     fn set_peer(&mut self, p: Peer<RoleServer>) {
-        let peers = self.peers.clone();
-        tokio::spawn(async move {
-            let mut peers = peers.write().await;
-            // TODO: we need a way to remove these! The Rust SDK seems to leek running servers
-            //  forever - it never times them out or disconnects them.
-            peers.push(p);
-        });
+        let peers = self
+            .peers
+            .iter()
+            .cloned()
+            .chain(std::iter::once(p))
+            .collect();
+        self.peers = Arc::new(peers);
     }
 
     fn get_info(&self) -> ServerInfo {
@@ -595,4 +674,133 @@ fn convert_arguments<T: serde::de::DeserializeOwned>(
 ) -> Result<T, McpError> {
     serde_json::from_value(Value::from(arguments.arguments))
         .map_err(|_| McpError::new(ErrorCode::INVALID_PARAMS, "Invalid input".to_string(), None))
+}
+
+struct StateMachine {}
+
+impl StateMachine {
+    pub(crate) async fn start(self, server: Server) -> Result<(), ServerError> {
+        let schema_stream = server
+            .schema_source
+            .into_stream()
+            .map(ServerEvent::SchemaUpdated)
+            .boxed();
+        let operation_stream = server.operation_source.into_stream().await.boxed();
+        let ctrl_c_stream = Self::ctrl_c_stream().boxed();
+        let mut stream = stream::select_all(vec![schema_stream, operation_stream, ctrl_c_stream]);
+
+        let mut state = State::Configuring(Configuring {
+            transport: server.transport,
+            endpoint: server.endpoint,
+            headers: server.headers,
+            introspection: server.introspection,
+            explorer: server.explorer,
+            custom_scalar_map: server.custom_scalar_map,
+            mutation_mode: server.mutation_mode,
+            disable_type_description: server.disable_type_description,
+            disable_schema_description: server.disable_schema_description,
+        });
+
+        while let Some(event) = stream.next().await {
+            state = match event {
+                ServerEvent::SchemaUpdated(registry_event) => match registry_event {
+                    SchemaEvent::UpdateSchema(schema_state) => {
+                        let schema = Self::sdl_to_api_schema(schema_state)?;
+                        match state {
+                            State::Configuring(configuring) => {
+                                configuring.set_schema(schema).await.into()
+                            }
+                            State::SchemaConfigured(schema_configured) => {
+                                schema_configured.set_schema(schema).await.into()
+                            }
+                            State::OperationsConfigured(operations_configured) => {
+                                operations_configured.set_schema(schema).await.into()
+                            }
+                            State::Running(running) => running.update_schema(schema).await.into(),
+                            other => other,
+                        }
+                    }
+                    SchemaEvent::NoMoreSchema => match state {
+                        State::Configuring(_) | State::OperationsConfigured(_) => {
+                            State::Error(ServerError::NoSchema)
+                        }
+                        _ => state,
+                    },
+                },
+                ServerEvent::OperationsUpdated(operations) => match state {
+                    State::Configuring(configuring) => {
+                        configuring.set_operations(operations).await.into()
+                    }
+                    State::SchemaConfigured(schema_configured) => {
+                        schema_configured.set_operations(operations).await.into()
+                    }
+                    State::OperationsConfigured(operations_configured) => operations_configured
+                        .set_operations(operations)
+                        .await
+                        .into(),
+                    State::Running(running) => running.update_operations(operations).await.into(),
+                    other => other,
+                },
+                ServerEvent::Shutdown => match state {
+                    State::Running(running) => {
+                        running.cancellation_token.cancel();
+                        State::Stopping
+                    }
+                    _ => State::Stopping,
+                },
+            };
+            if let State::Starting(starting) = state {
+                state = starting.start().await.into();
+            }
+            if matches!(&state, State::Error(_) | State::Stopping) {
+                break;
+            }
+        }
+        match state {
+            State::Error(e) => Err(e),
+            _ => Ok(()),
+        }
+    }
+
+    fn sdl_to_api_schema(schema_state: SchemaState) -> Result<Valid<Schema>, ServerError> {
+        match Supergraph::new(&schema_state.sdl) {
+            Ok(supergraph) => Ok(supergraph
+                .to_api_schema(ApiSchemaOptions::default())
+                .map_err(ServerError::Federation)?
+                .schema()
+                .clone()),
+            Err(_) => Schema::parse_and_validate(schema_state.sdl, "schema.graphql")
+                .map_err(|e| ServerError::GraphQLSchema(e.into())),
+        }
+    }
+
+    #[allow(clippy::expect_used)]
+    fn ctrl_c_stream() -> impl Stream<Item = ServerEvent> {
+        #[cfg(not(unix))]
+        {
+            async {
+                tokio::signal::ctrl_c()
+                    .await
+                    .expect("Failed to install CTRL+C signal handler");
+            }
+            .map(|_| ServerEvent::Shutdown)
+            .into_stream()
+            .boxed()
+        }
+
+        #[cfg(unix)]
+        future::select(
+            tokio::signal::ctrl_c().map(|s| s.ok()).boxed(),
+            async {
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                    .expect("Failed to install SIGTERM signal handler")
+                    .recv()
+                    .await
+            }
+            .boxed(),
+        )
+        .map(|_| ServerEvent::Shutdown)
+        .into_stream()
+        .boxed()
+    }
 }

--- a/docs/source/guides/index.mdx
+++ b/docs/source/guides/index.mdx
@@ -73,7 +73,7 @@ You can manually define the GraphQL operations that are exposed by Apollo MCP Se
 
 Alternatively, you can let an AI model read your graph schema via GraphQL introspection and have it determine the available operations. 
 
-### From operation schema files
+### From operation files
 
 An operation file is a `.graphql` file containing a single GraphQL operation. 
 
@@ -102,7 +102,11 @@ query GetAllWeatherData($coordinate: InputCoordinate!, $state: String!) {
 
 </CodeColumns>
 
-The `--operation` option of the MCP Server provides it with a list of operation files. For each operation file you provide, the MCP Server creates an MCP tool that calls the corresponding GraphQL operation. 
+The `--operation` option of the MCP Server provides it with a list of operation files. For each operation file you provide, the MCP Server creates an MCP tool that calls the corresponding GraphQL operation.
+
+The `--operation` option can also be used to specify a directory. All files with a `.graphql` extension in the directory will be loaded as operations.
+
+Files and directories specified with `--operation` will be hot reloaded. When specifying a file, the MCP tool will be updated when the file contents are modified. When specifying a directory, operations exposed as MCP tools will be updated when files are added, modified, or removed from the directory.
 
 ### From persisted query manifests
 

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -94,7 +94,7 @@ You can run an Apollo MCP Server locally to communicate over stdio.
     npx @modelcontextprotocol/inspector apollo-mcp-server \
     --directory <absolute-path-to-MCP-example-dir>
     --schema api.graphql \
-    --operations operations/ExploreCelestialBodies.graphql operations/GetAstronautDetails.graphql operations/GetAstronautsCurrentlyInSpace.graphql operations/SearchUpcomingLaunches.graphql \
+    --operations operations \
     --endpoint https://thespacedevs-production.up.railway.app/ 
     ```
 1. Open a browser and go to the Inspector URL at [`http://127.0.0.1:6274`](http://127.0.0.1:6274).
@@ -133,10 +133,7 @@ This quickstart using Claude Desktop as the MCP client. Configure Claude Desktop
             "--schema",
             "api.graphql",
             "--operations",
-            "operations/ExploreCelestialBodies.graphql",
-            "operations/GetAstronautDetails.graphql",
-            "operations/GetAstronautsCurrentlyInSpace.graphql",
-            "operations/SearchUpcomingLaunches.graphql",
+            "operations",
             "--endpoint",
             "https://thespacedevs-production.up.railway.app/"
           ]

--- a/graphql/TheSpaceDevs/README.md
+++ b/graphql/TheSpaceDevs/README.md
@@ -15,7 +15,7 @@ git clone https://github.com/apollographql/apollo-mcp-server
 cd apollo-mcp-server
 cargo build
 
-# Built binaries will be located in ./target/debug/mcp-apollo-server
+# Built binaries will be located in ./target/debug/apollo-mcp-server
 ```
 
 If you don't have an MCP client you plan on using right away, you can inspect the tools of the Apollo MCP server using the MCP Inspector:
@@ -36,10 +36,10 @@ Here is an example configuration you can use _(Note: you must provide your fill 
 {
   "mcpServers": {
     "thespacedevs": {
-      "command": "/Users/michaelwatson/Documents/GitHub/apollographql/mcp-apollo/target/debug/mcp-apollo-server",
+      "command": "/Users/michaelwatson/Documents/GitHub/apollographql/apollo-mcp-server/target/debug/apollo-mcp-server",
       "args": [
         "--directory",
-        "/Users/michaelwatson/Documents/GitHub/apollographql/mcp-apollo/graphql/TheSpaceDevs",
+        "/Users/michaelwatson/Documents/GitHub/apollographql/apollo-mcp-server/graphql/TheSpaceDevs",
         "--schema",
         "api.graphql",
         "--operations",
@@ -68,10 +68,10 @@ There are operations located at `./operations/*.graphql` for you to use in your 
 ```bash
 docker run \
   -it --rm \
-  --name mcp-apollo-server \
+  --name apollo-mcp-server \
   -p 5000:5000 \
   -v $PWD/graphql/TheSpaceDevs:/data \
-  ghcr.io/apollographql/mcp-apollo:latest \
+  ghcr.io/apollographql/apollo-mcp-server:latest \
   --sse-port 5000 \
   --schema api.graphql \
   --operations operations \
@@ -101,11 +101,10 @@ Here is an example configuration you can use _(Note: you must provide your fill 
 {
   "mcpServers": {
     "thespacedevs": {
-      "command": "/Users/michaelwatson/Documents/GitHub/apollographql/mcp-apollo/target/debug/mcp-apollo-server",
+      "command": "/Users/michaelwatson/Documents/GitHub/apollographql/apollo-mcp-server/target/debug/apollo-mcp-server",
       "args": [
         "--directory",
-        "/Users/michaelwatson/Documents/GitHub/apollographql/mcp-apollo/graphql/TheSpaceDevs",
-        "--sse-port 5000",
+        "/Users/michaelwatson/Documents/GitHub/apollographql/apollo-mcp-server/graphql/TheSpaceDevs",
         "--schema",
         "api.graphql",
         "--operations",
@@ -165,11 +164,10 @@ export APOLLO_GRAPH_REF=my-new-graph@current
 {
   "mcpServers": {
     "thespacedevs": {
-      "command": "/Users/michaelwatson/Documents/GitHub/apollographql/mcp-apollo/target/debug/mcp-apollo-server",
+      "command": "/Users/michaelwatson/Documents/GitHub/apollographql/apollo-mcp-server/target/debug/apollo-mcp-server",
       "args": [
         "--directory",
         "/Users/michaelwatson/Documents/GitHub/apollographql/mcp-apollo/graphql/TheSpaceDevs",
-        "--sse-port 5000",
         "--schema",
         "api.graphql",
         "--manifest",

--- a/graphql/TheSpaceDevs/README.md
+++ b/graphql/TheSpaceDevs/README.md
@@ -43,10 +43,7 @@ Here is an example configuration you can use _(Note: you must provide your fill 
         "--schema",
         "api.graphql",
         "--operations",
-        "operations/ExploreCelestialBodies.graphql",
-        "operations/GetAstronautDetails.graphql",
-        "operations/GetAstronautsCurrentlyInSpace.graphql",
-        "operations/SearchUpcomingLaunches.graphql",
+        "operations",
         "--endpoint",
         "https://thespacedevs-production.up.railway.app/",
         "--introspection"
@@ -77,7 +74,7 @@ docker run \
   ghcr.io/apollographql/mcp-apollo:latest \
   --sse-port 5000 \
   --schema api.graphql \
-  --operations operations/ExploreCelestialBodies.graphql operations/GetAstronautDetails.graphql operations/GetAstronautsCurrentlyInSpace.graphql operations/SearchUpcomingLaunches.graphql \
+  --operations operations \
   --endpoint https://thespacedevs-production.up.railway.app/
 ```
 
@@ -112,10 +109,7 @@ Here is an example configuration you can use _(Note: you must provide your fill 
         "--schema",
         "api.graphql",
         "--operations",
-        "operations/ExploreCelestialBodies.graphql",
-        "operations/GetAstronautDetails.graphql",
-        "operations/GetAstronautsCurrentlyInSpace.graphql",
-        "operations/SearchUpcomingLaunches.graphql",
+        "operations",
         "--endpoint",
         "https://thespacedevs-production.up.railway.app/",
         "--introspection"


### PR DESCRIPTION
* The `--operations` option now support specifying a directory. All `.graphql` files in the directory will be loaded as operations.
* The `--operations` option now supports hot reloading. If a directory is specified, the MCP Server will handle files being added or removed, as well as changes to individual files. If a file is specified, it will hot reload any changes to that file.
* The event streaming has been unified - instead of having multiple spawned tasks to pick up PQ events separately from schema events, there is now one unified event stream. This required refactoring the server states to add configuration states. Only once both schema and operations events have been received does the server enter the `Starting` state.