### PR TITLE
Remove note about Intel-based macs

### DIFF
--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -50,11 +50,6 @@ curl -sSL https://mcp.apollo.dev/download/nix/v0.3.0| sh
 
 If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
 
-<Note>
-
-These installation methods currently don't support Intel-based Macs. Support is planned for a future release.
-
-</Note>
 ### Windows PowerShell installer
 
 To install or upgrade to the **latest release** of Apollo MCP Server:

--- a/docs/source/guides/index.mdx
+++ b/docs/source/guides/index.mdx
@@ -34,12 +34,6 @@ curl -sSL https://mcp.apollo.dev/download/nix/v0.3.0 | sh
 
 If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
 
-<Note>
-
-These installation methods currently don't support Intel-based Macs. Support is planned for a future release.
-
-</Note>
-
 ### Windows PowerShell installer
 
 To install or upgrade to the **latest release** of Apollo MCP Server:


### PR DESCRIPTION
Intel-based Macs have been supported for a while, but the doc wasn't updated.