### PR TITLE
Fix platform URL

### DIFF
--- a/crates/apollo-mcp-registry/src/platform_api.rs
+++ b/crates/apollo-mcp-registry/src/platform_api.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 pub mod operation_collections;
 
-const DEFAULT_PLATFORM_API: &str = "https://registry.apollographql.com/api/graphql";
+const DEFAULT_PLATFORM_API: &str = "https://graphql.api.apollographql.com/api/graphql";
 
 /// Configuration for polling Apollo Uplink.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
I somehow changed the URL while I was moving it in this PR https://github.com/apollographql/apollo-mcp-server/pull/134
use the correct platform URL