### PR TITLE
Set the readOnlyHint for Query operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Implement the Streamable HTTP transport. Enable with `--http-port` and/or `--http-address`. (#98)
 - Include both the type description and field description in input schema (#100)
 - Hide String, ID, Int, Float, and Boolean descriptions in input schema (#100)
+- Set the `readOnlyHint` tool annotation for tools based on GraphQL query operations (#103)
 
 ### 🐛 Fixes
 

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -938,7 +938,17 @@ mod tests {
                 input_schema: {
                     "type": String("object"),
                 },
-                annotations: None,
+                annotations: Some(
+                    ToolAnnotations {
+                        title: None,
+                        read_only_hint: Some(
+                            false,
+                        ),
+                        destructive_hint: None,
+                        idempotent_hint: None,
+                        open_world_hint: None,
+                    },
+                ),
             },
             inner: RawOperation {
                 source_text: "mutation MutationName { id }",
@@ -972,7 +982,17 @@ mod tests {
                 input_schema: {
                     "type": String("object"),
                 },
-                annotations: None,
+                annotations: Some(
+                    ToolAnnotations {
+                        title: None,
+                        read_only_hint: Some(
+                            false,
+                        ),
+                        destructive_hint: None,
+                        idempotent_hint: None,
+                        open_world_hint: None,
+                    },
+                ),
             },
             inner: RawOperation {
                 source_text: "mutation MutationName { id }",
@@ -1006,7 +1026,17 @@ mod tests {
             input_schema: {
                 "type": String("object"),
             },
-            annotations: None,
+            annotations: Some(
+                ToolAnnotations {
+                    title: None,
+                    read_only_hint: Some(
+                        true,
+                    ),
+                    destructive_hint: None,
+                    idempotent_hint: None,
+                    open_world_hint: None,
+                },
+            ),
         }
         "###);
         insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
@@ -1045,7 +1075,17 @@ mod tests {
                     },
                 },
             },
-            annotations: None,
+            annotations: Some(
+                ToolAnnotations {
+                    title: None,
+                    read_only_hint: Some(
+                        true,
+                    ),
+                    destructive_hint: None,
+                    idempotent_hint: None,
+                    open_world_hint: None,
+                },
+            ),
         }
         "###);
         insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
@@ -1092,7 +1132,17 @@ mod tests {
                     },
                 },
             },
-            annotations: None,
+            annotations: Some(
+                ToolAnnotations {
+                    title: None,
+                    read_only_hint: Some(
+                        true,
+                    ),
+                    destructive_hint: None,
+                    idempotent_hint: None,
+                    open_world_hint: None,
+                },
+            ),
         }
         "###);
         insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
@@ -1150,7 +1200,17 @@ mod tests {
                     },
                 },
             },
-            annotations: None,
+            annotations: Some(
+                ToolAnnotations {
+                    title: None,
+                    read_only_hint: Some(
+                        true,
+                    ),
+                    destructive_hint: None,
+                    idempotent_hint: None,
+                    open_world_hint: None,
+                },
+            ),
         }
         "###);
         insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
@@ -1211,7 +1271,17 @@ mod tests {
                     },
                 },
             },
-            annotations: None,
+            annotations: Some(
+                ToolAnnotations {
+                    title: None,
+                    read_only_hint: Some(
+                        true,
+                    ),
+                    destructive_hint: None,
+                    idempotent_hint: None,
+                    open_world_hint: None,
+                },
+            ),
         }
         "###);
         insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
@@ -1269,7 +1339,17 @@ mod tests {
                     },
                 },
             },
-            annotations: None,
+            annotations: Some(
+                ToolAnnotations {
+                    title: None,
+                    read_only_hint: Some(
+                        true,
+                    ),
+                    destructive_hint: None,
+                    idempotent_hint: None,
+                    open_world_hint: None,
+                },
+            ),
         }
         "###);
         insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
@@ -1324,7 +1404,17 @@ mod tests {
                     },
                 },
             },
-            annotations: None,
+            annotations: Some(
+                ToolAnnotations {
+                    title: None,
+                    read_only_hint: Some(
+                        true,
+                    ),
+                    destructive_hint: None,
+                    idempotent_hint: None,
+                    open_world_hint: None,
+                },
+            ),
         }
         "###);
         insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
@@ -1387,7 +1477,17 @@ mod tests {
                     },
                 },
             },
