### PR TITLE
Fix issues with the introspect tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,21 +13,31 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### 📚 Documentation
 -->
 
+## [Unreleased]
+
+### 🐛 Fixes
+
+- Fix issues with the `introspect` tool. (#83)
+
 ## [0.2.0] - 2025-05-21
 
 ### 🚀 Features
+
 - The `--operations` argument now supports hot reloading and directory paths. If a directory is specified, all .graphql files in the directory will be loaded as operations. The running server will update when files are added to or removed from the directory. (#69)
 - Add an optional `--sse-address` argument to set the bind address of the MCP server. Defaults to 127.0.0.1. (#63)
 
 ### 🐛 Fixes
+
 - Fixed PowerShell script (#55)
 - Log to stdout, not stderr (#59)
 - The `--directory` argument is now optional. When using the stdio transport, it is recommended to either set this option or use absolute paths for other arguments. (#64)
 
 ### 📚 Documentation
+
 - Fix and simplify the example `rover dev --mcp` commands
 
 ## [0.1.0] - 2025-05-15
 
 ### 🚀 Features
+
 - Initial release of the Apollo MCP Server

--- a/crates/apollo-mcp-server/src/introspection.rs
+++ b/crates/apollo-mcp-server/src/introspection.rs
@@ -117,7 +117,9 @@ impl Introspect {
                             })
                         && schema
                             .root_operation(OperationType::Subscription)
-                            .is_none_or(|root_name| extended_type.name() == root_name)
+                            .is_none_or(|root_name| {
+                                extended_type.name() != root_name || type_name == root_name.as_str()
+                            })
                 })
                 .map(|(_, extended_type)| extended_type.serialize())
                 .map(|serialized| serialized.to_string())

--- a/crates/apollo-mcp-server/src/schema_tree_shake.rs
+++ b/crates/apollo-mcp-server/src/schema_tree_shake.rs
@@ -826,10 +826,11 @@ fn retain_directive(
     if let Some(tree_directive_node) = tree_shaker.directive_nodes.get_mut(directive_name) {
         tree_directive_node.retain = true;
         tree_directive_node.node.arguments.iter().for_each(|arg| {
-            if let Some(arg_type) = tree_shaker.schema.types.get(arg.name.as_str()) {
+            let arg_type_name = arg.ty.inner_named_type();
+            if let Some(arg_type) = tree_shaker.schema.types.get(arg_type_name) {
                 retain_type(tree_shaker, arg_type, None, depth_limit.decrement())
             } else {
-                tracing::error!("argument type {} not found", arg.name);
+                tracing::error!("argument type {} not found", arg_type_name);
             }
         });
     }
@@ -1123,6 +1124,26 @@ mod test {
         assert_eq!(
             shaker.shaken().unwrap().to_string(),
             "type Query {\n  field1: TypeA\n  field2: TypeB\n}\n\ntype TypeA {\n  id: TypeB\n}\n\ntype TypeB {\n  id: TypeC\n}\n\ntype TypeC {\n  id: TypeA\n}\n"
+        );
+    }
+
+    #[test]
+    fn should_retain_directives() {
+        let source_text = r#"
+            type Query {
+                field1: String @deprecated(reason: "Use 'field2' instead")
+                field2: String
+            }
+        "#;
+        let document = Parser::new()
+            .parse_ast(source_text, "schema.graphql")
+            .unwrap();
+        let schema = document.to_schema_validate().unwrap();
+        let mut shaker = SchemaTreeShaker::new(&schema);
+        shaker.retain_operation_type(OperationType::Query, None, DepthLimit::Limited(3));
+        assert_eq!(
+            shaker.shaken().unwrap().to_string(),
+            "type Query {\n  field1: String @deprecated(reason: \"Use 'field2' instead\")\n  field2: String\n}\n"
         );
     }
 }


### PR DESCRIPTION
fixes #70 

This PR addresses two issues with the `introspect` tool:

-  It resolves the error `argument type reason not found` that occurs when a schema contains directives.
-  It fixes the problem  where no content is returned when a schema includes the `Subscription` top-level type.

## Before

![Shot 2025-05-23 at 15 06 46](https://github.com/user-attachments/assets/e1e58a5f-5ef6-41fd-adf1-2d18efa7e3af)

```sh
2025-05-23T19:06:04.917064Z  INFO rmcp::service: received request id=2 request=CallToolRequest(Request { method: CallToolRequestMethod, params: CallToolRequestParam { name: "introspect", arguments: Some({"depth": Number(1), "type_name": String("Query")}) } })
2025-05-23T19:06:04.934714Z ERROR apollo_mcp_server::schema_tree_shake: argument type reason not found
2025-05-23T19:06:04.934718Z ERROR apollo_mcp_server::schema_tree_shake: argument type reason not found
2025-05-23T19:06:04.940833Z  INFO rmcp::service: response message id=2 result=CallToolResult(CallToolResult { content: [], is_error: None })
```

## After

![Shot 2025-05-23 at 15 12 18](https://github.com/user-attachments/assets/db739c59-904d-42c7-ad7a-e3b9d1ca6e06)

```sh
2025-05-23T19:11:57.978978Z  INFO rmcp::service: received request id=1 request=ListToolsRequest(Request { method: ListToolsRequestMethod, params: Some(PaginatedRequestParamInner { cursor: None }) })
2025-05-23T19:11:57.979078Z  INFO rmcp::service: response message id=1 result=ListToolsResult(ListToolsResult { next_cursor: None, tools: [Tool { name: "execute", description: "Execute a GraphQL operation. Use the `introspect` tool to get information about the GraphQL schema. Always use the schema to create operations - do not try arbitrary operations. DO NOT try to execute introspection queries.", input_schema: {"$schema": String("http://json-schema.org/draft-07/schema#"), "title": String("Input"), "type": String("object"), "required": Array [String("query")], "properties": Object {"query": Object {"description": String("The GraphQL operation"), "type": String("string")}, "variables": Object {"description": String("The variable values"), "default": String(""), "type": String("string")}}} }, Tool { name: "introspect", description: "Get detailed information about types from the GraphQL schema. Use the type name `Query` to get root query fields.", input_schema: {"$schema": String("http://json-schema.org/draft-07/schema#"), "title": String("IntrospectInput"), "type": String("object"), "required": Array [String("type_name")], "properties": Object {"depth": Object {"description": String("How far to recurse the type hierarchy. Use 0 for no limit. Defaults to 1."), "default": Number(1), "type": String("integer"), "format": String("uint32"), "minimum": Number(0.0)}, "type_name": Object {"description": String("The name of the type to get information about."), "type": String("string")}}} }] })
2025-05-23T19:12:04.723734Z  INFO rmcp::service: received request id=2 request=CallToolRequest(Request { method: CallToolRequestMethod, params: CallToolRequestParam { name: "introspect", arguments: Some({"depth": Number(1), "type_name": String("Query")}) } })
2025-05-23T19:12:04.724632Z  INFO rmcp::service: response message id=2 result=CallToolResult(CallToolResult { content: [Annotated { raw: Text(RawTextContent { text: "type Query {\n  users: [User!]! @deprecated(reason: \"Use 'allUsers' instead for better performance\")\n  allUsers(limit: Int, offset: Int): UserConnection!\n  getUser(id: ID!): User @deprecated\n  user(id: ID!): User\n  posts: [Post!]!\n}\n" }), annotations: None }], is_error: None })
```
