### PR TITLE
Fix recursive inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### 🛠 Maintenance
 ### 📚 Documentation
 -->
+## [UNRELEASED]
+
+### 🚀 Features
+
+- Include both the type description and field description in input schema (#100)
+- Hide String, ID, Int, Float, and Boolean descriptions in input schema (#100)
+
+### 🐛 Fixes
+
+- Fix error with recursive input types (#100)
 
 ## [0.2.1] - 2025-05-27
 

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -16,6 +16,7 @@ use apollo_mcp_registry::uplink::persisted_queries::ManifestSource;
 use apollo_mcp_registry::uplink::persisted_queries::event::Event as ManifestEvent;
 use futures::{Stream, StreamExt};
 use regex::Regex;
+use rmcp::schemars::Map;
 use rmcp::{
     model::Tool,
     schemars::schema::{
@@ -523,16 +524,17 @@ fn get_json_schema(
     custom_scalar_map: Option<&CustomScalarMap>,
 ) -> RootSchema {
     let mut obj = ObjectValidation::default();
+    let mut definitions = Map::new();
 
     operation.variables.iter().for_each(|variable| {
         let variable_name = variable.name.to_string();
-        let type_name = variable.ty.inner_named_type();
         let schema = type_to_schema(
             // For the root description, for now we can use the type description.
-            description(type_name, graphql_schema),
+            None,
             variable.ty.as_ref(),
             graphql_schema,
             custom_scalar_map,
+            &mut definitions,
         );
         obj.properties.insert(variable_name.clone(), schema);
         if variable.ty.is_non_null() {
@@ -546,6 +548,7 @@ fn get_json_schema(
             object: Some(Box::new(obj)),
             ..Default::default()
         },
+        definitions,
         ..Default::default()
     }
 }
@@ -573,7 +576,7 @@ fn schema_factory(
     })
 }
 
-fn description(name: &Name, graphql_schema: &GraphqlSchema) -> Option<String> {
+fn input_object_description(name: &Name, graphql_schema: &GraphqlSchema) -> Option<String> {
     if let Some(input_object) = graphql_schema.get_input_object(name) {
         input_object.description.as_ref().map(|d| d.to_string())
     } else if let Some(scalar) = graphql_schema.get_scalar(name) {
@@ -614,6 +617,7 @@ fn type_to_schema(
     variable_type: &Type,
     graphql_schema: &GraphqlSchema,
     custom_scalar_map: Option<&CustomScalarMap>,
+    definitions: &mut Map<String, Schema>,
 ) -> Schema {
     match variable_type {
         Type::NonNullNamed(named) | Type::Named(named) => match named.as_str() {
@@ -643,34 +647,53 @@ fn type_to_schema(
             ),
             _ => {
                 if let Some(input_type) = graphql_schema.get_input_object(named) {
-                    let mut obj = ObjectValidation::default();
+                    if !definitions.contains_key(named.as_str()) {
+                        definitions
+                            .insert(named.to_string(), Schema::Object(SchemaObject::default())); // Insert temporary value into map so any recursive references will not try to also create it.
+                        let mut obj = ObjectValidation::default();
 
-                    input_type.fields.iter().for_each(|(name, field)| {
-                        let description = field.description.as_ref().map(|n| n.to_string());
-                        obj.properties.insert(
-                            name.to_string(),
-                            type_to_schema(
-                                description,
-                                field.ty.as_ref(),
-                                graphql_schema,
-                                custom_scalar_map,
+                        input_type.fields.iter().for_each(|(name, field)| {
+                            let description = field.description.as_ref().map(|n| n.to_string());
+                            obj.properties.insert(
+                                name.to_string(),
+                                type_to_schema(
+                                    description,
+                                    field.ty.as_ref(),
+                                    graphql_schema,
+                                    custom_scalar_map,
+                                    definitions,
+                                ),
+                            );
+
+                            if field.is_required() {
+                                obj.required.insert(name.to_string());
+                            }
+                        });
+
+                        definitions.insert(
+                            named.to_string(),
+                            schema_factory(
+                                input_object_description(named, graphql_schema),
+                                Some(InstanceType::Object),
+                                Some(obj),
+                                None,
+                                None,
+                                None,
                             ),
                         );
+                    }
 
-                        if field.is_required() {
-                            obj.required.insert(name.to_string());
-                        }
-                    });
-
-                    schema_factory(
-                        description,
-                        Some(InstanceType::Object),
-                        Some(obj),
-                        None,
-                        None,
-                        None,
-                    )
+                    Schema::Object(SchemaObject {
+                        metadata: Some(Box::new(Metadata {
+                            description,
+                            ..Default::default()
+                        })),
+                        reference: Some(format!("#/definitions/{}", named)),
+                        ..Default::default()
+                    })
                 } else if graphql_schema.get_scalar(named).is_some() {
+                    let default_description =
+                        description.or(input_object_description(named, graphql_schema)); // TODO: move to reference
                     if let Some(custom_scalar_map) = custom_scalar_map {
                         if let Some(custom_scalar_schema_object) =
                             custom_scalar_map.get(named.as_str())
@@ -679,13 +702,13 @@ fn type_to_schema(
                             let mut meta = *custom_schema.metadata.unwrap_or_default();
                             // If description isn't included in custom schema, inject the one from the schema
                             if meta.description.is_none() {
-                                meta.description = description;
+                                meta.description = default_description;
                             }
                             custom_schema.metadata = Some(Box::new(meta));
                             Schema::Object(custom_schema)
                         } else {
                             warn!(name=?named, "custom scalar missing from custom_scalar_map");
-                            schema_factory(description, None, None, None, None, None)
+                            schema_factory(default_description, None, None, None, None, None)
                         }
                     } else {
                         warn!(name=?named, "custom scalars aren't currently supported without a custom_scalar_map");
@@ -693,7 +716,7 @@ fn type_to_schema(
                     }
                 } else if let Some(enum_type) = graphql_schema.get_enum(named) {
                     schema_factory(
-                        description,
+                        description.or(input_object_description(named, graphql_schema)), // TODO: move to reference
                         Some(InstanceType::String),
                         None,
                         None,
@@ -713,8 +736,13 @@ fn type_to_schema(
             }
         },
         Type::NonNullList(list_type) | Type::List(list_type) => {
-            let inner_type_schema =
-                type_to_schema(description, list_type, graphql_schema, custom_scalar_map);
+            let inner_type_schema = type_to_schema(
+                description,
+                list_type,
+                graphql_schema,
+                custom_scalar_map,
+                definitions,
+            );
             schema_factory(
                 None,
                 Some(InstanceType::Array),
@@ -1342,6 +1370,11 @@ mod tests {
                 "type": String("object"),
                 "properties": Object {
                     "id": Object {
+                        "$ref": String("#/definitions/RealInputObject"),
+                    },
+                },
+                "definitions": Object {
+                    "RealInputObject": Object {
                         "type": String("object"),
                         "required": Array [
                             String("required"),
@@ -1359,29 +1392,6 @@ mod tests {
                     },
                 },
             },
-        }
-        "###);
-        insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
-        {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "object",
-              "required": [
-                "required"
-              ],
-              "properties": {
-                "optional": {
-                  "description": "optional is a input field that is optional",
-                  "type": "string"
-                },
-                "required": {
-                  "description": "required is a input field that is required",
-                  "type": "string"
-                }
-              }
-            }
-          }
         }
         "###);
     }
@@ -1981,5 +1991,73 @@ mod tests {
             operation.tool.description.as_ref(),
             @r###""###
         );
+    }
+
+    #[test]
+    fn recursive_inputs() {
+        let operation = Operation::from_document(
+            r###"query Test($filter: Filter){
+                field(filter: $filter) {
+                    id
+                }
+            }"###,
+            &Schema::parse(
+                r#"
+                """the filter input"""
+                input Filter {
+                """the filter.field field"""
+                    field: String
+                    """the filter.filter field"""
+                    filter: Filter
+                }
+                type Query {
+                """the Query.field field"""
+                  field(
+                    """the filter argument"""
+                    filter: Filter
+                  ): String
+                }
+            "#,
+                "operation.graphql",
+            )
+            .unwrap(),
+            None,
+            None,
+            MutationMode::None,
+            true,
+            true,
+        )
+        .unwrap();
+
+        insta::assert_debug_snapshot!(operation.tool, @r###"
+        Tool {
+            name: "Test",
+            description: "",
+            input_schema: {
+                "type": String("object"),
+                "properties": Object {
+                    "filter": Object {
+                        "$ref": String("#/definitions/Filter"),
+                    },
+                },
+                "definitions": Object {
+                    "Filter": Object {
+                        "description": String("the filter input"),
+                        "type": String("object"),
+                        "properties": Object {
+                            "field": Object {
+                                "description": String("the filter.field field"),
+                                "type": String("string"),
+                            },
+                            "filter": Object {
+                                "description": String("the filter.filter field"),
+                                "$ref": String("#/definitions/Filter"),
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        "###);
     }
 }

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -529,7 +529,6 @@ fn get_json_schema(
     operation.variables.iter().for_each(|variable| {
         let variable_name = variable.name.to_string();
         let schema = type_to_schema(
-            // For the root description, for now we can use the type description.
             None,
             variable.ty.as_ref(),
             graphql_schema,

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -940,36 +940,6 @@ mod tests {
     }
 
     #[test]
-    fn mutation_mode_explicit() {
-        let operation = Operation::from_document(
-            "mutation MutationName { id }",
-            &SCHEMA,
-            None,
-            None,
-            MutationMode::Explicit,
-            false,
-            false,
-        )
-        .unwrap();
-
-        insta::assert_debug_snapshot!(operation, @r###"
-        Operation {
-            tool: Tool {
-                name: "MutationName",
-                description: "The returned value is optional and has type `String`",
-                input_schema: {
-                    "type": String("object"),
-                },
-            },
-            inner: RawOperation {
-                source_text: "mutation MutationName { id }",
-                persisted_query_id: None,
-            },
-        }
-        "###);
-    }
-
-    #[test]
     fn mutation_mode_all() {
         let operation = Operation::from_document(
             "mutation MutationName { id }",
@@ -2084,6 +2054,7 @@ mod tests {
             true,
             true,
         )
+        .unwrap()
         .unwrap();
 
         insta::assert_debug_snapshot!(operation.tool, @r###"

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -941,6 +941,36 @@ mod tests {
     }
 
     #[test]
+    fn mutation_mode_explicit() {
+        let operation = Operation::from_document(
+            "mutation MutationName { id }",
+            &SCHEMA,
+            None,
+            None,
+            MutationMode::Explicit,
+            false,
+            false,
+        )
+        .unwrap();
+
+        insta::assert_debug_snapshot!(operation, @r###"
+        Operation {
+            tool: Tool {
+                name: "MutationName",
+                description: "The returned value is optional and has type `String`",
+                input_schema: {
+                    "type": String("object"),
+                },
+            },
+            inner: RawOperation {
+                source_text: "mutation MutationName { id }",
+                persisted_query_id: None,
+            },
+        }
+        "###);
+    }
+
+    #[test]
     fn mutation_mode_all() {
         let operation = Operation::from_document(
             "mutation MutationName { id }",

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -1604,7 +1604,14 @@ mod tests {
             input_schema: {
                 "type": String("object"),
                 "properties": Object {
-                    "id": Object {},
+                    "id": Object {
+                        "$ref": String("#/definitions/RealCustomScalar"),
+                    },
+                },
+                "definitions": Object {
+                    "RealCustomScalar": Object {
+                        "description": String("RealCustomScalar exists"),
+                    },
                 },
             },
         }
@@ -1674,22 +1681,16 @@ mod tests {
                 "type": String("object"),
                 "properties": Object {
                     "id": Object {
+                        "$ref": String("#/definitions/RealCustomScalar"),
+                    },
+                },
+                "definitions": Object {
+                    "RealCustomScalar": Object {
                         "description": String("RealCustomScalar exists"),
                         "type": String("string"),
                     },
                 },
             },
-        }
-        "###);
-        insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
-        {
-          "type": "object",
-          "properties": {
-            "id": {
-              "description": "RealCustomScalar exists",
-              "type": "string"
-            }
-          }
         }
         "###);
     }

--- a/crates/apollo-mcp-server/src/schema_tree_shake.rs
+++ b/crates/apollo-mcp-server/src/schema_tree_shake.rs
@@ -1196,7 +1196,7 @@ mod test {
         shaker.retain_operation_type(OperationType::Query, None, DepthLimit::Unlimited);
         assert_eq!(
             shaker.shaken().unwrap().to_string(),
-            "directive @CustomDirective(arg: CustomScalar) on FIELD_DEFINITION\n\ntype Query {\n  field1: String @CustomDirective(arg: \"Use 'field2' instead\")\n  field2: String\n}\n\nscalar CustomScalar\n"
+            "input Filter {\n  field: String\n  filter: Filter\n}\n\ntype Query {\n  field(filter: Filter): String\n}\n"
         );
     }
 }

--- a/crates/apollo-mcp-server/src/schema_tree_shake.rs
+++ b/crates/apollo-mcp-server/src/schema_tree_shake.rs
@@ -1176,4 +1176,27 @@ mod test {
             "directive @CustomDirective(arg: CustomScalar) on FIELD_DEFINITION\n\ntype Query {\n  field1: String @CustomDirective(arg: \"Use 'field2' instead\")\n  field2: String\n}\n\nscalar CustomScalar\n"
         );
     }
+
+    #[test]
+    fn recursive_input() {
+        let source_text = r#"
+            input Filter {
+                field: String
+                filter: Filter
+            }
+            type Query {
+                field(filter: Filter): String
+            }
+        "#;
+        let document = Parser::new()
+            .parse_ast(source_text, "schema.graphql")
+            .unwrap();
+        let schema = document.to_schema_validate().unwrap();
+        let mut shaker = SchemaTreeShaker::new(&schema);
+        shaker.retain_operation_type(OperationType::Query, None, DepthLimit::Unlimited);
+        assert_eq!(
+            shaker.shaken().unwrap().to_string(),
+            "directive @CustomDirective(arg: CustomScalar) on FIELD_DEFINITION\n\ntype Query {\n  field1: String @CustomDirective(arg: \"Use 'field2' instead\")\n  field2: String\n}\n\nscalar CustomScalar\n"
+        );
+    }
 }


### PR DESCRIPTION
This PR fixes an error where the input schema would crash the server if it was recursive. 
for input objects, enums, and scalars it will use references where the reference has the type description, and the usages will have the field descriptions. 

review with whitespace off