### PR TITLE
fix: handle headers with colons in value

### DIFF
--- a/.changesets/fix_headers_with_colon.md
+++ b/.changesets/fix_headers_with_colon.md
@@ -1,0 +1,3 @@
+### fix: handle headers with colons in value - @DaleSeo PR #128
+
+The MCP server won't crash when a header's value contains colons.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
         "rstest",
         "schemars",
         "serde",
+        "splitn",
         "Streamable",
         "Subschema",
         "subschemas",


### PR DESCRIPTION
The server crashes when a header's value contains colons. This PR updates the header parsing logic to resolve the issue.

```sh
$ cargo run -p apollo-mcp-server -- -u --http-address 127.0.0.1 --http-port 5000 --header "X-API-KEY: service:apollo-platform:12345"
2025-06-09T16:56:48.321750Z  INFO Apollo MCP Server v0.3.0 // (c) Apollo Graph, Inc. // Licensed under MIT
Error: invalid header: x-api-key: service:apollo-platform:12345

Stack backtrace:
   0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/../../backtrace/src/backtrace/libunwind.rs:117:9
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/../../backtrace/src/backtrace/mod.rs:66:14
   2: std::backtrace::Backtrace::create
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/backtrace.rs:331:13
   3: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
             at /Users/dale.seo/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anyhow-1.0.98/src/backtrace.rs:27:14
   4: <T as core::convert::Into<U>>::into
             at /nix/store/06cp4mhldyaqdbg8rslcrs8p9j76n51l-rust-default-1.86.0/lib/rustlib/src/rust/library/core/src/convert/mod.rs:761:9
   5: anyhow::kind::Trait::new
             at /Users/dale.seo/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anyhow-1.0.98/src/kind.rs:95:9
   6: apollo_mcp_server::main::{{closure}}
             at ./crates/apollo-mcp-server/src/main.rs:183:18
   7: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /nix/store/06cp4mhldyaqdbg8rslcrs8p9j76n51l-rust-default-1.86.0/lib/rustlib/src/rust/library/core/src/future/future.rs:124:9
   8: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
             at /Users/dale.seo/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.45.0/src/runtime/park.rs:284:60
   9: tokio::task::coop::with_budget
             at /Users/dale.seo/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.45.0/src/task/coop/mod.rs:167:5
  10: tokio::task::coop::budget
             at /Users/dale.seo/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.45.0/src/task/coop/mod.rs:133:5
```

<!-- https://apollographql.atlassian.net/browse/GT-229 -->