### PR TITLE
fix: allow for empty mounts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -157,6 +157,13 @@
             packages.apollo-mcp
           ];
 
+          # The server expects /data to exist, so we create it in the last layer to
+          # ensure that the server doesn't crash if nothing is mounted.
+          fakeRootCommands = ''
+            mkdir data
+            chmod a+r data
+          '';
+
           config = let
             http-port = 5000;
           in {


### PR DESCRIPTION
This PR fixes an issue where the container would require a mount at `/data` even if no local schemas were needed, which is typically the case when using uplink for operations.