### PR TITLE
Extend RawOperation to include variables and headers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,18 +1,20 @@
 {
     "rust-analyzer.check.command": "clippy",
-    "rust-analyzer.cargo.features": ["json"],
     "[rust]": {
         "editor.defaultFormatter": "rust-lang.rust-analyzer",
         "editor.formatOnSave": true,       
     },
     "cSpell.words": [
+        "clippy",
         "insta",
         "peekable",
+        "redactions",
         "reqwest",
         "rmcp",
         "rstest",
         "schemars",
         "serde",
+        "Streamable",
         "Subschema",
         "subschemas",
         "Supergraph",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "rust-analyzer.check.command": "clippy",
+    "rust-analyzer.cargo.features": ["json"],
     "[rust]": {
         "editor.defaultFormatter": "rust-lang.rust-analyzer",
         "editor.formatOnSave": true,       

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -5,6 +5,7 @@ use apollo_compiler::response::serde_json_bytes::serde_json;
 use apollo_compiler::response::serde_json_bytes::serde_json::Value;
 use reqwest::header::{HeaderMap, HeaderValue};
 use rmcp::model::{CallToolResult, Content, ErrorCode};
+use std::borrow::Cow;
 
 pub struct Request<'a> {
     pub input: Value,
@@ -24,13 +25,13 @@ pub trait Executable {
     fn variables(&self, input: Value) -> Result<Value, McpError>;
 
     /// Get the headers to execute the operation with
-    fn headers(&self, default_headers: &HeaderMap<HeaderValue>) -> HeaderMap<HeaderValue>;
+    fn headers(&self, default_headers: Cow<HeaderMap<HeaderValue>>) -> HeaderMap<HeaderValue>;
 
     /// Execute as a GraphQL operation using the endpoint and headers
     async fn execute(&self, request: Request<'_>) -> Result<CallToolResult, McpError> {
         reqwest::Client::new()
             .post(request.endpoint)
-            .headers(self.headers(&request.headers))
+            .headers(self.headers(Cow::Borrowed(&request.headers)))
             .body(if let Some(id) = self.persisted_query_id() {
                 serde_json::json!({
                     "extensions": {

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -5,7 +5,6 @@ use apollo_compiler::response::serde_json_bytes::serde_json;
 use apollo_compiler::response::serde_json_bytes::serde_json::Value;
 use reqwest::header::{HeaderMap, HeaderValue};
 use rmcp::model::{CallToolResult, Content, ErrorCode};
-use std::borrow::Cow;
 
 pub struct Request<'a> {
     pub input: Value,
@@ -25,13 +24,13 @@ pub trait Executable {
     fn variables(&self, input: Value) -> Result<Value, McpError>;
 
     /// Get the headers to execute the operation with
-    fn headers(&self, default_headers: Cow<HeaderMap<HeaderValue>>) -> HeaderMap<HeaderValue>;
+    fn headers(&self, default_headers: &HeaderMap<HeaderValue>) -> HeaderMap<HeaderValue>;
 
     /// Execute as a GraphQL operation using the endpoint and headers
     async fn execute(&self, request: Request<'_>) -> Result<CallToolResult, McpError> {
         reqwest::Client::new()
             .post(request.endpoint)
-            .headers(self.headers(Cow::Borrowed(&request.headers)))
+            .headers(self.headers(&request.headers))
             .body(if let Some(id) = self.persisted_query_id() {
                 serde_json::json!({
                     "extensions": {

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -24,16 +24,13 @@ pub trait Executable {
     fn variables(&self, input: Value) -> Result<Value, McpError>;
 
     /// Get the headers to execute the operation with
-    fn headers(
-        &self,
-        default_headers: &HeaderMap<HeaderValue>,
-    ) -> Result<HeaderMap<HeaderValue>, McpError>;
+    fn headers(&self, default_headers: &HeaderMap<HeaderValue>) -> HeaderMap<HeaderValue>;
 
     /// Execute as a GraphQL operation using the endpoint and headers
     async fn execute(&self, request: Request<'_>) -> Result<CallToolResult, McpError> {
         reqwest::Client::new()
             .post(request.endpoint)
-            .headers(self.headers(&request.headers)?)
+            .headers(self.headers(&request.headers))
             .body(if let Some(id) = self.persisted_query_id() {
                 serde_json::json!({
                     "extensions": {

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -23,7 +23,7 @@ pub trait Executable {
     /// Get the variables to execute the operation with
     fn variables(&self, input: Value) -> Result<Value, McpError>;
 
-    /// Get the headers to execute the operation with
+    /// Get the variables to execute the operation with
     fn headers(
         &self,
         default_headers: &HeaderMap<HeaderValue>,

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -3,7 +3,7 @@
 use crate::errors::McpError;
 use apollo_compiler::response::serde_json_bytes::serde_json;
 use apollo_compiler::response::serde_json_bytes::serde_json::Value;
-use reqwest::header::HeaderMap;
+use reqwest::header::{HeaderMap, HeaderValue};
 use rmcp::model::{CallToolResult, Content, ErrorCode};
 
 pub struct Request<'a> {
@@ -23,11 +23,17 @@ pub trait Executable {
     /// Get the variables to execute the operation with
     fn variables(&self, input: Value) -> Result<Value, McpError>;
 
+    /// Get the headers to execute the operation with
+    fn headers(
+        &self,
+        default_headers: &HeaderMap<HeaderValue>,
+    ) -> Result<HeaderMap<HeaderValue>, McpError>;
+
     /// Execute as a GraphQL operation using the endpoint and headers
     async fn execute(&self, request: Request<'_>) -> Result<CallToolResult, McpError> {
         reqwest::Client::new()
             .post(request.endpoint)
-            .headers(request.headers)
+            .headers(self.headers(&request.headers)?)
             .body(if let Some(id) = self.persisted_query_id() {
                 serde_json::json!({
                     "extensions": {

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -23,7 +23,7 @@ pub trait Executable {
     /// Get the variables to execute the operation with
     fn variables(&self, input: Value) -> Result<Value, McpError>;
 
-    /// Get the variables to execute the operation with
+    /// Get the headers to execute the operation with
     fn headers(
         &self,
         default_headers: &HeaderMap<HeaderValue>,

--- a/crates/apollo-mcp-server/src/introspection.rs
+++ b/crates/apollo-mcp-server/src/introspection.rs
@@ -198,11 +198,8 @@ impl graphql::Executable for Execute {
         }
     }
 
-    fn headers(
-        &self,
-        default_headers: &HeaderMap<HeaderValue>,
-    ) -> Result<HeaderMap<HeaderValue>, McpError> {
-        Ok(default_headers.clone())
+    fn headers(&self, default_headers: &HeaderMap<HeaderValue>) -> HeaderMap<HeaderValue> {
+        default_headers.clone()
     }
 }
 

--- a/crates/apollo-mcp-server/src/introspection.rs
+++ b/crates/apollo-mcp-server/src/introspection.rs
@@ -15,7 +15,6 @@ use rmcp::schemars::JsonSchema;
 use rmcp::serde_json::Value;
 use rmcp::{schemars, serde_json};
 use serde::Deserialize;
-use std::borrow::Cow;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -199,8 +198,8 @@ impl graphql::Executable for Execute {
         }
     }
 
-    fn headers(&self, default_headers: Cow<HeaderMap<HeaderValue>>) -> HeaderMap<HeaderValue> {
-        default_headers.into_owned()
+    fn headers(&self, default_headers: &HeaderMap<HeaderValue>) -> HeaderMap<HeaderValue> {
+        default_headers.clone()
     }
 }
 

--- a/crates/apollo-mcp-server/src/introspection.rs
+++ b/crates/apollo-mcp-server/src/introspection.rs
@@ -9,6 +9,7 @@ use apollo_compiler::Schema;
 use apollo_compiler::ast::OperationType;
 use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::validation::Valid;
+use reqwest::header::{HeaderMap, HeaderValue};
 use rmcp::model::{CallToolResult, Content, ErrorCode, Tool};
 use rmcp::schemars::JsonSchema;
 use rmcp::serde_json::Value;
@@ -195,6 +196,13 @@ impl graphql::Executable for Execute {
                 None,
             )),
         }
+    }
+
+    fn headers(
+        &self,
+        default_headers: &HeaderMap<HeaderValue>,
+    ) -> Result<HeaderMap<HeaderValue>, McpError> {
+        Ok(default_headers.clone())
     }
 }
 

--- a/crates/apollo-mcp-server/src/introspection.rs
+++ b/crates/apollo-mcp-server/src/introspection.rs
@@ -15,6 +15,7 @@ use rmcp::schemars::JsonSchema;
 use rmcp::serde_json::Value;
 use rmcp::{schemars, serde_json};
 use serde::Deserialize;
+use std::borrow::Cow;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -198,8 +199,8 @@ impl graphql::Executable for Execute {
         }
     }
 
-    fn headers(&self, default_headers: &HeaderMap<HeaderValue>) -> HeaderMap<HeaderValue> {
-        default_headers.clone()
+    fn headers(&self, default_headers: Cow<HeaderMap<HeaderValue>>) -> HeaderMap<HeaderValue> {
+        default_headers.into_owned()
     }
 }
 

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -844,9 +844,21 @@ impl graphql::Executable for Operation {
                 )),
             }?;
 
-            raw_variables.iter().for_each(|(key, value)| {
-                variables.insert(key.clone(), value.clone());
-            });
+            raw_variables.iter().try_for_each(|(key, value)| {
+                if variables.contains_key(key) {
+                    Err(McpError::new(
+                        ErrorCode::INVALID_PARAMS,
+                        format!(
+                            "Variable conflict, only variables in input schema should be passed",
+                            key
+                        ),
+                        None,
+                    ))
+                } else {
+                    variables.insert(key, value);
+                    Ok(())
+                }
+            })?;
 
             Ok(Value::Object(variables))
         } else {

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -189,7 +189,7 @@ impl serde::Serialize for RawOperation {
         }
         if let Some(ref headers) = self.headers {
             state.serialize_field(
-                "variables",
+                "headers",
                 headers
                     .iter()
                     .map(|(name, value)| {

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -28,6 +28,7 @@ use rmcp::{
     serde_json::{self, Value},
 };
 use serde::Serialize;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -853,12 +854,12 @@ impl graphql::Executable for Operation {
         }
     }
 
-    fn headers(&self, default_headers: &HeaderMap<HeaderValue>) -> HeaderMap<HeaderValue> {
+    fn headers(&self, default_headers: Cow<HeaderMap<HeaderValue>>) -> HeaderMap<HeaderValue> {
         match self.inner.headers.as_ref() {
-            None => default_headers.clone(),
+            None => default_headers,
             Some(raw_headers) if default_headers.is_empty() => raw_headers.clone(),
             Some(raw_headers) => {
-                let mut headers = default_headers.clone();
+                let mut headers = default_headers;
                 raw_headers.iter().for_each(|(key, value)| {
                     if headers.contains_key(key) {
                         tracing::debug!(

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -877,7 +877,7 @@ impl graphql::Executable for Operation {
                 if variables.contains_key(key) {
                     Err(McpError::new(
                         ErrorCode::INVALID_PARAMS,
-                        "Variable {key} conflict, only variables in input schema should be passed",
+                        "No such parameter: {key}",
                         None,
                     ))
                 } else {

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -1055,6 +1055,8 @@ mod tests {
             inner: RawOperation {
                 source_text: "mutation MutationName { id }",
                 persisted_query_id: None,
+                headers: None,
+                variables: None,
             },
         }
         "###);
@@ -1103,6 +1105,8 @@ mod tests {
             inner: RawOperation {
                 source_text: "mutation MutationName { id }",
                 persisted_query_id: None,
+                headers: None,
+                variables: None,
             },
         }
         "###);

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -146,12 +146,6 @@ impl From<ManifestSource> for OperationSource {
     }
 }
 
-// impl From<String> for OperationSource {
-//     fn from(collection_id: String) -> Self {
-//         OperationSource::Collection(collection_id)
-//     }
-// }
-
 impl From<Vec<PathBuf>> for OperationSource {
     fn from(paths: Vec<PathBuf>) -> Self {
         OperationSource::Files(paths)
@@ -169,12 +163,6 @@ pub enum MutationMode {
     All,
 }
 
-// pub struct OperationCollectionOperation {
-//     source_text: String,
-//     headers: Option<HashMap<String, String>>,
-//     variables: Option<HashMap<String, Value>>,
-// }
-
 #[derive(Debug, Clone, Serialize)]
 pub struct RawOperation {
     source_text: String,
@@ -185,17 +173,6 @@ pub struct RawOperation {
     #[serde(skip_serializing_if = "Option::is_none")]
     variables: Option<HashMap<String, Value>>,
 }
-
-// impl From<OperationCollectionOperation> for RawOperation {
-//     fn from(operation: OperationCollectionOperation) -> Self {
-//         Self {
-//             source_text: operation.source_text,
-//             persisted_query_id: None,
-//             headers: operation.headers,
-//             variables: operation.variables,
-//         }
-//     }
-// }
 
 impl From<String> for RawOperation {
     fn from(source_text: String) -> Self {

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -171,7 +171,7 @@ pub struct RawOperation {
 }
 
 // Custom Serialize implementation for RawOperation
-// This is needed because reqwests HeaderMap/HeaderValue/HeaderName don't derive Serialize
+// This is needed because reqwest HeaderMap/HeaderValue/HeaderName don't derive Serialize
 impl serde::Serialize for RawOperation {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -28,7 +28,6 @@ use rmcp::{
     serde_json::{self, Value},
 };
 use serde::Serialize;
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -892,12 +891,12 @@ impl graphql::Executable for Operation {
         }
     }
 
-    fn headers(&self, default_headers: Cow<HeaderMap<HeaderValue>>) -> HeaderMap<HeaderValue> {
+    fn headers(&self, default_headers: &HeaderMap<HeaderValue>) -> HeaderMap<HeaderValue> {
         match self.inner.headers.as_ref() {
-            None => default_headers.into_owned(),
+            None => default_headers.clone(),
             Some(raw_headers) if default_headers.is_empty() => raw_headers.clone(),
             Some(raw_headers) => {
-                let mut headers = default_headers.into_owned();
+                let mut headers = default_headers.clone();
                 raw_headers.iter().for_each(|(key, value)| {
                     if headers.contains_key(key) {
                         tracing::debug!(

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -28,6 +28,7 @@ use rmcp::{
     serde_json::{self, Value},
 };
 use serde::Serialize;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -890,12 +891,12 @@ impl graphql::Executable for Operation {
         }
     }
 
-    fn headers(&self, default_headers: &HeaderMap<HeaderValue>) -> HeaderMap<HeaderValue> {
+    fn headers(&self, default_headers: Cow<HeaderMap<HeaderValue>>) -> HeaderMap<HeaderValue> {
         match self.inner.headers.as_ref() {
-            None => default_headers.clone(),
+            None => default_headers.into_owned(),
             Some(raw_headers) if default_headers.is_empty() => raw_headers.clone(),
             Some(raw_headers) => {
-                let mut headers = default_headers.clone();
+                let mut headers = default_headers.into_owned();
                 raw_headers.iter().for_each(|(key, value)| {
                     if headers.contains_key(key) {
                         tracing::debug!(

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -860,6 +860,12 @@ impl graphql::Executable for Operation {
             Some(raw_headers) => {
                 let mut headers = default_headers.clone();
                 raw_headers.iter().for_each(|(key, value)| {
+                    if headers.contains_key(key) {
+                        tracing::debug!(
+                            "Header {} has a default value, overwriting with operation value",
+                            key
+                        );
+                    }
                     headers.insert(key, value);
                 });
                 headers

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -172,6 +172,7 @@ pub struct RawOperation {
 }
 
 // Custom Serialize implementation for RawOperation
+// This is needed because reqwests HeaderMap/HeaderValue/HeaderName don't derive Serialize
 impl serde::Serialize for RawOperation {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
Extending RawOperation to include headers/variables to support operation collection data. 

Headers will act as overrides for default headers passed in by CLI

For variables I think they should act as overrides and remove them from the inputs, if they are defaults I don't think we are added any value with them. 

Ways to define variables
### Inline
no changing the value, and multiple uses need to repeat the value
```
query QueryName { field1(v: "v") field2(v: "v") }
```

### passed in
shared value across multiple fields, must be passed in
```
query QueryName($v: ID!) { field1(v: $v) field2(v: $v) }
```

### passed in with default
shared value across multiple fields, can be omited and default value will be used
```
query QueryName($v: ID! = "v") { field1(v: $v) field2(v: $v) }
```

### passed in with RawOperationVariable
shared value across multiple fields, but cannot be passed in
```
query QueryName($v: ID!) { field1(v: $v) field2(v: $v) }
```
```
{ v: "value" }
```