### PR TITLE
ignore __typename

### DIFF
--- a/crates/apollo-mcp-server/src/schema_tree_shake.rs
+++ b/crates/apollo-mcp-server/src/schema_tree_shake.rs
@@ -507,7 +507,13 @@ fn selection_set_to_fields(
     named_fragments: &HashMap<String, Node<FragmentDefinition>>,
 ) -> Vec<Node<Field>> {
     match selection_set {
-        Selection::Field(field) => vec![field.clone()],
+        Selection::Field(field) => {
+            if field.name == "__typename" {
+                vec![]
+            } else {
+                vec![field.clone()]
+            }
+        }
         Selection::FragmentSpread(fragment) => named_fragments
             .get(fragment.fragment_name.as_str())
             .map(|f| {


### PR DESCRIPTION
__typename doesn't exist in the schema, but might show up in operations. We should just ignore these when treeshaking
<img width="1004" alt="image" src="https://github.com/user-attachments/assets/79ab7b16-fc3d-4c37-b1eb-41d3a6c66686" />
