### PR TITLE
Operation Collections - fix update checking

### DIFF
--- a/.changesets/fix_jeffrey_fix_collection_update_checking.md
+++ b/.changesets/fix_jeffrey_fix_collection_update_checking.md
@@ -1,0 +1,3 @@
+### Fix tool update on every poll - @Jephuff PR #146
+
+Only update the tool list if an operation was removed, changed, or added.

--- a/crates/apollo-mcp-registry/src/platform_api/operation_collections/collection_poller.rs
+++ b/crates/apollo-mcp-registry/src/platform_api/operation_collections/collection_poller.rs
@@ -78,36 +78,36 @@ async fn handle_poll_result(
 
     if changed_ids.is_empty() && removed_ids.is_empty() {
         tracing::debug!("no operation changed");
-        Ok(None)
-    } else {
-        if !removed_ids.is_empty() {
-            tracing::info!("removed operation ids: {:?}", removed_ids);
-            for id in removed_ids {
-                previous_updated_at.remove(id);
-            }
-        }
-
-        if !changed_ids.is_empty() {
-            tracing::info!("changed operation ids: {:?}", changed_ids);
-            let full_response = graphql_request::<OperationCollectionEntriesQuery>(
-                &OperationCollectionEntriesQuery::build_query(
-                    operation_collection_entries_query::Variables {
-                        collection_entry_ids: changed_ids,
-                    },
-                ),
-                platform_api_config,
-            )
-            .await?;
-            for operation in full_response.operation_collection_entries {
-                previous_updated_at.insert(
-                    operation.id.clone(),
-                    OperationData::from(&operation).clone(),
-                );
-            }
-        }
-
-        Ok(Some(previous_updated_at.clone().into_values().collect()))
+        return Ok(None);
     }
+
+    if !removed_ids.is_empty() {
+        tracing::info!("removed operation ids: {:?}", removed_ids);
+        for id in removed_ids {
+            previous_updated_at.remove(id);
+        }
+    }
+
+    if !changed_ids.is_empty() {
+        tracing::info!("changed operation ids: {:?}", changed_ids);
+        let full_response = graphql_request::<OperationCollectionEntriesQuery>(
+            &OperationCollectionEntriesQuery::build_query(
+                operation_collection_entries_query::Variables {
+                    collection_entry_ids: changed_ids,
+                },
+            ),
+            platform_api_config,
+        )
+        .await?;
+        for operation in full_response.operation_collection_entries {
+            previous_updated_at.insert(
+                operation.id.clone(),
+                OperationData::from(&operation).clone(),
+            );
+        }
+    }
+
+    Ok(Some(previous_updated_at.clone().into_values().collect()))
 }
 
 #[derive(Clone)]

--- a/crates/apollo-mcp-registry/src/platform_api/operation_collections/collection_poller.rs
+++ b/crates/apollo-mcp-registry/src/platform_api/operation_collections/collection_poller.rs
@@ -60,12 +60,11 @@ async fn handle_poll_result(
     poll: Vec<(String, String)>,
     platform_api_config: &PlatformApiConfig,
 ) -> Result<Option<Vec<OperationData>>, CollectionError> {
-    let mut keep_ids = poll.iter().map(|(id, _)| id);
-    for id in previous_updated_at.clone().keys() {
-        if keep_ids.all(|keep_id| keep_id != id) {
-            previous_updated_at.remove(id);
-        }
-    }
+    let removed_ids = previous_updated_at.clone();
+    let removed_ids = removed_ids
+        .keys()
+        .filter(|id| poll.iter().all(|(keep_id, _)| keep_id != *id))
+        .collect::<Vec<_>>();
 
     let changed_ids: Vec<String> = poll
         .into_iter()
@@ -77,26 +76,34 @@ async fn handle_poll_result(
         })
         .collect();
 
-    if changed_ids.is_empty() {
+    if changed_ids.is_empty() && removed_ids.is_empty() {
         tracing::debug!("no operation changed");
         Ok(None)
     } else {
-        tracing::debug!("changed operation ids: {:?}", changed_ids);
-        let full_response = graphql_request::<OperationCollectionEntriesQuery>(
-            &OperationCollectionEntriesQuery::build_query(
-                operation_collection_entries_query::Variables {
-                    collection_entry_ids: changed_ids,
-                },
-            ),
-            platform_api_config,
-        )
-        .await?;
+        if !removed_ids.is_empty() {
+            tracing::info!("removed operation ids: {:?}", removed_ids);
+            for id in removed_ids {
+                previous_updated_at.remove(id);
+            }
+        }
 
-        for operation in full_response.operation_collection_entries {
-            previous_updated_at.insert(
-                operation.id.clone(),
-                OperationData::from(&operation).clone(),
-            );
+        if !changed_ids.is_empty() {
+            tracing::info!("changed operation ids: {:?}", changed_ids);
+            let full_response = graphql_request::<OperationCollectionEntriesQuery>(
+                &OperationCollectionEntriesQuery::build_query(
+                    operation_collection_entries_query::Variables {
+                        collection_entry_ids: changed_ids,
+                    },
+                ),
+                platform_api_config,
+            )
+            .await?;
+            for operation in full_response.operation_collection_entries {
+                previous_updated_at.insert(
+                    operation.id.clone(),
+                    OperationData::from(&operation).clone(),
+                );
+            }
         }
 
         Ok(Some(previous_updated_at.clone().into_values().collect()))


### PR DESCRIPTION
The update checking was off so it would update all operations on every poll. This will fix it so that it only deletes removed operations and will only update the tool list if something has changed. 