### PR TITLE
Ignore mutation and subscription operations rather than erroring

### DIFF
--- a/crates/apollo-mcp-server/src/errors.rs
+++ b/crates/apollo-mcp-server/src/errors.rs
@@ -1,14 +1,8 @@
-use apollo_compiler::{
-    Node, Schema,
-    ast::{Document, OperationDefinition},
-    validation::WithErrors,
-};
+use apollo_compiler::{Schema, ast::Document, validation::WithErrors};
 use apollo_federation::error::FederationError;
 use reqwest::header::{InvalidHeaderName, InvalidHeaderValue};
 use rmcp::serde_json;
 use tokio::task::JoinError;
-
-use crate::operations::MutationMode;
 
 /// An error in operation parsing
 #[derive(Debug, thiserror::Error)]
@@ -33,12 +27,6 @@ pub enum OperationError {
 
     #[error(transparent)]
     File(#[from] std::io::Error),
-
-    #[error("Mutation {0} not allowed while with --allow-mutations {1:?}")]
-    MutationNotAllowed(Node<OperationDefinition>, MutationMode),
-
-    #[error("Subscriptions are not allowed: {0}")]
-    SubscriptionNotAllowed(Node<OperationDefinition>),
 }
 
 /// An error in server initialization

--- a/crates/apollo-mcp-server/src/schema_tree_shake.rs
+++ b/crates/apollo-mcp-server/src/schema_tree_shake.rs
@@ -848,7 +848,7 @@ mod test {
     use rstest::{fixture, rstest};
 
     use crate::{
-        operations::{MutationMode, operation_defs},
+        operations::operation_defs,
         schema_tree_shake::{DepthLimit, SchemaTreeShaker},
     };
 
@@ -980,7 +980,9 @@ mod test {
         let schema = document.to_schema_validate().unwrap();
         let mut shaker = SchemaTreeShaker::new(&schema);
         let (operation_document, operation_def, _comments) =
-            operation_defs("query TestQuery { id }", false, MutationMode::None).unwrap();
+            operation_defs("query TestQuery { id }", false)
+                .unwrap()
+                .unwrap();
         shaker.retain_operation(&operation_def, &operation_document, DepthLimit::Unlimited);
         assert_eq!(
             shaker.shaken().unwrap().to_string(),

--- a/crates/apollo-mcp-server/src/server.rs
+++ b/crates/apollo-mcp-server/src/server.rs
@@ -352,7 +352,10 @@ impl Starting {
                     self.disable_schema_description,
                 )
             })
-            .collect::<Result<_, OperationError>>()?;
+            .collect::<Result<Vec<Option<Operation>>, OperationError>>()?
+            .into_iter()
+            .flatten()
+            .collect();
 
         debug!(
             "Loaded {} operations:\n{}",
@@ -477,7 +480,10 @@ impl Running {
                     self.disable_schema_description,
                 )
             })
-            .collect::<Result<_, OperationError>>()?;
+            .collect::<Result<Vec<Option<Operation>>, OperationError>>()?
+            .into_iter()
+            .flatten()
+            .collect();
 
         debug!(
             "Updated {} operations:\n{}",
@@ -512,7 +518,10 @@ impl Running {
                         self.disable_schema_description,
                     )
                 })
-                .collect::<Result<_, OperationError>>()?;
+                .collect::<Result<Vec<Option<Operation>>, OperationError>>()?
+                .into_iter()
+                .flatten()
+                .collect();
 
             debug!(
                 "Loaded {} operations:\n{}",


### PR DESCRIPTION
The MCP Server would error out if mutation or subscription operations were specifed but not allowed. It should be possible to have such operations in a PQ list or operation files, but just not use them in the MCP Server. For example, the user may want to define mutations, but turn them on or off using the `--allow-mutations` option.

* Subscription operations are now simply ignored as they are unsupported by the MCP server
* Mutation operations are ignored with a warning if the specified mutation mode does not allow them
* The `introspect` tool will not return mutations if the mutation mode does not allow them