### PR TITLE
Return JSON content and set is_error

### DIFF
--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -55,7 +55,7 @@ pub trait Executable {
                     None,
                 )
             })?
-            .text()
+            .json::<Value>()
             .await
             .map_err(|reqwest_error| {
                 McpError::new(
@@ -64,10 +64,13 @@ pub trait Executable {
                     None,
                 )
             })
-            .and_then(Content::json)
-            .map(|result| CallToolResult {
-                content: vec![result],
-                is_error: None,
+            .map(|json| CallToolResult {
+                content: vec![Content::json(&json).unwrap_or(Content::text(json.to_string()))],
+                is_error: Some(
+                    json.get("errors")
+                        .filter(|value| !matches!(value, Value::Null))
+                        .is_some(),
+                ),
             })
     }
 }

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -69,7 +69,11 @@ pub trait Executable {
                 is_error: Some(
                     json.get("errors")
                         .filter(|value| !matches!(value, Value::Null))
-                        .is_some(),
+                        .is_some()
+                        && json
+                            .get("data")
+                            .filter(|value| !matches!(value, Value::Null))
+                            .is_none(),
                 ),
             })
     }


### PR DESCRIPTION
Since GrqphQL returns JSON, use `Content::json`. This makes the output look much better in some MCP clients, such as MCP Inspector.

Also set `is_error` based on the presence of errors in the response, following the [guildlines here](https://modelcontextprotocol.io/docs/concepts/tools#error-handling-2). 

# Before

<img width="819" alt="before" src="https://github.com/user-attachments/assets/5b7e3714-e224-4de0-81e7-891dfd4a00e5" />

# After

<img width="855" alt="after" src="https://github.com/user-attachments/assets/2ffc79f3-8388-4258-8f57-7a6d732d496c" />
