### PR TITLE
docs: reveal the mistakenly commented portion of the user guide

### DIFF
--- a/docs/source/guides/index.mdx
+++ b/docs/source/guides/index.mdx
@@ -39,7 +39,7 @@ If your machine doesn't have the `curl` command, you can get the latest version 
 These installation methods currently don't support Intel-based Macs. Support is planned for a future release.
 
 </Note>
-{/*
+
 ### Windows PowerShell installer
 
 To install or upgrade to the **latest release** of Apollo MCP Server:


### PR DESCRIPTION
A significant portion of our user guide is commented out (L42-L194) due to a typo.

![Shot 2025-06-11 at 15 52 36](https://github.com/user-attachments/assets/06d3cf39-fb73-48ae-a668-b66cd2363c43)
