### PR TITLE
Operation loading fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### 📚 Documentation
 -->
 
+## [Unreleased]
+### 🐛 Fixes
+- Improvements to operation loading (#80)
+  - When specifying multiple operation paths, all paths were reloaded when any one changed
+  - Many redundant events were sent on startup, causing verbose logging about loaded operations
+  - Better error handling for missing, invalid, or empty operation files
+- The `execute` tool did not handle variables correctly (#77)
+- Cycles in schema type definitions would lead to stack overflow (#74)
+
 ## [0.2.0] - 2025-05-21
 
 ### 🚀 Features

--- a/crates/apollo-mcp-server/src/event.rs
+++ b/crates/apollo-mcp-server/src/event.rs
@@ -2,6 +2,7 @@ use crate::operations::RawOperation;
 use apollo_mcp_registry::uplink::schema::event::Event as SchemaEvent;
 use std::fmt::Debug;
 use std::fmt::Formatter;
+use std::io;
 
 /// MCP Server events
 pub enum Event {
@@ -10,6 +11,9 @@ pub enum Event {
 
     /// The operations have been updated
     OperationsUpdated(Vec<RawOperation>),
+
+    /// An error occurred when loading operations
+    OperationError(io::Error),
 
     /// The server should gracefully shut down
     Shutdown,
@@ -23,6 +27,9 @@ impl Debug for Event {
             }
             Event::OperationsUpdated(operations) => {
                 write!(f, "OperationsChanged({:?})", operations)
+            }
+            Event::OperationError(e) => {
+                write!(f, "OperationError({:?}", e)
             }
             Event::Shutdown => {
                 write!(f, "Shutdown")

--- a/crates/apollo-mcp-server/src/server.rs
+++ b/crates/apollo-mcp-server/src/server.rs
@@ -745,6 +745,9 @@ impl StateMachine {
                     State::Running(running) => running.update_operations(operations).await.into(),
                     other => other,
                 },
+                ServerEvent::OperationError(e) => {
+                    State::Error(ServerError::Operation(OperationError::File(e)))
+                }
                 ServerEvent::Shutdown => match state {
                     State::Running(running) => {
                         running.cancellation_token.cancel();


### PR DESCRIPTION
- When specifying multiple operation paths, all paths were reloaded when any one changed
- Many redundant events were sent on startup, causing verbose logging about loaded operations
- Better error handling for missing, invalid, or empty operation files