### PR TITLE
Accept variables as string or json

### DIFF
--- a/crates/apollo-mcp-server/src/introspection.rs
+++ b/crates/apollo-mcp-server/src/introspection.rs
@@ -145,7 +145,7 @@ pub struct Input {
     query: String,
 
     /// The variable values
-    variables: Option<String>,
+    variables: Option<Value>,
 }
 
 impl Execute {
@@ -182,14 +182,19 @@ impl graphql::Executable for Execute {
         let input = serde_json::from_value::<Input>(input).map_err(|_| {
             McpError::new(ErrorCode::INVALID_PARAMS, "Invalid input".to_string(), None)
         })?;
-        input
-            .variables
-            .map(|v| {
-                serde_json::from_str(&v).map_err(|_| {
-                    McpError::new(ErrorCode::INVALID_PARAMS, "Invalid input".to_string(), None)
-                })
-            })
-            .unwrap_or(Ok(Value::Null))
+        match input.variables {
+            None => Ok(Value::Null),
+            Some(Value::Null) => Ok(Value::Null),
+            Some(Value::String(s)) => serde_json::from_str(&s).map_err(|_| {
+                McpError::new(ErrorCode::INVALID_PARAMS, "Invalid input".to_string(), None)
+            }),
+            Some(obj) if obj.is_object() => Ok(obj),
+            _ => Err(McpError::new(
+                ErrorCode::INVALID_PARAMS,
+                "Invalid input".to_string(),
+                None,
+            )),
+        }
     }
 }
 
@@ -200,7 +205,7 @@ mod tests {
     use rmcp::serde_json::json;
 
     #[test]
-    fn execute_query_with_variables() {
+    fn execute_query_with_variables_as_string() {
         let execute = Execute::new(MutationMode::None);
 
         let query = "query GetUser($id: ID!) { user(id: $id) { id name } }";
@@ -209,6 +214,25 @@ mod tests {
         let input = json!({
             "query": query,
             "variables": variables.to_string()
+        });
+
+        assert_eq!(
+            Executable::operation(&execute, input.clone()),
+            Ok(query.to_string())
+        );
+        assert_eq!(Executable::variables(&execute, input), Ok(variables));
+    }
+
+    #[test]
+    fn execute_query_with_variables_as_json() {
+        let execute = Execute::new(MutationMode::None);
+
+        let query = "query GetUser($id: ID!) { user(id: $id) { id name } }";
+        let variables = json!({ "id": "123" });
+
+        let input = json!({
+            "query": query,
+            "variables": variables
         });
 
         assert_eq!(


### PR DESCRIPTION
Some LLMs were still having trouble executing GraphQL operations with variables. The MCP Server will now accept the variables in string form:

```
"{\"state\": \"CO\"}"
```
 or as JSON:
 ```json
{
  "state": "CO"
}
```