### PR TITLE
Fix rover dev option documentation

### DIFF
--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -94,10 +94,8 @@ The mapping of `rover dev` options to MCP Server options:
 | `rover dev` option                                    | Equivalent MCP Server option                          |
 |:------------------------------------------------------|:------------------------------------------------------|
 | `--mcp-directory <DIRECTORY>`                         | `-d, --directory <DIRECTORY>`                         |
-| `--mcp-sse-port <PORT>`                               | `--sse-port <PORT>`                                   |
-| `--mcp-sse-address <ADDRESS>`                         | `--sse-address <ADDRESS>`                             |
-| `--mcp-http-port <PORT>`                              | `--http-port <PORT>`                                  |
-| `--mcp-http-address <ADDRESS>`                        | `--http-address <ADDRESS>`                            |
+| `--mcp-port <PORT>`                                   | `--http-port <PORT>`                                  |
+| `--mcp-address <ADDRESS>`                             | `--http-address <ADDRESS>`                            |
 | `--mcp-introspection`                                 | `-i, --introspection`                                 |
 | `--mcp-uplink`                                        | `-u, --uplink`                                        |
 | `--mcp-operations [<OPERATIONS>...]`                  | `-o, --operations [<OPERATIONS>...]`                  |


### PR DESCRIPTION
Fix the documentation of `rover dev` MCP options to match https://github.com/apollographql/rover/pull/2607