### PR TITLE
Test warning logs in operations module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "url",
 ]
 
@@ -2857,6 +2858,27 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -33,6 +33,7 @@ url.workspace = true
 [dev-dependencies]
 insta = { workspace = true }
 rstest = "0.25.0"
+tracing-test = "0.2.5"
 
 [lints]
 workspace = true


### PR DESCRIPTION
This PR adds assertions for warning logs in the operations module, addressing 3 TODO comments.

- Added `tracing-test` as a dev dependency for log capture in tests
- Enhanced 3 existing tests with log assertions:
  - `unknown_type_should_be_any()`
  - `custom_scalar_without_map_should_be_any()`
  - `custom_scalar_with_map_but_not_found_should_error()`
