### PR TITLE
Fix nix package binary name mismatch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -126,8 +126,8 @@
         rec {
           inherit (garbageCollector) saveFromGC;
 
-          default = apollo-mcp;
-          apollo-mcp = apollo-mcp-builder.packages.apollo-mcp;
+          default = apollo-mcp-server;
+          apollo-mcp-server = apollo-mcp-builder.packages.apollo-mcp-server;
         }
         // cross;
 
@@ -154,7 +154,7 @@
           mtime = commitDate;
 
           contents = [
-            packages.apollo-mcp
+            packages.apollo-mcp-server
           ];
 
           config = let

--- a/nix/apollo-mcp.nix
+++ b/nix/apollo-mcp.nix
@@ -27,7 +27,7 @@
   craneLib = (crane.mkLib pkgs).overrideToolchain toolchain;
   craneCommonArgs = {
     inherit src;
-    pname = "apollo-mcp";
+    pname = "apollo-mcp-server";
     strictDeps = true;
 
     nativeBuildInputs = [perl pkg-config];
@@ -69,7 +69,7 @@ in {
 
   # List of packages exposed by this project
   packages = {
-    apollo-mcp = craneLib.buildPackage craneCommonArgs;
+    apollo-mcp-server = craneLib.buildPackage craneCommonArgs;
 
     # Builder for apollo-mcp-server. Takes the rust target triple for specifying
     # the cross-compile target. Set the target to the same as the host for native builds.


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/GT-187 -->

```sh
$ nix run github:apollographql/apollo-mcp-server
error: unable to execute '/nix/store/l46dc02f3nqkhkvyjg609zs94gbs3agb-apollo-mcp-0.2.1/bin/apollo-mcp': No such file or directory
```

When running `nix run github:apollographql/apollo-mcp-server`, the above error occurrs because Nix looks for a binary named `apollo-mcp`, but the actual binary produced was named `apollo-mcp-server`.

This PR updates the package name in `flake.nix` and `nix/apollo-mcp.nix` to match the actual binary name.

## How to test

Check out to the branch:

```sh
$ git checkout GT-187
$ cd apollo-mcp-server
```

Build the Package:

```sh
$ nix build .#apollo-mcp-server
```

Verify the Binary:

```sh
$ ls -l result/bin
```

Run the server:

```sh
nix run .#apollo-mcp-server -- --help
```