### PR TITLE
docs: use 127.0.0.1 instead of localhost

### DIFF
--- a/docs/source/guides/index.mdx
+++ b/docs/source/guides/index.mdx
@@ -264,7 +264,6 @@ You can also deploy the server as a container using the instructions in [Deployi
 ```sh
 target/debug/apollo-mcp-server \
   --directory <absolute path to this git repo> \
-  --http-address 127.0.0.1 \
   --http-port 5000 \
   --schema graphql/weather/api.graphql \
   --operations graphql/weather/operations/forecast.graphql graphql/weather/operations/alerts.graphql graphql/weather/operations/all.graphql


### PR DESCRIPTION
I would like to update the user guide documentation to use `127.0.0.1` instead of `localhost` when connecting to the MCP server from the MCP inspector. I have encountered this issue several times and noticed that other folks are experiencing the same problem. This change should help prevent similar frustration for first-time users.