### PR TITLE
Add client metadata to GraphQL requests

### DIFF
--- a/.changesets/feat_pubmodmatt_client_metadata.md
+++ b/.changesets/feat_pubmodmatt_client_metadata.md
@@ -1,0 +1,3 @@
+### Add client metadata to GraphQL requests - @pubmodmatt PR #137
+
+The MCP Server will now identify itself to Apollo Router through the `ApolloClientMetadata` extension. This allows traffic from MCP to be identified in the router, for example through telemetry.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-mcp-registry"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "derivative",
  "derive_more 2.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,9 @@
 resolver = "2"
 members = ["crates/apollo-mcp-server", "crates/apollo-mcp-registry"]
 
-package.version = "0.3.0"
+[workspace.package]
+authors = ["Apollo <opensource@apollographql.com>"]
+version = "0.3.0"
 
 [workspace.dependencies]
 apollo-compiler = "1.27.0"

--- a/crates/apollo-mcp-registry/Cargo.toml
+++ b/crates/apollo-mcp-registry/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "apollo-mcp-registry"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
-authors = ["Apollo <opensource@apollographql.com>"]
+authors.workspace = true
 license-file = "../LICENSE"
 repository = "https://github.com/apollographql/apollo-mcp-server"
 description = "Registry providing schema and operations to the MCP Server"

--- a/crates/apollo-mcp-registry/src/uplink.rs
+++ b/crates/apollo-mcp-registry/src/uplink.rs
@@ -395,7 +395,7 @@ where
 {
     let res = client
         .post(url)
-        // .header("x-router-version", env!("CARGO_PKG_VERSION"))
+        .header("x-apollo-mcp-server-version", env!("CARGO_PKG_VERSION"))
         .json(request_body)
         .send()
         .await

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "apollo-mcp-server"
 version.workspace = true
+authors.workspace = true
 edition = "2024"
 license-file = "../LICENSE"
 

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -73,21 +73,11 @@ struct Args {
     introspection: bool,
 
     /// Enable use of uplink to get the schema and persisted queries (requires APOLLO_KEY and APOLLO_GRAPH_REF)
-    #[arg(
-        long,
-        short = 'u',
-        requires = "apollo_graph_ref",
-        requires = "apollo_key"
-    )]
+    #[arg(long, short = 'u')]
     uplink: bool,
 
     /// Expose a tool to open queries in Apollo Explorer (requires APOLLO_KEY and APOLLO_GRAPH_REF)
-    #[arg(
-        long,
-        short = 'x',
-        requires = "apollo_graph_ref",
-        requires = "apollo_key"
-    )]
+    #[arg(long, short = 'x')]
     explorer: bool,
 
     /// Operation files to expose as MCP tools
@@ -127,7 +117,7 @@ struct Args {
     http_port: Option<u16>,
 
     /// collection id to expose as MCP tools (requires APOLLO_KEY)
-    #[arg(long, conflicts_with_all(["operations", "manifest"]), requires = "apollo_key")]
+    #[arg(long, conflicts_with_all(["operations", "manifest"]))]
     collection: Option<String>,
 
     /// The endpoints (comma separated) polled to fetch the latest supergraph schema.
@@ -148,6 +138,7 @@ struct Args {
 }
 
 impl Args {
+    #[allow(clippy::result_large_err)]
     fn uplink_config(&self) -> Result<UplinkConfig, ServerError> {
         Ok(UplinkConfig {
             apollo_key: SecretString::from(
@@ -167,7 +158,9 @@ impl Args {
                 .transpose()?,
         })
     }
-    fn parse_endpoints(&self, endpoints: &str) -> std::result::Result<Endpoints, ServerError> {
+
+    #[allow(clippy::result_large_err)]
+    fn parse_endpoints(&self, endpoints: &str) -> Result<Endpoints, ServerError> {
         Ok(Endpoints::fallback(
             endpoints
                 .split(',')
@@ -176,6 +169,8 @@ impl Args {
                 .map_err(ServerError::UrlParseError)?,
         ))
     }
+
+    #[allow(clippy::result_large_err)]
     fn platform_api_config(&self) -> Result<PlatformApiConfig, ServerError> {
         Ok(PlatformApiConfig::new(
             SecretString::from(


### PR DESCRIPTION
* Add `ApolloClientMetadata` for GraphQL requests. This will allow us to collect usage data for traffic from the MCP server that goes through Apollo Router
* Add a `x-apollo-mcp-server-version` header to Uplink requests. This is similar to the header router uses, `x-router-version`, and should allow collecting usage data for calls to Uplink from the MCP server
* Change the crates to pick up `workspace.package.version` and `workspace.package.author`. This ensures that `CARGO_PKG_VERSION` will be the top level Apollo MCP Server version
* Fix broken arguments that prevent the MCP server from starting up
* Fix clippy warnings

Example of router logs with the new metadata:

`2025-06-13T13:33:18.616606Z INFO router{http.route=/,http.request.method=POST,http.request.method=POST,http.request.method=POST,http.route=/,url.path=/,client.name=my-web-app,client.version=,}  http.request.version=HTTP/1.1 http.request.method=POST http.request.uri=/ http.request.headers={"apollographql-client-name": "my-web-app", "content-type": "application/json", "accept": "*/*", "accept-encoding": "gzip", "host": "127.0.0.1:4000", "content-length": "205"} http.request.body="{\"query\":\"query GetAlerts($state: String!) { alerts(state: $state) { severity description instruction } }\",\"variables\":{\"state\":\"AK\"},\"extensions\":{\"ApolloClientMetadata\":{\"type\":\"mcp\",\"version\":\"0.3.0\"}}}"  kind=router.request
`