-            annotations: None,
+            annotations: Some(
+                ToolAnnotations {
+                    title: None,
+                    read_only_hint: Some(
+                        true,
+                    ),
+                    destructive_hint: None,
+                    idempotent_hint: None,
+                    open_world_hint: None,
+                },
+            ),
         }
         "###);
         insta::assert_snapshot!(serde_json::to_string_pretty(&serde_json::json!(tool.input_schema)).unwrap(), @r###"
@@ -1465,7 +1565,17 @@ mod tests {
                     },
                 },
             },
-            annotations: None,
+            annotations: Some(
+                ToolAnnotations {
+                    title: None,
+                    read_only_hint: Some(
+                        true,
+                    ),
+                    destructive_hint: None,
+                    idempotent_hint: None,
+                    open_world_hint: None,
+                },
+            ),
         }
         "###);
     }
@@ -1512,7 +1622,17 @@ mod tests {
                     },
                 },
             },
-            annotations: None,
+            annotations: Some(
+                ToolAnnotations {
+                    title: None,
+                    read_only_hint: Some(
+                        true,
+                    ),
+                    destructive_hint: None,
+                    idempotent_hint: None,
+                    open_world_hint: None,
+                },
+            ),
         }
         "###);
     }
@@ -1621,7 +1741,17 @@ mod tests {
                     "id": Object {},
                 },
             },
-            annotations: None,
+            annotations: Some(
+                ToolAnnotations {
+                    title: None,
+                    read_only_hint: Some(
+                        true,
+                    ),
+                    destructive_hint: None,
+                    idempotent_hint: None,
+                    open_world_hint: None,
+                },
+            ),
         }
         "###);
     }
@@ -1661,7 +1791,17 @@ mod tests {
                     },
                 },
             },
-            annotations: None,
+            annotations: Some(
+                ToolAnnotations {
+                    title: None,
+                    read_only_hint: Some(
+                        true,
+                    ),
+                    destructive_hint: None,
+                    idempotent_hint: None,
+                    open_world_hint: None,
+                },
+            ),
         }
         "###);
     }
@@ -1701,7 +1841,17 @@ mod tests {
                     },
                 },
             },
-            annotations: None,
+            annotations: Some(
+                ToolAnnotations {
+                    title: None,
+                    read_only_hint: Some(
+                        true,
+                    ),
+                    destructive_hint: None,
+                    idempotent_hint: None,
+                    open_world_hint: None,
+                },
+            ),
         }
         "###);
     }
@@ -1744,7 +1894,17 @@ mod tests {
                     },
                 },
             },
-            annotations: None,
+            annotations: Some(
+                ToolAnnotations {
+                    title: None,
+                    read_only_hint: Some(
+                        true,
+                    ),
+                    destructive_hint: None,
+                    idempotent_hint: None,
+                    open_world_hint: None,
+                },
+            ),
         }
         "###);
     }
@@ -2142,7 +2302,17 @@ mod tests {
                     },
                 },
             },
-            annotations: None,
+            annotations: Some(
+                ToolAnnotations {
+                    title: None,
+                    read_only_hint: Some(
+                        true,
+                    ),
+                    destructive_hint: None,
+                    idempotent_hint: None,
+                    open_world_hint: None,
+                },
+            ),
         }
         "###);
     }

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -16,6 +16,7 @@ use apollo_mcp_registry::uplink::persisted_queries::ManifestSource;
 use apollo_mcp_registry::uplink::persisted_queries::event::Event as ManifestEvent;
 use futures::{Stream, StreamExt};
 use regex::Regex;
+use rmcp::model::ToolAnnotations;
 use rmcp::schemars::Map;
 use rmcp::{
     model::Tool,
@@ -333,7 +334,10 @@ impl Operation {
                 ));
             };
 
-            let tool: Tool = Tool::new(operation_name.clone(), description, schema);
+            let tool: Tool = Tool::new(operation_name.clone(), description, schema).annotate(
+                ToolAnnotations::new()
+                    .read_only(operation.operation_type != OperationType::Mutation),
+            );
             let character_count = tool_character_length(&tool);
             match character_count {
                 Ok(length) => info!(


### PR DESCRIPTION
The latest version of the Rust MCP SDK supports [tool annotations](https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations). Add the `readOnlyHint` for tools based on GraphQL query operations.

We can't really know without more information if mutations qualify for the `destructiveHint` or `idempotentHint`, so we don't set those for now.