### PR TITLE
Ignore mutations in the schema when `--allow-mutations` is set to none

### DIFF
--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -251,7 +251,7 @@ pub fn operation_defs(
             return Err(OperationError::SubscriptionNotAllowed(operation));
         }
         OperationType::Mutation => {
-            if !allow_mutations {
+            if !allow_mutations && mutation_mode == MutationMode::None {
                 return Err(OperationError::MutationNotAllowed(operation, mutation_mode));
             }
         }


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/GT-181 -->