### PR TITLE
Remove `--explorer` from launch configurations 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,6 @@
                 "5000",
                 "--allow-mutations",
                 "all",
-                "--explorer",
             ],
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
@@ -53,7 +52,6 @@
                 "5000",
                 "--allow-mutations",
                 "all",
-                "--explorer",
             ],
             "cwd": "${workspaceFolder}",
             "env": {


### PR DESCRIPTION
Updating the `launch.json` file so that the configurations don't include the `--explorer` CLI option. The `--explorer` CLI option requires the `APOLLO_GRAPH_REF` environment variable.

### Before

![Shot 2025-06-16 at 11 07 29](https://github.com/user-attachments/assets/990283f5-e154-4f90-a4d1-0b7029157e77)

### After

![Shot 2025-06-16 at 11 13 13](https://github.com/user-attachments/assets/c513dd08-8652-4e79-930a-6137e42f692d)
