### PR TITLE
Add default collection support

### DIFF
--- a/crates/apollo-mcp-registry/src/platform_api/operation_collections/collection_poller.rs
+++ b/crates/apollo-mcp-registry/src/platform_api/operation_collections/collection_poller.rs
@@ -9,6 +9,11 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use super::{error::CollectionError, event::CollectionEvent};
 use crate::platform_api::PlatformApiConfig;
+use operation_collection_default_polling_query::OperationCollectionDefaultPollingQueryVariant;
+use operation_collection_default_query::{
+    OperationCollectionDefaultQueryVariant,
+    OperationCollectionDefaultQueryVariantOnGraphVariantMcpDefaultCollectionOperations as OperationCollectionDefaultEntry,
+};
 use operation_collection_entries_query::OperationCollectionEntriesQueryOperationCollectionEntries;
 use operation_collection_polling_query::{
     OperationCollectionPollingQueryOperationCollection as PollingOperationCollectionResult,
@@ -54,6 +59,24 @@ struct OperationCollectionPollingQuery;
     response_derives = "PartialEq, Debug, Deserialize"
 )]
 struct OperationCollectionQuery;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "src/platform_api/operation_collections/operation_collections.graphql",
+    schema_path = "src/platform_api/platform-api.graphql",
+    request_derives = "Debug",
+    response_derives = "PartialEq, Debug, Deserialize"
+)]
+struct OperationCollectionDefaultQuery;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "src/platform_api/operation_collections/operation_collections.graphql",
+    schema_path = "src/platform_api/platform-api.graphql",
+    request_derives = "Debug",
+    response_derives = "PartialEq, Debug, Deserialize"
+)]
+struct OperationCollectionDefaultPollingQuery;
 
 async fn handle_poll_result(
     previous_updated_at: &mut HashMap<String, OperationData>,
@@ -176,10 +199,40 @@ impl From<&OperationCollectionEntriesQueryOperationCollectionEntries> for Operat
         }
     }
 }
+impl From<&OperationCollectionDefaultEntry> for OperationData {
+    fn from(operation: &OperationCollectionDefaultEntry) -> Self {
+        Self {
+            id: operation.id.clone(),
+            last_updated_at: operation.last_updated_at.clone(),
+            source_text: operation
+                .operation_data
+                .current_operation_revision
+                .body
+                .clone(),
+            headers: operation
+                .operation_data
+                .current_operation_revision
+                .headers
+                .as_ref()
+                .map(|headers| {
+                    headers
+                        .iter()
+                        .map(|h| (h.name.clone(), h.value.clone()))
+                        .collect()
+                }),
+            variables: operation
+                .operation_data
+                .current_operation_revision
+                .variables
+                .clone(),
+        }
+    }
+}
 
 #[derive(Clone)]
 pub enum CollectionSource {
     Id(String, PlatformApiConfig),
+    Default(String, PlatformApiConfig),
 }
 
 async fn write_init_response(
@@ -217,6 +270,9 @@ impl CollectionSource {
         match self {
             CollectionSource::Id(id, platform_api_config) => {
                 self.collection_id_stream(id.clone(), platform_api_config.clone())
+            }
+            CollectionSource::Default(graph_ref, platform_api_config) => {
+                self.default_collection_stream(graph_ref.clone(), platform_api_config.clone())
             }
         }
     }
@@ -318,6 +374,123 @@ impl CollectionSource {
         });
         Box::pin(ReceiverStream::new(receiver))
     }
+
+    pub fn default_collection_stream(
+        &self,
+        graph_ref: String,
+        platform_api_config: PlatformApiConfig,
+    ) -> Pin<Box<dyn Stream<Item = CollectionEvent> + Send>> {
+        let (sender, receiver) = channel(2);
+        tokio::task::spawn(async move {
+            let mut previous_updated_at = HashMap::new();
+            match graphql_request::<OperationCollectionDefaultQuery>(
+                &OperationCollectionDefaultQuery::build_query(
+                    operation_collection_default_query::Variables {
+                        graph_ref: graph_ref.clone(),
+                    },
+                ),
+                &platform_api_config,
+            )
+            .await
+            {
+                Ok(response) => match response.variant {
+                    Some(OperationCollectionDefaultQueryVariant::GraphVariant(variant)) => {
+                        if let Some(collection) = variant.mcp_default_collection {
+                            let should_poll = write_init_response(
+                                &sender,
+                                &mut previous_updated_at,
+                                collection.operations.iter().map(OperationData::from),
+                            )
+                            .await;
+                            if !should_poll {
+                                return;
+                            }
+                        } else {
+                            tracing::debug!(
+                                "No default collection found for graph variant: {graph_ref}"
+                            );
+                        }
+                    }
+                    Some(OperationCollectionDefaultQueryVariant::InvalidRefFormat(err)) => {
+                        if let Err(e) = sender
+                            .send(CollectionEvent::CollectionError(CollectionError::Response(
+                                err.message,
+                            )))
+                            .await
+                        {
+                            tracing::debug!(
+                                "failed to send error to collection stream. This is likely to be because the server is shutting down: {e}"
+                            );
+                            return;
+                        }
+                    }
+                    None => {
+                        if let Err(e) = sender
+                            .send(CollectionEvent::CollectionError(CollectionError::Response(
+                                "{graphRef} not found".to_string(),
+                            )))
+                            .await
+                        {
+                            tracing::debug!(
+                                "failed to send error to collection stream. This is likely to be because the server is shutting down: {e}"
+                            );
+                        }
+                        return;
+                    }
+                },
+                Err(err) => {
+                    if let Err(e) = sender.send(CollectionEvent::CollectionError(err)).await {
+                        tracing::debug!(
+                            "failed to send error to collection stream. This is likely to be because the server is shutting down: {e}"
+                        );
+                    }
+                    return;
+                }
+            };
+
+            loop {
+                tokio::time::sleep(platform_api_config.poll_interval).await;
+
+                match poll_operation_collection_default(
+                    graph_ref.clone(),
+                    &platform_api_config,
+                    &mut previous_updated_at,
+                )
+                .await
+                {
+                    Ok(Some(operations)) => {
+                        let operations_count = operations.len();
+                        if let Err(e) = sender
+                            .send(CollectionEvent::UpdateOperationCollection(operations))
+                            .await
+                        {
+                            tracing::debug!(
+                                "failed to push to stream. This is likely to be because the server is shutting down: {e}"
+                            );
+                            break;
+                        } else if operations_count > MAX_COLLECTION_SIZE_FOR_POLLING {
+                            tracing::warn!(
+                                "Operation Collection polling disabled. Collection has {operations_count} operations which exceeds the maximum of {MAX_COLLECTION_SIZE_FOR_POLLING}."
+                            );
+                            break;
+                        }
+                    }
+                    Ok(None) => {
+                        tracing::debug!("Operation collection unchanged");
+                    }
+                    Err(err) => {
+                        if let Err(e) = sender.send(CollectionEvent::CollectionError(err)).await {
+                            tracing::debug!(
+                                "failed to send error to collection stream. This is likely to be because the server is shutting down: {e}"
+                            );
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+        Box::pin(ReceiverStream::new(receiver))
+    }
 }
 
 async fn poll_operation_collection_id(
@@ -353,6 +526,45 @@ async fn poll_operation_collection_id(
         | PollingOperationCollectionResult::ValidationError(PollingValidationError { message }) => {
             Err(CollectionError::Response(message))
         }
+    }
+}
+
+async fn poll_operation_collection_default(
+    graph_ref: String,
+    platform_api_config: &PlatformApiConfig,
+    previous_updated_at: &mut HashMap<String, OperationData>,
+) -> Result<Option<Vec<OperationData>>, CollectionError> {
+    let response = graphql_request::<OperationCollectionDefaultPollingQuery>(
+        &OperationCollectionDefaultPollingQuery::build_query(
+            operation_collection_default_polling_query::Variables { graph_ref },
+        ),
+        platform_api_config,
+    )
+    .await?;
+
+    match response.variant {
+        Some(OperationCollectionDefaultPollingQueryVariant::GraphVariant(variant)) => {
+            if let Some(collection) = variant.mcp_default_collection {
+                handle_poll_result(
+                    previous_updated_at,
+                    collection
+                        .operations
+                        .into_iter()
+                        .map(|operation| (operation.id, operation.last_updated_at))
+                        .collect(),
+                    platform_api_config,
+                )
+                .await
+            } else {
+                Ok(None) // TODO: remove operations?
+            }
+        }
+        Some(OperationCollectionDefaultPollingQueryVariant::InvalidRefFormat(err)) => {
+            Err(CollectionError::Response(err.message))
+        }
+        None => Err(CollectionError::Response(
+            "Default collection not found".to_string(),
+        )),
     }
 }
 

--- a/crates/apollo-mcp-registry/src/platform_api/operation_collections/operation_collections.graphql
+++ b/crates/apollo-mcp-registry/src/platform_api/operation_collections/operation_collections.graphql
@@ -58,10 +58,16 @@ query OperationCollectionDefaultQuery($graphRef: ID!) {
         __typename
         ... on GraphVariant {
           mcpDefaultCollection {
-            operations {
+            __typename
+            ... on OperationCollection {
+              operations {
                 lastUpdatedAt
                 id
                 ...OperationData
+              }
+            }
+            ... on PermissionError {
+              message
             }
           }
         }
@@ -76,11 +82,16 @@ query OperationCollectionDefaultPollingQuery($graphRef: ID!) {
         __typename
         ... on GraphVariant {
           mcpDefaultCollection {
-            operations {
+            __typename
+            ... on OperationCollection {
+              operations {
                 id
                 lastUpdatedAt
+              }
             }
-            
+            ... on PermissionError {
+              message
+            }
           }
         }
         ... on InvalidRefFormat {

--- a/crates/apollo-mcp-registry/src/platform_api/operation_collections/operation_collections.graphql
+++ b/crates/apollo-mcp-registry/src/platform_api/operation_collections/operation_collections.graphql
@@ -53,6 +53,42 @@ query OperationCollectionPollingQuery($operationCollectionId: ID!) {
     }
 }
 
+query OperationCollectionDefaultQuery($graphRef: ID!) {
+    variant(ref: $graphRef) {
+        __typename
+        ... on GraphVariant {
+          mcpDefaultCollection {
+            operations {
+                lastUpdatedAt
+                id
+                ...OperationData
+            }
+          }
+        }
+        ... on InvalidRefFormat {
+            message
+        }
+    }
+}
+
+query OperationCollectionDefaultPollingQuery($graphRef: ID!) {
+    variant(ref: $graphRef) {
+        __typename
+        ... on GraphVariant {
+          mcpDefaultCollection {
+            operations {
+                id
+                lastUpdatedAt
+            }
+            
+          }
+        }
+        ... on InvalidRefFormat {
+            message
+        }
+    }
+}
+
 query OperationCollectionEntriesQuery($collectionEntryIds: [ID!]!) {
   operationCollectionEntries(collectionEntryIds: $collectionEntryIds) {
     id

--- a/crates/apollo-mcp-registry/src/platform_api/platform-api.graphql
+++ b/crates/apollo-mcp-registry/src/platform_api/platform-api.graphql
@@ -8329,6 +8329,9 @@ enum GraphType {
 
 """A graph variant"""
 type GraphVariant {
+  """The default collection MCP servers will use if no explicit collection is provided"""
+
+  mcpDefaultCollection: OperationCollection
   """The variant's global identifier in the form `graphID@variant`."""
   id: ID!
 

--- a/crates/apollo-mcp-registry/src/platform_api/platform-api.graphql
+++ b/crates/apollo-mcp-registry/src/platform_api/platform-api.graphql
@@ -4463,6 +4463,11 @@ input PublishSubgraphsSubgraphInput {
 """Queries defined by this subgraph"""
 type Query {
   """
+  This field accepts up to 400 requests per minute. This rate may be temporarily adjusted based on system conditions.
+  """
+  operationCollectionEntries(collectionEntryIds: [ID!]!): [OperationCollectionEntry!]!
+
+  """
   Returns details of the authenticated `User` or `Graph` executing this query. If this is an unauthenticated query (i.e., no API key is provided), this field returns null.
   """
   me: Identity

--- a/crates/apollo-mcp-registry/src/platform_api/platform-api.graphql
+++ b/crates/apollo-mcp-registry/src/platform_api/platform-api.graphql
@@ -1,1659 +1,33 @@
 """
 An organization in Apollo Studio. Can have multiple members and graphs.
 """
-type Account {
-  billingInfo: BillingInfo
-  billingInsights(from: Date!, limit: Int, to: Date, windowSize: BillingUsageStatsWindowSize): BillingInsights!
-  capabilities: AccountCapabilities
-  currentBillingMonth: BillingMonth
-  currentPlan: BillingPlan!
-  currentSubscription: BillingSubscription
-  eligibleForUsageBasedPlan: Boolean!
-  expiredTrialDismissedAt: Timestamp
-  expiredTrialSubscription: BillingSubscription
-  hasBeenOnTrial: Boolean!
-  hasBillingInfo: Boolean
-
-  """
-  Internal immutable identifier for the account. Only visible to Apollo admins (because it really
-  shouldn't be used in normal client apps).
-  """
-  internalID: ID!
-  invoices: [Invoice!]!
-  isLocked: Boolean
-  isOnExpiredTrial: Boolean!
-  isOnTrial: Boolean!
-  isSelfServiceDeletable: Boolean
-  limits: AccountLimits
-  lockDetails: AccountLockDetails
-
+type Organization {
   """
   Fetches an offline license for the account.
   (If you need this then please contact your Apollo account manager to discuss your requirements.)
   """
-  offlineLicense: RouterEntitlement
-
-  """
-  Fetches *legacy serverless* usage based pricing operations counts for the calling user. If a particular window is not specified,
-  totals for the user's current billing period are returned. (Will error if the user is not currently on a usage
-  based plan.)
-  """
-  operationUsage(forWindow: AccountOperationUsageWindowInput): AccountOperationUsage!
-  requestsInCurrentBillingPeriod: Long
-  routerEntitlement: RouterEntitlement
-  subscriptions: [BillingSubscription!]!
-  survey(id: String!): Survey
-
-  """Fetch a CloudOnboarding associated with this account"""
-  cloudOnboarding(graphRef: String!): CloudOnboarding
-
-  """List the private subgraphs associated with your Apollo account"""
-  privateSubgraphs(cloudProvider: CloudProvider!): [PrivateSubgraph!]!
-
-  """These are the roles that the account is able to use"""
-  availableRoles: [UserPermission!]!
-  companyUrl: String
-
-  """The time at which the account was created"""
-  createdAt: Timestamp
+  offlineLicense: RouterLicense
 
   """
   Globally unique identifier, which isn't guaranteed stable (can be changed by administrators).
   """
   id: ID!
-  invitations(includeAccepted: Boolean! = false): [AccountInvitation!]
 
   """The user memberships belonging to an Organization"""
   memberships: [AccountMembership!]
 
   """Name of the organization, which can change over time and isn't unique."""
   name: String!
-  roles: AccountRoles
-
-  """
-  How many seats would be included in your next bill, as best estimated today
-  """
-  seatCountForNextBill: Int
-  seats: Seats
-  secondaryIDs: [ID!]!
 
   """The session length in seconds for a user in this org"""
   sessionDurationInSeconds: Int
-
-  """
-  If non-null, this organization tracks its members through an upstream IdP;
-  invitations are not possible on SSO-synchronized account.
-  """
-  sso: OrganizationSSO
-  ssoV2: SsoConfig
-
-  """A list of reusable invitations for the organization."""
-  staticInvitations: [OrganizationInviteLink!]
   auditLogExports: [AuditLogExport!]
 
-  """
-  Get an URL to which an avatar image can be uploaded. Client uploads by sending a PUT request
-  with the image data to MediaUploadInfo.url. Client SHOULD set the "Content-Type" header to the
-  browser-inferred MIME type, and SHOULD set the "x-apollo-content-filename" header to the
-  filename, if such information is available. Client MUST set the "x-apollo-csrf-token" header to
-  MediaUploadInfo.csrfToken.
-  """
-  avatarUpload: AvatarUploadResult
-
-  """
-  Get an image URL for the account's avatar. Note that CORS is not enabled for these URLs. The size
-  argument is used for bandwidth reduction, and should be the size of the image as displayed in the
-  application. Apollo's media server will downscale larger images to at least the requested size,
-  but this will not happen for third-party media servers.
-  """
-  avatarUrl(size: Int! = 40): String
-  billingContactEmail: String
-  graphIDAvailable(id: ID!): Boolean!
+  """Graphs belonging to this organization."""
+  graphs(includeDeleted: Boolean): [Graph!]!
 
   """Graphs belonging to this organization."""
-  graphs(filterBy: GraphFilter, includeDeleted: Boolean): [Service!]!
-
-  """Graphs belonging to this organization."""
-  graphsConnection(
-    """Return the elements in the list that come after the specified cursor."""
-    after: String
-
-    """Return the elements in the list that come before the specified cursor."""
-    before: String
-
-    """
-    Filtering options for graphs returned from the connection. Defaults to returning all graphs.
-    """
-    filterBy: GraphFilter
-
-    """Return the first n elements from the list."""
-    first: Int
-
-    """Return the last n elements from the list."""
-    last: Int
-  ): AccountGraphConnection
-  provisionedAt: Timestamp @deprecated(reason: "use Account.createdAt instead")
-  requests(from: Timestamp!, to: Timestamp!): Long
-
-  """Graphs belonging to this organization."""
-  services(includeDeleted: Boolean): [Service!]! @deprecated(reason: "Use graphs field instead")
-  state: AccountState @deprecated(reason: "no longer relevant; it's only ever populated for enterprise accounts")
-  stats(
-    from: Timestamp!
-
-    """
-    Granularity of buckets. Defaults to the entire range (aggregate all data into a single durationBucket) when null.
-    """
-    resolution: Resolution
-
-    """Defaults to the current time when null."""
-    to: Timestamp
-  ): AccountStatsWindow! @deprecated(reason: "use Account.statsWindow instead")
-  statsWindow(
-    from: Timestamp!
-
-    """
-    Granularity of buckets. Defaults to the entire range (aggregate all data into a single durationBucket) when null.
-    """
-    resolution: Resolution
-
-    """Defaults to the current time when null."""
-    to: Timestamp
-  ): AccountStatsWindow
-
-  """
-  All Variants within the Graphs belonging to this organization. Can be limited to those favorited by the current user.
-  """
-  variants(
-    """
-    Filtering options for graph variants returned from the connection. Defaults to returning all graph variants.
-    """
-    filterBy: GraphVariantFilter = ALL
-  ): AccountGraphVariantConnection @deprecated(reason: "use Service.variants instead")
-
-  """Returns a different registry related stats pertaining to this account."""
-  registryStatsWindow(from: Timestamp!, resolution: Resolution, to: Timestamp): RegistryStatsWindow
-
-  """Gets a ticket for this org, by id"""
-  supportTicket(id: ID!): SupportTicket
-
-  """List of support tickets submitted for this org"""
-  supportTickets: [SupportTicket!]
-}
-
-"""Columns of AccountBillingUsageStats."""
-enum AccountBillingUsageStatsColumn {
-  AGENT_ID
-  AGENT_VERSION
-  GRAPH_DEPLOYMENT_TYPE
-  OPERATION_COUNT
-  OPERATION_COUNT_PROVIDED_EXPLICITLY
-  OPERATION_SUBTYPE
-  OPERATION_TYPE
-  ROUTER_FEATURES_ENABLED
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-}
-
-type AccountBillingUsageStatsDimensions {
-  agentId: String
-  agentVersion: String
-  graphDeploymentType: String
-  operationCountProvidedExplicitly: String
-  operationSubtype: String
-  operationType: String
-  routerFeaturesEnabled: String
-  schemaTag: String
-  serviceId: ID
-}
-
-"""
-Filter for data in AccountBillingUsageStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input AccountBillingUsageStatsFilter {
-  """
-  Selects rows whose agentId dimension equals the given value if not null. To query for the null value, use {in: {agentId: [null]}} instead.
-  """
-  agentId: String
-
-  """
-  Selects rows whose agentVersion dimension equals the given value if not null. To query for the null value, use {in: {agentVersion: [null]}} instead.
-  """
-  agentVersion: String
-  and: [AccountBillingUsageStatsFilter!]
-
-  """
-  Selects rows whose graphDeploymentType dimension equals the given value if not null. To query for the null value, use {in: {graphDeploymentType: [null]}} instead.
-  """
-  graphDeploymentType: String
-  in: AccountBillingUsageStatsFilterIn
-  not: AccountBillingUsageStatsFilter
-
-  """
-  Selects rows whose operationCountProvidedExplicitly dimension equals the given value if not null. To query for the null value, use {in: {operationCountProvidedExplicitly: [null]}} instead.
-  """
-  operationCountProvidedExplicitly: String
-
-  """
-  Selects rows whose operationSubtype dimension equals the given value if not null. To query for the null value, use {in: {operationSubtype: [null]}} instead.
-  """
-  operationSubtype: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [AccountBillingUsageStatsFilter!]
-
-  """
-  Selects rows whose routerFeaturesEnabled dimension equals the given value if not null. To query for the null value, use {in: {routerFeaturesEnabled: [null]}} instead.
-  """
-  routerFeaturesEnabled: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-}
-
-"""
-Filter for data in AccountBillingUsageStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input AccountBillingUsageStatsFilterIn {
-  """
-  Selects rows whose agentId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  agentId: [String]
-
-  """
-  Selects rows whose agentVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  agentVersion: [String]
-
-  """
-  Selects rows whose graphDeploymentType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  graphDeploymentType: [String]
-
-  """
-  Selects rows whose operationCountProvidedExplicitly dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationCountProvidedExplicitly: [String]
-
-  """
-  Selects rows whose operationSubtype dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationSubtype: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose routerFeaturesEnabled dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  routerFeaturesEnabled: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-}
-
-type AccountBillingUsageStatsMetrics {
-  operationCount: Long!
-}
-
-input AccountBillingUsageStatsOrderBySpec {
-  column: AccountBillingUsageStatsColumn!
-  direction: Ordering!
-}
-
-type AccountBillingUsageStatsRecord {
-  """Dimensions of AccountBillingUsageStats that can be grouped by."""
-  groupBy: AccountBillingUsageStatsDimensions!
-
-  """Metrics of AccountBillingUsageStats that can be aggregated over."""
-  metrics: AccountBillingUsageStatsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-type AccountCapabilities {
-  asList: [AccountCapability!]!
-  clientVersions: Boolean!
-  clients: Boolean!
-  cloudGraphs: Boolean!
-  connectorsInRouter: Boolean!
-  contracts: Boolean!
-  customSessionLengths: Boolean!
-  datadog: Boolean!
-  federation: Boolean!
-  launches: Boolean!
-  linting: Boolean!
-  metrics: Boolean!
-  notifications: Boolean!
-  operationRegistry: Boolean!
-  persistedQueries: Boolean!
-  proposals: Boolean!
-  schemaValidation: Boolean!
-  sso: Boolean!
-  traces: Boolean!
-  userRoles: Boolean!
-  webhooks: Boolean!
-}
-
-type AccountCapability {
-  description: String
-  label: String!
-  value: Boolean!
-}
-
-"""Columns of AccountCardinalityStats."""
-enum AccountCardinalityStatsColumn {
-  CLIENT_NAME_CARDINALITY
-  CLIENT_VERSION_CARDINALITY
-  OPERATION_SHAPE_CARDINALITY
-  SCHEMA_COORDINATE_CARDINALITY
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-}
-
-type AccountCardinalityStatsDimensions {
-  schemaTag: String
-  serviceId: ID
-}
-
-"""
-Filter for data in AccountCardinalityStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input AccountCardinalityStatsFilter {
-  and: [AccountCardinalityStatsFilter!]
-  in: AccountCardinalityStatsFilterIn
-  not: AccountCardinalityStatsFilter
-  or: [AccountCardinalityStatsFilter!]
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-}
-
-"""
-Filter for data in AccountCardinalityStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input AccountCardinalityStatsFilterIn {
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-}
-
-type AccountCardinalityStatsMetrics {
-  clientNameCardinality: Float!
-  clientVersionCardinality: Float!
-  operationShapeCardinality: Float!
-  schemaCoordinateCardinality: Float!
-}
-
-input AccountCardinalityStatsOrderBySpec {
-  column: AccountCardinalityStatsColumn!
-  direction: Ordering!
-}
-
-type AccountCardinalityStatsRecord {
-  """Dimensions of AccountCardinalityStats that can be grouped by."""
-  groupBy: AccountCardinalityStatsDimensions!
-
-  """Metrics of AccountCardinalityStats that can be aggregated over."""
-  metrics: AccountCardinalityStatsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-type AccountChecksStatsMetrics {
-  totalFailedChecks: Long!
-  totalSuccessfulChecks: Long!
-}
-
-type AccountChecksStatsRecord {
-  id: ID!
-  timestamp: Timestamp!
-  metrics: AccountChecksStatsMetrics!
-}
-
-"""Columns of AccountCoordinateUsage."""
-enum AccountCoordinateUsageColumn {
-  CLIENT_NAME
-  CLIENT_VERSION
-  ESTIMATED_EXECUTION_COUNT
-  EXECUTION_COUNT
-  KIND
-  NAMED_ATTRIBUTE
-  NAMED_TYPE
-  OPERATION_SUBTYPE
-  OPERATION_TYPE
-  QUERY_ID
-  QUERY_NAME
-  REFERENCING_OPERATION_COUNT
-  REQUEST_COUNT_NULL
-  REQUEST_COUNT_UNDEFINED
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-}
-
-type AccountCoordinateUsageDimensions {
-  clientName: String
-  clientVersion: String
-  kind: String
-  namedAttribute: String
-  namedType: String
-  operationSubtype: String
-  operationType: String
-  queryId: String
-  queryName: String
-  schemaTag: String
-  serviceId: ID
-}
-
-"""
-Filter for data in AccountCoordinateUsage. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input AccountCoordinateUsageFilter {
-  and: [AccountCoordinateUsageFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-  in: AccountCoordinateUsageFilterIn
-
-  """
-  Selects rows whose kind dimension equals the given value if not null. To query for the null value, use {in: {kind: [null]}} instead.
-  """
-  kind: String
-
-  """
-  Selects rows whose namedAttribute dimension equals the given value if not null. To query for the null value, use {in: {namedAttribute: [null]}} instead.
-  """
-  namedAttribute: String
-
-  """
-  Selects rows whose namedType dimension equals the given value if not null. To query for the null value, use {in: {namedType: [null]}} instead.
-  """
-  namedType: String
-  not: AccountCoordinateUsageFilter
-
-  """
-  Selects rows whose operationSubtype dimension equals the given value if not null. To query for the null value, use {in: {operationSubtype: [null]}} instead.
-  """
-  operationSubtype: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [AccountCoordinateUsageFilter!]
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: String
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-}
-
-"""
-Filter for data in AccountCoordinateUsage. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input AccountCoordinateUsageFilterIn {
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose kind dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  kind: [String]
-
-  """
-  Selects rows whose namedAttribute dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  namedAttribute: [String]
-
-  """
-  Selects rows whose namedType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  namedType: [String]
-
-  """
-  Selects rows whose operationSubtype dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationSubtype: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [String]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-}
-
-type AccountCoordinateUsageMetrics {
-  estimatedExecutionCount: Long!
-  executionCount: Long!
-  referencingOperationCount: Long!
-  requestCountNull: Long!
-  requestCountUndefined: Long!
-}
-
-input AccountCoordinateUsageOrderBySpec {
-  column: AccountCoordinateUsageColumn!
-  direction: Ordering!
-}
-
-type AccountCoordinateUsageRecord {
-  """Dimensions of AccountCoordinateUsage that can be grouped by."""
-  groupBy: AccountCoordinateUsageDimensions!
-
-  """Metrics of AccountCoordinateUsage that can be aggregated over."""
-  metrics: AccountCoordinateUsageMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of AccountEdgeServerInfos."""
-enum AccountEdgeServerInfosColumn {
-  BOOT_ID
-  EXECUTABLE_SCHEMA_ID
-  LIBRARY_VERSION
-  PLATFORM
-  RUNTIME_VERSION
-  SCHEMA_TAG
-  SERVER_ID
-  SERVICE_ID
-  TIMESTAMP
-  USER_VERSION
-}
-
-type AccountEdgeServerInfosDimensions {
-  bootId: ID
-  executableSchemaId: ID
-  libraryVersion: String
-  platform: String
-  runtimeVersion: String
-  schemaTag: String
-  serverId: ID
-  serviceId: ID
-  userVersion: String
-}
-
-"""
-Filter for data in AccountEdgeServerInfos. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input AccountEdgeServerInfosFilter {
-  and: [AccountEdgeServerInfosFilter!]
-
-  """
-  Selects rows whose bootId dimension equals the given value if not null. To query for the null value, use {in: {bootId: [null]}} instead.
-  """
-  bootId: ID
-
-  """
-  Selects rows whose executableSchemaId dimension equals the given value if not null. To query for the null value, use {in: {executableSchemaId: [null]}} instead.
-  """
-  executableSchemaId: ID
-  in: AccountEdgeServerInfosFilterIn
-
-  """
-  Selects rows whose libraryVersion dimension equals the given value if not null. To query for the null value, use {in: {libraryVersion: [null]}} instead.
-  """
-  libraryVersion: String
-  not: AccountEdgeServerInfosFilter
-  or: [AccountEdgeServerInfosFilter!]
-
-  """
-  Selects rows whose platform dimension equals the given value if not null. To query for the null value, use {in: {platform: [null]}} instead.
-  """
-  platform: String
-
-  """
-  Selects rows whose runtimeVersion dimension equals the given value if not null. To query for the null value, use {in: {runtimeVersion: [null]}} instead.
-  """
-  runtimeVersion: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serverId dimension equals the given value if not null. To query for the null value, use {in: {serverId: [null]}} instead.
-  """
-  serverId: ID
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-
-  """
-  Selects rows whose userVersion dimension equals the given value if not null. To query for the null value, use {in: {userVersion: [null]}} instead.
-  """
-  userVersion: String
-}
-
-"""
-Filter for data in AccountEdgeServerInfos. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input AccountEdgeServerInfosFilterIn {
-  """
-  Selects rows whose bootId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  bootId: [ID]
-
-  """
-  Selects rows whose executableSchemaId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  executableSchemaId: [ID]
-
-  """
-  Selects rows whose libraryVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  libraryVersion: [String]
-
-  """
-  Selects rows whose platform dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  platform: [String]
-
-  """
-  Selects rows whose runtimeVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  runtimeVersion: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serverId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serverId: [ID]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-
-  """
-  Selects rows whose userVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  userVersion: [String]
-}
-
-input AccountEdgeServerInfosOrderBySpec {
-  column: AccountEdgeServerInfosColumn!
-  direction: Ordering!
-}
-
-type AccountEdgeServerInfosRecord {
-  """Dimensions of AccountEdgeServerInfos that can be grouped by."""
-  groupBy: AccountEdgeServerInfosDimensions!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of AccountErrorStats."""
-enum AccountErrorStatsColumn {
-  CLIENT_NAME
-  CLIENT_VERSION
-  ERRORS_COUNT
-  PATH
-  QUERY_ID
-  QUERY_NAME
-  REQUESTS_WITH_ERRORS_COUNT
-  SCHEMA_HASH
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-}
-
-type AccountErrorStatsDimensions {
-  clientName: String
-  clientVersion: String
-  path: String
-  queryId: ID
-  queryName: String
-  schemaHash: String
-  schemaTag: String
-  serviceId: ID
-}
-
-"""
-Filter for data in AccountErrorStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input AccountErrorStatsFilter {
-  and: [AccountErrorStatsFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-  in: AccountErrorStatsFilterIn
-  not: AccountErrorStatsFilter
-  or: [AccountErrorStatsFilter!]
-
-  """
-  Selects rows whose path dimension equals the given value if not null. To query for the null value, use {in: {path: [null]}} instead.
-  """
-  path: String
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: ID
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead.
-  """
-  schemaHash: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-}
-
-"""
-Filter for data in AccountErrorStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input AccountErrorStatsFilterIn {
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  path: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [ID]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaHash: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-}
-
-type AccountErrorStatsMetrics {
-  errorsCount: Long!
-  requestsWithErrorsCount: Long!
-}
-
-input AccountErrorStatsOrderBySpec {
-  column: AccountErrorStatsColumn!
-  direction: Ordering!
-}
-
-type AccountErrorStatsRecord {
-  """Dimensions of AccountErrorStats that can be grouped by."""
-  groupBy: AccountErrorStatsDimensions!
-
-  """Metrics of AccountErrorStats that can be aggregated over."""
-  metrics: AccountErrorStatsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of AccountFederatedErrorStats."""
-enum AccountFederatedErrorStatsColumn {
-  AGENT_VERSION
-  CLIENT_NAME
-  CLIENT_VERSION
-  ERROR_CODE
-  ERROR_COUNT
-  ERROR_PATH
-  ERROR_SERVICE
-  OPERATION_ID
-  OPERATION_NAME
-  OPERATION_TYPE
-  SCHEMA_TAG
-  SERVICE_ID
-  SEVERITY
-  TIMESTAMP
-}
-
-type AccountFederatedErrorStatsDimensions {
-  agentVersion: String
-  clientName: String
-  clientVersion: String
-  errorCode: String
-  errorPath: String
-  errorService: String
-  operationId: String
-  operationName: String
-  operationType: String
-  schemaTag: String
-  serviceId: ID
-  severity: String
-}
-
-"""
-Filter for data in AccountFederatedErrorStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input AccountFederatedErrorStatsFilter {
-  """
-  Selects rows whose agentVersion dimension equals the given value if not null. To query for the null value, use {in: {agentVersion: [null]}} instead.
-  """
-  agentVersion: String
-  and: [AccountFederatedErrorStatsFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-
-  """
-  Selects rows whose errorCode dimension equals the given value if not null. To query for the null value, use {in: {errorCode: [null]}} instead.
-  """
-  errorCode: String
-
-  """
-  Selects rows whose errorPath dimension equals the given value if not null. To query for the null value, use {in: {errorPath: [null]}} instead.
-  """
-  errorPath: String
-
-  """
-  Selects rows whose errorService dimension equals the given value if not null. To query for the null value, use {in: {errorService: [null]}} instead.
-  """
-  errorService: String
-  in: AccountFederatedErrorStatsFilterIn
-  not: AccountFederatedErrorStatsFilter
-
-  """
-  Selects rows whose operationId dimension equals the given value if not null. To query for the null value, use {in: {operationId: [null]}} instead.
-  """
-  operationId: String
-
-  """
-  Selects rows whose operationName dimension equals the given value if not null. To query for the null value, use {in: {operationName: [null]}} instead.
-  """
-  operationName: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [AccountFederatedErrorStatsFilter!]
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-
-  """
-  Selects rows whose severity dimension equals the given value if not null. To query for the null value, use {in: {severity: [null]}} instead.
-  """
-  severity: String
-}
-
-"""
-Filter for data in AccountFederatedErrorStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input AccountFederatedErrorStatsFilterIn {
-  """
-  Selects rows whose agentVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  agentVersion: [String]
-
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose errorCode dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  errorCode: [String]
-
-  """
-  Selects rows whose errorPath dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  errorPath: [String]
-
-  """
-  Selects rows whose errorService dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  errorService: [String]
-
-  """
-  Selects rows whose operationId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationId: [String]
-
-  """
-  Selects rows whose operationName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationName: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-
-  """
-  Selects rows whose severity dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  severity: [String]
-}
-
-type AccountFederatedErrorStatsMetrics {
-  errorCount: Long!
-}
-
-input AccountFederatedErrorStatsOrderBySpec {
-  column: AccountFederatedErrorStatsColumn!
-  direction: Ordering!
-}
-
-type AccountFederatedErrorStatsRecord {
-  """Dimensions of AccountFederatedErrorStats that can be grouped by."""
-  groupBy: AccountFederatedErrorStatsDimensions!
-
-  """Metrics of AccountFederatedErrorStats that can be aggregated over."""
-  metrics: AccountFederatedErrorStatsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of AccountFieldExecutions."""
-enum AccountFieldExecutionsColumn {
-  ERRORS_COUNT
-  ESTIMATED_EXECUTION_COUNT
-  FIELD_NAME
-  OBSERVED_EXECUTION_COUNT
-  PARENT_TYPE
-  REFERENCING_OPERATION_COUNT
-  REQUESTS_WITH_ERRORS_COUNT
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-}
-
-type AccountFieldExecutionsDimensions {
-  fieldName: String
-  parentType: String
-  schemaTag: String
-  serviceId: ID
-}
-
-"""
-Filter for data in AccountFieldExecutions. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input AccountFieldExecutionsFilter {
-  and: [AccountFieldExecutionsFilter!]
-
-  """
-  Selects rows whose fieldName dimension equals the given value if not null. To query for the null value, use {in: {fieldName: [null]}} instead.
-  """
-  fieldName: String
-  in: AccountFieldExecutionsFilterIn
-  not: AccountFieldExecutionsFilter
-  or: [AccountFieldExecutionsFilter!]
-
-  """
-  Selects rows whose parentType dimension equals the given value if not null. To query for the null value, use {in: {parentType: [null]}} instead.
-  """
-  parentType: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-}
-
-"""
-Filter for data in AccountFieldExecutions. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input AccountFieldExecutionsFilterIn {
-  """
-  Selects rows whose fieldName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  fieldName: [String]
-
-  """
-  Selects rows whose parentType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  parentType: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-}
-
-type AccountFieldExecutionsMetrics {
-  errorsCount: Long!
-  estimatedExecutionCount: Long!
-  observedExecutionCount: Long!
-  referencingOperationCount: Long!
-  requestsWithErrorsCount: Long!
-}
-
-input AccountFieldExecutionsOrderBySpec {
-  column: AccountFieldExecutionsColumn!
-  direction: Ordering!
-}
-
-type AccountFieldExecutionsRecord {
-  """Dimensions of AccountFieldExecutions that can be grouped by."""
-  groupBy: AccountFieldExecutionsDimensions!
-
-  """Metrics of AccountFieldExecutions that can be aggregated over."""
-  metrics: AccountFieldExecutionsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of AccountFieldLatencies."""
-enum AccountFieldLatenciesColumn {
-  FIELD_HISTOGRAM
-  FIELD_NAME
-  PARENT_TYPE
-  SCHEMA_HASH
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-}
-
-type AccountFieldLatenciesDimensions {
-  field: String
-  fieldName: String
-  parentType: String
-  schemaHash: String
-  schemaTag: String
-  serviceId: ID
-}
-
-"""
-Filter for data in AccountFieldLatencies. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input AccountFieldLatenciesFilter {
-  and: [AccountFieldLatenciesFilter!]
-
-  """
-  Selects rows whose fieldName dimension equals the given value if not null. To query for the null value, use {in: {fieldName: [null]}} instead.
-  """
-  fieldName: String
-  in: AccountFieldLatenciesFilterIn
-  not: AccountFieldLatenciesFilter
-  or: [AccountFieldLatenciesFilter!]
-
-  """
-  Selects rows whose parentType dimension equals the given value if not null. To query for the null value, use {in: {parentType: [null]}} instead.
-  """
-  parentType: String
-
-  """
-  Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead.
-  """
-  schemaHash: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-}
-
-"""
-Filter for data in AccountFieldLatencies. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input AccountFieldLatenciesFilterIn {
-  """
-  Selects rows whose fieldName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  fieldName: [String]
-
-  """
-  Selects rows whose parentType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  parentType: [String]
-
-  """
-  Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaHash: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-}
-
-type AccountFieldLatenciesMetrics {
-  fieldHistogram: DurationHistogram!
-}
-
-input AccountFieldLatenciesOrderBySpec {
-  column: AccountFieldLatenciesColumn!
-  direction: Ordering!
-}
-
-type AccountFieldLatenciesRecord {
-  """Dimensions of AccountFieldLatencies that can be grouped by."""
-  groupBy: AccountFieldLatenciesDimensions!
-
-  """Metrics of AccountFieldLatencies that can be aggregated over."""
-  metrics: AccountFieldLatenciesMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of AccountFieldUsage."""
-enum AccountFieldUsageColumn {
-  CLIENT_NAME
-  CLIENT_VERSION
-  ESTIMATED_EXECUTION_COUNT
-  EXECUTION_COUNT
-  FIELD_NAME
-  OPERATION_SUBTYPE
-  OPERATION_TYPE
-  PARENT_TYPE
-  QUERY_ID
-  QUERY_NAME
-  REFERENCING_OPERATION_COUNT
-  SCHEMA_HASH
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-}
-
-type AccountFieldUsageDimensions {
-  clientName: String
-  clientVersion: String
-  fieldName: String
-  operationSubtype: String
-  operationType: String
-  parentType: String
-  queryId: ID
-  queryName: String
-  schemaHash: String
-  schemaTag: String
-  serviceId: ID
-}
-
-"""
-Filter for data in AccountFieldUsage. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input AccountFieldUsageFilter {
-  and: [AccountFieldUsageFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-
-  """
-  Selects rows whose fieldName dimension equals the given value if not null. To query for the null value, use {in: {fieldName: [null]}} instead.
-  """
-  fieldName: String
-  in: AccountFieldUsageFilterIn
-  not: AccountFieldUsageFilter
-
-  """
-  Selects rows whose operationSubtype dimension equals the given value if not null. To query for the null value, use {in: {operationSubtype: [null]}} instead.
-  """
-  operationSubtype: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [AccountFieldUsageFilter!]
-
-  """
-  Selects rows whose parentType dimension equals the given value if not null. To query for the null value, use {in: {parentType: [null]}} instead.
-  """
-  parentType: String
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: ID
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead.
-  """
-  schemaHash: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-}
-
-"""
-Filter for data in AccountFieldUsage. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input AccountFieldUsageFilterIn {
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose fieldName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  fieldName: [String]
-
-  """
-  Selects rows whose operationSubtype dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationSubtype: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose parentType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  parentType: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [ID]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaHash: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-}
-
-type AccountFieldUsageMetrics {
-  estimatedExecutionCount: Long!
-  executionCount: Long!
-  referencingOperationCount: Long!
-}
-
-input AccountFieldUsageOrderBySpec {
-  column: AccountFieldUsageColumn!
-  direction: Ordering!
-}
-
-type AccountFieldUsageRecord {
-  """Dimensions of AccountFieldUsage that can be grouped by."""
-  groupBy: AccountFieldUsageDimensions!
-
-  """Metrics of AccountFieldUsage that can be aggregated over."""
-  metrics: AccountFieldUsageMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""A list of graphs that belong to an account."""
-type AccountGraphConnection {
-  """A list of edges from the account to its graphs."""
-  edges: [AccountGraphEdge!]
-
-  """A list of graphs attached to the account."""
-  nodes: [Service!]
-
-  """Information to aid in pagination."""
-  pageInfo: PageInfo!
-}
-
-"""An edge between an account and a graph."""
-type AccountGraphEdge {
-  """A cursor for use in pagination."""
-  cursor: String!
-
-  """A graph attached to the account."""
-  node: Service
-}
-
-"""Columns of AccountGraphosCloudMetrics."""
-enum AccountGraphosCloudMetricsColumn {
-  AGENT_VERSION
-  CLOUD_PROVIDER
-  RESPONSE_SIZE
-  RESPONSE_SIZE_THROTTLED
-  ROUTER_ID
-  ROUTER_OPERATIONS
-  ROUTER_OPERATIONS_THROTTLED
-  SCHEMA_TAG
-  SERVICE_ID
-  SUBGRAPH_FETCHES
-  SUBGRAPH_FETCHES_THROTTLED
-  TIER
-  TIMESTAMP
-}
-
-type AccountGraphosCloudMetricsDimensions {
-  agentVersion: String
-  cloudProvider: String
-  routerId: String
-  schemaTag: String
-  serviceId: ID
-  tier: String
-}
-
-"""
-Filter for data in AccountGraphosCloudMetrics. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input AccountGraphosCloudMetricsFilter {
-  """
-  Selects rows whose agentVersion dimension equals the given value if not null. To query for the null value, use {in: {agentVersion: [null]}} instead.
-  """
-  agentVersion: String
-  and: [AccountGraphosCloudMetricsFilter!]
-
-  """
-  Selects rows whose cloudProvider dimension equals the given value if not null. To query for the null value, use {in: {cloudProvider: [null]}} instead.
-  """
-  cloudProvider: String
-  in: AccountGraphosCloudMetricsFilterIn
-  not: AccountGraphosCloudMetricsFilter
-  or: [AccountGraphosCloudMetricsFilter!]
-
-  """
-  Selects rows whose routerId dimension equals the given value if not null. To query for the null value, use {in: {routerId: [null]}} instead.
-  """
-  routerId: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-
-  """
-  Selects rows whose tier dimension equals the given value if not null. To query for the null value, use {in: {tier: [null]}} instead.
-  """
-  tier: String
-}
-
-"""
-Filter for data in AccountGraphosCloudMetrics. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input AccountGraphosCloudMetricsFilterIn {
-  """
-  Selects rows whose agentVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  agentVersion: [String]
-
-  """
-  Selects rows whose cloudProvider dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  cloudProvider: [String]
-
-  """
-  Selects rows whose routerId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  routerId: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-
-  """
-  Selects rows whose tier dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  tier: [String]
-}
-
-type AccountGraphosCloudMetricsMetrics {
-  responseSize: Long!
-  responseSizeThrottled: Long!
-  routerOperations: Long!
-  routerOperationsThrottled: Long!
-  subgraphFetches: Long!
-  subgraphFetchesThrottled: Long!
-}
-
-input AccountGraphosCloudMetricsOrderBySpec {
-  column: AccountGraphosCloudMetricsColumn!
-  direction: Ordering!
-}
-
-type AccountGraphosCloudMetricsRecord {
-  """Dimensions of AccountGraphosCloudMetrics that can be grouped by."""
-  groupBy: AccountGraphosCloudMetricsDimensions!
-
-  """Metrics of AccountGraphosCloudMetrics that can be aggregated over."""
-  metrics: AccountGraphosCloudMetricsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""A list of all variants from all graphs attached to the account."""
-type AccountGraphVariantConnection {
-  """A list of edges from the account to its variants."""
-  edges: [AccountGraphVariantEdge!]
-
-  """A list of all variants from all graphs attached to the account."""
-  nodes: [GraphVariant!]
-
-  """Information to aid in pagination."""
-  pageInfo: PageInfo!
-}
-
-"""An edge between an account and a graph variant."""
-type AccountGraphVariantEdge {
-  """A cursor for use in pagination."""
-  cursor: String!
-
-  """A variant from a graph attached to the account."""
-  node: GraphVariant
+  services(includeDeleted: Boolean): [Graph!]! @deprecated(reason: "Use graphs field instead")
 }
 
 """An invitation for a user to join an organization."""
@@ -1679,43 +53,10 @@ type AccountInvitation {
   role: UserPermission!
 }
 
-type AccountLimit {
-  description: String
-  label: String!
-  value: Long
-}
-
-type AccountLimits {
-  asList: [AccountLimit!]!
-  maxAuditInDays: Int
-  maxGraphOSSeats: Long
-  maxRangeInDays: Int
-  maxRangeInDaysForChecks: Int
-  maxRequestsPerMonth: Long
-}
-
-type AccountLockDetails {
-  actor: String
-  reason: String
-  timestamp: Timestamp
-  type: AccountLockType
-}
-
-enum AccountLockType {
-  AUTOMATED_TRIAL_END
-  MANUAL
-}
-
 """The membership association between a user and an organization."""
 type AccountMembership {
-  account: Account!
-
   """The timestamp when the user was added to the organization."""
   createdAt: Timestamp!
-
-  """If this membership is a free seat (based on role)"""
-  free: Boolean
-  permission: UserPermission! @deprecated(reason: "Use role instead.")
 
   """The user's role within the organization'."""
   role: UserPermission!
@@ -1724,1134 +65,19 @@ type AccountMembership {
   user: User!
 }
 
-type AccountMutation {
-  """
-  Cancel account subscriptions, subscriptions will remain active until the end of the paid period.
-  Currently only works for Recurly subscriptions on team plans.
-  """
-  cancelSubscriptions: Account
-  currentSubscription: BillingSubscriptionMutation
-  ensureRecurlyAccountExists: RecurlyAccountDetails
-
-  """
-  If the org is on an enterprise trial, extend the trial by the given number of days, or the default number of days for that plan if numDays is not set.
-  """
-  extendTrial(numDays: Int): Account
-
-  """Get reference to the account ID"""
-  internalID: String
-
-  """See Account type. Field is needed by extending subgraph."""
-  name: String
-
-  """
-  Reactivate a canceled current subscription.
-  Currently only works for Recurly subscriptions on team plans.
-  """
-  reactivateCurrentSubscription: Account
-
-  """See Account type. Field is needed by extending subgraph."""
-  seats: Seats
-
-  """
-  Apollo admins only: set the billing plan to an arbitrary plan effective immediately terminating any current paid plan.
-  """
-  setPlan(id: ID!): Void
-
-  """
-  Apollo admins only: Terminate the ongoing subscription in the account as soon as possible, without refunds.
-  """
-  terminateSubscription(providerId: ID!): Account
-
-  """
-  Apollo admins only: terminate any ongoing subscriptions in the account, without refunds
-  Currently only works for Recurly subscriptions.
-  """
-  terminateSubscriptions: Account
-
-  """Update the billing address for a Recurly token"""
-  updateBillingAddress(billingAddress: BillingAddressInput!): Account
-
-  """Update the billing information from a Recurly token"""
-  updateBillingInfo(token: String!): Void
-
-  """Create a CloudOnboarding for this account"""
-  createCloudOnboarding(input: CloudOnboardingInput!): CreateOnboardingResult!
-
-  """
-  Mutations for interacting with an Apollo account's private subgraphs on GraphOS
-  """
-  privateSubgraph: PrivateSubgraphMutation!
-  addOidcConfigurationToBaseConnection(config: OidcConfigurationInput!, connectionId: ID!, enabled: Boolean): OidcConnection
-  addSamlMetadataToBaseConnection(connectionId: ID!, enabled: Boolean, metadata: SamlConfigurationInput!): SamlConnection
-  addSamlVerificationCert(pem: String!): Void @deprecated(reason: "Use saml { addVerificationCert } instead")
-  createBaseSsoConnection(
-    domains: [String!]!
-    idpId: String
-
-    """
-    Whether to use the org's existing legacy 'idpid' field for the connection. If true, the existing value is used instead of the one provided in the input. Defaults to false.
-    """
-    useLegacyIdpId: Boolean
-  ): BaseConnection
-  createOidcConfigurationUrl(id: ID!): String
-  createStaticInvitation(role: UserPermission!): OrganizationInviteLink
-  finalizeSsoReconfiguration(
-    deleteExistingWebApiKeys: Boolean = false
-    newConnectionId: ID!
-
-    """
-    Whether to verify that at least one user has successfully logged in with the connection before finalizing. Defaults to true.
-    """
-    verifySsoSessionExists: Boolean = true
-  ): Void
-  finalizeSsoV2Migration(
-    deleteExistingWebApiKeys: Boolean = false
-    deleteNonSsoMemberships: Boolean = false
-
-    """
-    Whether to verify that at least one user has successfully logged in with the connection before finalizing. Defaults to true.
-    """
-    verifySsoSessionExists: Boolean = true
-  ): Void
-
-  """Hard delete an account and all associated services"""
-  hardDelete: Void
-
+type OrganizationMutation {
   """Send an invitation to join the organization by E-mail"""
   invite(email: String!, role: UserPermission): AccountInvitation
-  reAddSsoUser(role: UserPermission!, userId: ID!): Void
-
-  """Delete an invitation"""
-  removeInvitation(id: ID): Void
-
-  """Remove a member of the account"""
-  removeMember(id: ID!): Account
-  replaceSsoConnectionDomains(domains: [String!]!, id: ID!): SsoConnection
-
-  """Send a new E-mail for an existing invitation"""
-  resendInvitation(id: ID): AccountInvitation
-  revokeStaticInvitation(token: String!): OrganizationInviteLink
-
-  """Revokes a user's sessions within the organization"""
-  revokeUserSessions(userId: ID!): Void
-  saml: SamlConnectionMutation
 
   """Create or update a custom session length for an org"""
   setCustomSessionLength(sessionDurationInSeconds: Int!): Int!
-  trackTermsAccepted(at: Timestamp!): Void
-  updateCompanyUrl(companyUrl: String): Account
-
-  """Update the account ID"""
-  updateID(id: ID!): Account
-  updateLegacySsoProvider(ssoProvider: OrganizationSSOProvider!): Void
-
-  """Update the company name"""
-  updateName(name: String!): Void
-
-  """
-  Updates the OIDC metadata for an existing SSO connection. Connection must be disabled prior to the update.
-  """
-  updateOidcConnectionMetadata(connectionId: ID!, metadata: OidcConfigurationUpdateInput!): OidcConnection
-
-  """Updates the role assigned to new SSO users."""
-  updateSSODefaultRole(role: UserPermission!): OrganizationSSO
-
-  """
-  Updates the SAML metadata for an existing SSO connection. Connection must be disabled prior to the update.
-  """
-  updateSamlConnectionMetadata(connectionId: ID!, metadata: SamlConfigurationInput!): SamlConnection
-
-  """Update a user's role within an organization"""
-  updateUserPermission(permission: UserPermission!, userID: ID!): User @deprecated(reason: "Use updateUserRole instead.")
 
   """Update a user's role within an organization"""
   updateUserRole(role: UserPermission!, userID: ID!): User
-  auditExport(id: String!): AuditLogExportMutation
   createGraph(graphType: GraphType!, hiddenFromUninvitedNonAdmin: Boolean!, id: ID!, title: String!, variantCreationConfig: VariantCreationConfig): GraphCreationResult!
 
-  """
-  Delete the account's avatar. Requires Account.canUpdateAvatar to be true.
-  """
-  deleteAvatar: AvatarDeleteError
-
-  """
-  Lock an account, which limits the functionality available with regard to its graphs.
-  """
-  lock(reason: String, type: AccountLockType): Account
-
   """Trigger a request for an audit export"""
-  requestAuditExport(actors: [ActorInput!], from: Timestamp!, graphIds: [String!], to: Timestamp!): Account
-
-  """
-  This is called by the form shown to users after they cancel their team subscription.
-  """
-  submitTeamCancellationFeedback(feedback: String!): Void
-
-  """Unlock a locked account."""
-  unlock: Account
-
-  """Set the E-mail address of the account, used notably for billing"""
-  updateEmail(email: String!): Void
-}
-
-"""Columns of AccountOperationCheckStats."""
-enum AccountOperationCheckStatsColumn {
-  CACHED_REQUESTS_COUNT
-  CLIENT_NAME
-  CLIENT_VERSION
-  OPERATION_SUBTYPE
-  OPERATION_TYPE
-  QUERY_ID
-  QUERY_NAME
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-  UNCACHED_REQUESTS_COUNT
-}
-
-type AccountOperationCheckStatsDimensions {
-  clientName: String
-  clientVersion: String
-  operationSubtype: String
-  operationType: String
-  queryId: ID
-  queryName: String
-  schemaTag: String
-  serviceId: ID
-}
-
-"""
-Filter for data in AccountOperationCheckStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input AccountOperationCheckStatsFilter {
-  and: [AccountOperationCheckStatsFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-  in: AccountOperationCheckStatsFilterIn
-  not: AccountOperationCheckStatsFilter
-
-  """
-  Selects rows whose operationSubtype dimension equals the given value if not null. To query for the null value, use {in: {operationSubtype: [null]}} instead.
-  """
-  operationSubtype: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [AccountOperationCheckStatsFilter!]
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: ID
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-}
-
-"""
-Filter for data in AccountOperationCheckStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input AccountOperationCheckStatsFilterIn {
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose operationSubtype dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationSubtype: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [ID]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-}
-
-type AccountOperationCheckStatsMetrics {
-  cachedRequestsCount: Long!
-  uncachedRequestsCount: Long!
-}
-
-input AccountOperationCheckStatsOrderBySpec {
-  column: AccountOperationCheckStatsColumn!
-  direction: Ordering!
-}
-
-type AccountOperationCheckStatsRecord {
-  """Dimensions of AccountOperationCheckStats that can be grouped by."""
-  groupBy: AccountOperationCheckStatsDimensions!
-
-  """Metrics of AccountOperationCheckStats that can be aggregated over."""
-  metrics: AccountOperationCheckStatsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-type AccountOperationUsage {
-  selfHosted: BillableMetricStats!
-  serverless: BillableMetricStats!
-  totalOperations: BillableMetricStats!
-}
-
-input AccountOperationUsageWindowInput {
-  from: Date!
-  limit: Int! = 100
-  to: Date!
-  windowSize: BillingUsageStatsWindowSize! = DAY
-}
-
-type AccountPublishesStatsMetrics {
-  totalPublishes: Long!
-}
-
-type AccountPublishesStatsRecord {
-  id: ID!
-  timestamp: Timestamp!
-  metrics: AccountPublishesStatsMetrics!
-}
-
-"""Columns of AccountQueryStats."""
-enum AccountQueryStatsColumn {
-  CACHED_HISTOGRAM
-  CACHED_REQUESTS_COUNT
-  CACHE_TTL_HISTOGRAM
-  CLIENT_NAME
-  CLIENT_VERSION
-  FORBIDDEN_OPERATION_COUNT
-  FROM_ENGINEPROXY
-  OPERATION_SUBTYPE
-  OPERATION_TYPE
-  PERSISTED_QUERY_ID
-  QUERY_ID
-  QUERY_NAME
-  REGISTERED_OPERATION_COUNT
-  REQUESTS_WITH_ERRORS_COUNT
-  SCHEMA_HASH
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-  UNCACHED_HISTOGRAM
-  UNCACHED_REQUESTS_COUNT
-}
-
-type AccountQueryStatsDimensions {
-  clientName: String
-  clientVersion: String
-  fromEngineproxy: String
-  operationSubtype: String
-  operationType: String
-  persistedQueryId: String
-  queryId: ID
-  queryName: String
-  querySignature: String
-  querySignatureLength: Int
-  schemaHash: String
-  schemaTag: String
-  serviceId: ID
-}
-
-"""
-Filter for data in AccountQueryStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input AccountQueryStatsFilter {
-  and: [AccountQueryStatsFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-
-  """
-  Selects rows whose fromEngineproxy dimension equals the given value if not null. To query for the null value, use {in: {fromEngineproxy: [null]}} instead.
-  """
-  fromEngineproxy: String
-  in: AccountQueryStatsFilterIn
-  not: AccountQueryStatsFilter
-
-  """
-  Selects rows whose operationSubtype dimension equals the given value if not null. To query for the null value, use {in: {operationSubtype: [null]}} instead.
-  """
-  operationSubtype: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [AccountQueryStatsFilter!]
-
-  """
-  Selects rows whose persistedQueryId dimension equals the given value if not null. To query for the null value, use {in: {persistedQueryId: [null]}} instead.
-  """
-  persistedQueryId: String
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: ID
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead.
-  """
-  schemaHash: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-}
-
-"""
-Filter for data in AccountQueryStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input AccountQueryStatsFilterIn {
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose fromEngineproxy dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  fromEngineproxy: [String]
-
-  """
-  Selects rows whose operationSubtype dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationSubtype: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose persistedQueryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  persistedQueryId: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [ID]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaHash: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-}
-
-type AccountQueryStatsMetrics {
-  cacheTtlHistogram: DurationHistogram!
-  cachedHistogram: DurationHistogram!
-  cachedRequestsCount: Long!
-  forbiddenOperationCount: Long!
-  registeredOperationCount: Long!
-  requestsWithErrorsCount: Long!
-  totalLatencyHistogram: DurationHistogram!
-  totalRequestCount: Long!
-  uncachedHistogram: DurationHistogram!
-  uncachedRequestsCount: Long!
-}
-
-input AccountQueryStatsOrderBySpec {
-  column: AccountQueryStatsColumn!
-  direction: Ordering!
-}
-
-type AccountQueryStatsRecord {
-  """Dimensions of AccountQueryStats that can be grouped by."""
-  groupBy: AccountQueryStatsDimensions!
-
-  """Metrics of AccountQueryStats that can be aggregated over."""
-  metrics: AccountQueryStatsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-type AccountRoles {
-  canAudit: Boolean!
-  canCreateService: Boolean!
-  canDelete: Boolean!
-  canManageMembers: Boolean!
-  canManageSessions: Boolean!
-  canProvisionSSO: Boolean!
-  canQuery: Boolean!
-  canQueryAudit: Boolean!
-  canQueryBillingInfo: Boolean!
-  canQueryMembers: Boolean!
-  canQueryStats: Boolean!
-  canReadTickets: Boolean!
-  canRemoveMembers: Boolean!
-  canSetConstrainedPlan: Boolean!
-  canUpdateBillingInfo: Boolean!
-  canUpdateMetadata: Boolean!
-}
-
-enum AccountState {
-  ACTIVE
-  CLOSED
-  UNKNOWN
-  UNPROVISIONED
-}
-
-"""A time window with a specified granularity over a given account."""
-type AccountStatsWindow {
-  billingUsageStats(
-    """Filter to select what rows to return."""
-    filter: AccountBillingUsageStatsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order AccountBillingUsageStats by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [AccountBillingUsageStatsOrderBySpec!]
-  ): [AccountBillingUsageStatsRecord!]!
-  cardinalityStats(
-    """Filter to select what rows to return."""
-    filter: AccountCardinalityStatsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order AccountCardinalityStats by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [AccountCardinalityStatsOrderBySpec!]
-  ): [AccountCardinalityStatsRecord!]!
-  coordinateUsage(
-    """Filter to select what rows to return."""
-    filter: AccountCoordinateUsageFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order AccountCoordinateUsage by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [AccountCoordinateUsageOrderBySpec!]
-  ): [AccountCoordinateUsageRecord!]!
-  edgeServerInfos(
-    """Filter to select what rows to return."""
-    filter: AccountEdgeServerInfosFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order AccountEdgeServerInfos by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [AccountEdgeServerInfosOrderBySpec!]
-  ): [AccountEdgeServerInfosRecord!]!
-  errorStats(
-    """Filter to select what rows to return."""
-    filter: AccountErrorStatsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order AccountErrorStats by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [AccountErrorStatsOrderBySpec!]
-  ): [AccountErrorStatsRecord!]!
-  federatedErrorStats(
-    """Filter to select what rows to return."""
-    filter: AccountFederatedErrorStatsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order AccountFederatedErrorStats by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [AccountFederatedErrorStatsOrderBySpec!]
-  ): [AccountFederatedErrorStatsRecord!]!
-  fieldExecutions(
-    """Filter to select what rows to return."""
-    filter: AccountFieldExecutionsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order AccountFieldExecutions by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [AccountFieldExecutionsOrderBySpec!]
-  ): [AccountFieldExecutionsRecord!]!
-  fieldLatencies(
-    """Filter to select what rows to return."""
-    filter: AccountFieldLatenciesFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order AccountFieldLatencies by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [AccountFieldLatenciesOrderBySpec!]
-  ): [AccountFieldLatenciesRecord!]!
-  fieldUsage(
-    """Filter to select what rows to return."""
-    filter: AccountFieldUsageFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order AccountFieldUsage by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [AccountFieldUsageOrderBySpec!]
-  ): [AccountFieldUsageRecord!]!
-  graphosCloudMetrics(
-    """Filter to select what rows to return."""
-    filter: AccountGraphosCloudMetricsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order AccountGraphosCloudMetrics by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [AccountGraphosCloudMetricsOrderBySpec!]
-  ): [AccountGraphosCloudMetricsRecord!]!
-  operationCheckStats(
-    """Filter to select what rows to return."""
-    filter: AccountOperationCheckStatsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order AccountOperationCheckStats by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [AccountOperationCheckStatsOrderBySpec!]
-  ): [AccountOperationCheckStatsRecord!]!
-  queryStats(
-    """Filter to select what rows to return."""
-    filter: AccountQueryStatsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order AccountQueryStats by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [AccountQueryStatsOrderBySpec!]
-  ): [AccountQueryStatsRecord!]!
-
-  """From field rounded down to the nearest resolution."""
-  roundedDownFrom: Timestamp!
-
-  """To field rounded up to the nearest resolution."""
-  roundedUpTo: Timestamp!
-  tracePathErrorsRefs(
-    """Filter to select what rows to return."""
-    filter: AccountTracePathErrorsRefsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order AccountTracePathErrorsRefs by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [AccountTracePathErrorsRefsOrderBySpec!]
-  ): [AccountTracePathErrorsRefsRecord!]!
-  traceRefs(
-    """Filter to select what rows to return."""
-    filter: AccountTraceRefsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order AccountTraceRefs by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [AccountTraceRefsOrderBySpec!]
-  ): [AccountTraceRefsRecord!]!
-}
-
-"""Columns of AccountTracePathErrorsRefs."""
-enum AccountTracePathErrorsRefsColumn {
-  CLIENT_NAME
-  CLIENT_VERSION
-  DURATION_BUCKET
-  ERRORS_COUNT_IN_PATH
-  ERRORS_COUNT_IN_TRACE
-  ERROR_CODE
-  ERROR_MESSAGE
-  ERROR_SERVICE
-  PATH
-  QUERY_ID
-  QUERY_NAME
-  SCHEMA_HASH
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-  TRACE_HTTP_STATUS_CODE
-  TRACE_ID
-  TRACE_SIZE_BYTES
-  TRACE_STARTS_AT
-}
-
-type AccountTracePathErrorsRefsDimensions {
-  clientName: String
-  clientVersion: String
-  durationBucket: Int
-  errorCode: String
-  errorMessage: String
-  errorService: String
-  path: String
-  queryId: ID
-  queryName: String
-  schemaHash: String
-  schemaTag: String
-  serviceId: ID
-  traceHttpStatusCode: Int
-  traceId: ID
-  traceStartsAt: Timestamp
-}
-
-"""
-Filter for data in AccountTracePathErrorsRefs. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input AccountTracePathErrorsRefsFilter {
-  and: [AccountTracePathErrorsRefsFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-
-  """
-  Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead.
-  """
-  durationBucket: Int
-
-  """
-  Selects rows whose errorCode dimension equals the given value if not null. To query for the null value, use {in: {errorCode: [null]}} instead.
-  """
-  errorCode: String
-
-  """
-  Selects rows whose errorMessage dimension equals the given value if not null. To query for the null value, use {in: {errorMessage: [null]}} instead.
-  """
-  errorMessage: String
-
-  """
-  Selects rows whose errorService dimension equals the given value if not null. To query for the null value, use {in: {errorService: [null]}} instead.
-  """
-  errorService: String
-  in: AccountTracePathErrorsRefsFilterIn
-  not: AccountTracePathErrorsRefsFilter
-  or: [AccountTracePathErrorsRefsFilter!]
-
-  """
-  Selects rows whose path dimension equals the given value if not null. To query for the null value, use {in: {path: [null]}} instead.
-  """
-  path: String
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: ID
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead.
-  """
-  schemaHash: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-
-  """
-  Selects rows whose traceHttpStatusCode dimension equals the given value if not null. To query for the null value, use {in: {traceHttpStatusCode: [null]}} instead.
-  """
-  traceHttpStatusCode: Int
-
-  """
-  Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead.
-  """
-  traceId: ID
-}
-
-"""
-Filter for data in AccountTracePathErrorsRefs. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input AccountTracePathErrorsRefsFilterIn {
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  durationBucket: [Int]
-
-  """
-  Selects rows whose errorCode dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  errorCode: [String]
-
-  """
-  Selects rows whose errorMessage dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  errorMessage: [String]
-
-  """
-  Selects rows whose errorService dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  errorService: [String]
-
-  """
-  Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  path: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [ID]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaHash: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-
-  """
-  Selects rows whose traceHttpStatusCode dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  traceHttpStatusCode: [Int]
-
-  """
-  Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  traceId: [ID]
-}
-
-type AccountTracePathErrorsRefsMetrics {
-  errorsCountInPath: Long!
-  errorsCountInTrace: Long!
-  traceSizeBytes: Long!
-}
-
-input AccountTracePathErrorsRefsOrderBySpec {
-  column: AccountTracePathErrorsRefsColumn!
-  direction: Ordering!
-}
-
-type AccountTracePathErrorsRefsRecord {
-  """Dimensions of AccountTracePathErrorsRefs that can be grouped by."""
-  groupBy: AccountTracePathErrorsRefsDimensions!
-
-  """Metrics of AccountTracePathErrorsRefs that can be aggregated over."""
-  metrics: AccountTracePathErrorsRefsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of AccountTraceRefs."""
-enum AccountTraceRefsColumn {
-  CLIENT_NAME
-  CLIENT_VERSION
-  DURATION_BUCKET
-  OPERATION_SUBTYPE
-  OPERATION_TYPE
-  QUERY_ID
-  QUERY_NAME
-  SCHEMA_HASH
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-  TRACE_COUNT
-  TRACE_ID
-}
-
-type AccountTraceRefsDimensions {
-  clientName: String
-  clientVersion: String
-  durationBucket: Int
-  generatedTraceId: String
-  operationSubtype: String
-  operationType: String
-  queryId: ID
-  queryName: String
-  querySignature: String
-  schemaHash: String
-  schemaTag: String
-  serviceId: ID
-  traceId: ID
-}
-
-"""
-Filter for data in AccountTraceRefs. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input AccountTraceRefsFilter {
-  and: [AccountTraceRefsFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-
-  """
-  Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead.
-  """
-  durationBucket: Int
-  in: AccountTraceRefsFilterIn
-  not: AccountTraceRefsFilter
-
-  """
-  Selects rows whose operationSubtype dimension equals the given value if not null. To query for the null value, use {in: {operationSubtype: [null]}} instead.
-  """
-  operationSubtype: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [AccountTraceRefsFilter!]
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: ID
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead.
-  """
-  schemaHash: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-
-  """
-  Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead.
-  """
-  traceId: ID
-}
-
-"""
-Filter for data in AccountTraceRefs. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input AccountTraceRefsFilterIn {
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  durationBucket: [Int]
-
-  """
-  Selects rows whose operationSubtype dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationSubtype: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [ID]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaHash: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-
-  """
-  Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  traceId: [ID]
-}
-
-type AccountTraceRefsMetrics {
-  traceCount: Long!
-}
-
-input AccountTraceRefsOrderBySpec {
-  column: AccountTraceRefsColumn!
-  direction: Ordering!
-}
-
-type AccountTraceRefsRecord {
-  """Dimensions of AccountTraceRefs that can be grouped by."""
-  groupBy: AccountTraceRefsDimensions!
-
-  """Metrics of AccountTraceRefs that can be aggregated over."""
-  metrics: AccountTraceRefsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
+  requestAuditExport(actors: [ActorInput!], from: Timestamp!, graphIds: [String!], to: Timestamp!): Organization
 }
 
 """
@@ -2881,20 +107,6 @@ enum ActorType {
   USER
 }
 
-"""
-parentCommentId is only present for replies. schemaCoordinate & subgraph are only present for initial change comments. If all are absent, this is a general parent comment on the proposal.
-"""
-input AddCommentInput {
-  message: String!
-  parentCommentId: String
-  revisionId: String!
-  schemaCoordinate: String
-  schemaScope: String
-  usersToNotify: [String!]
-}
-
-union AddCommentResult = NotFoundError | ParentChangeProposalComment | ParentGeneralProposalComment | ReplyChangeProposalComment | ReplyGeneralProposalComment | ValidationError
-
 union AddOperationCollectionEntriesResult = AddOperationCollectionEntriesSuccess | PermissionError | ValidationError
 
 type AddOperationCollectionEntriesSuccess {
@@ -2902,8 +114,6 @@ type AddOperationCollectionEntriesSuccess {
 }
 
 union AddOperationCollectionEntryResult = OperationCollectionEntry | PermissionError | ValidationError
-
-union AddOperationCollectionToVariantResult = GraphVariant | InvalidTarget | PermissionError | ValidationError
 
 input AddOperationInput {
   """The operation's fields."""
@@ -2913,19 +123,18 @@ input AddOperationInput {
   name: String!
 }
 
-type AffectedClient {
-  """
-  ID, often the name, of the client set by the user and reported alongside metrics
-  """
-  clientReferenceId: ID @deprecated(reason: "Unsupported.")
+"""Filter options available when searching affected queries for a check."""
+input AffectedQueriesFilterInput {
+  """Filter by a keyword to match against the query's operation name or ID."""
+  search: String
 
-  """version of the client set by the user and reported alongside metrics"""
-  clientVersion: String @deprecated(reason: "Unsupported.")
-}
-
-enum AffectedEnv {
-  NON_PRODUCTION
-  PRODUCTION
+  """
+  Filter affected queries by one or more statuses.
+  
+  For example, use `[BROKEN]` to return only queries that are broken,
+  or `[BROKEN, POTENTIALLY_AFFECTED]` to include queries that are broken OR possibly affected.
+  """
+  status: [AffectedQueryStatus!]
 }
 
 type AffectedQuery {
@@ -2969,6 +178,24 @@ type AffectedQuery {
   alreadyIgnored: Boolean
 }
 
+enum AffectedQueryStatus {
+  """This query will break as a result of the changes in this check."""
+  BROKEN
+
+  """This query is valid but may be affected by the changes in this check."""
+  POTENTIALLY_AFFECTED
+
+  """
+  This query is affected by the changes, but was marked as safe in a previous check.
+  """
+  SAFE
+
+  """
+  This query is affected by the changes, but was ignored in a previous check
+  """
+  IGNORED
+}
+
 """
 Represents an API key that's used to authenticate a
 particular Apollo user or graph.
@@ -2989,31 +216,9 @@ type ApiKeyProvision {
   created: Boolean!
 }
 
-"""A generic event for the `trackApolloKotlinUsage` mutation"""
-input ApolloKotlinUsageEventInput {
-  """When the event occurred"""
-  date: Timestamp!
-
-  """Optional parameters attached to the event"""
-  payload: Object
-
-  """Type of event"""
-  type: ID!
-}
-
-"""A generic property for the `trackApolloKotlinUsage` mutation"""
-input ApolloKotlinUsagePropertyInput {
-  """Optional parameters attached to the property"""
-  payload: Object
-
-  """Type of property"""
-  type: ID!
-}
-
 type AuditLogExport {
   """The list of actors to filter the audit export"""
   actors: [Identity!]
-  bigqueryTriggeredAt: Timestamp
 
   """The time when the audit export was completed"""
   completedAt: Timestamp
@@ -3023,13 +228,12 @@ type AuditLogExport {
 
   """List of URLs to download the audits for the requested range"""
   downloadUrls: [String!]
-  exportedFiles: [String!]
 
   """The starting point of audits to include in export"""
   from: Timestamp!
 
   """The list of graphs to filter the audit export"""
-  graphs: [Service!]
+  graphs: [Graph!]
 
   """The id for the audit export"""
   id: ID!
@@ -3044,11 +248,6 @@ type AuditLogExport {
   to: Timestamp!
 }
 
-type AuditLogExportMutation {
-  cancel: Account
-  delete: Account
-}
-
 enum AuditStatus {
   CANCELLED
   COMPLETED
@@ -3058,715 +257,10 @@ enum AuditStatus {
   QUEUED
 }
 
-type AvatarDeleteError {
-  clientMessage: String!
-  code: AvatarDeleteErrorCode!
-  serverMessage: String!
-}
-
-enum AvatarDeleteErrorCode {
-  SSO_USERS_CANNOT_DELETE_SELF_AVATAR
-}
-
-type AvatarUploadError {
-  clientMessage: String!
-  code: AvatarUploadErrorCode!
-  serverMessage: String!
-}
-
-enum AvatarUploadErrorCode {
-  SSO_USERS_CANNOT_UPLOAD_SELF_AVATAR
-}
-
-union AvatarUploadResult = AvatarUploadError | MediaUploadInfo
-
-"""AWS Load Balancer information"""
-type AwsLoadBalancer {
-  """DNS endpoint for the load balancer"""
-  endpoint: String!
-
-  """ARN for the load balancer"""
-  arn: String!
-
-  """ARN for the HTTPS listener for the load balancer"""
-  listenerArn: String!
-}
-
-"""Input for AWS Load Balancer"""
-input AwsLoadBalancerInput {
-  endpoint: String!
-  arn: String!
-  listenerArn: String!
-}
-
-"""AWS-specific information for a Shard"""
-type AwsShard {
-  """AWS Account ID where the Shard is hosted"""
-  accountId: String!
-
-  """ARN of the ECS Cluster"""
-  ecsClusterArn: String!
-
-  """ARN of the IAM role to perform provisioning operations on this shard"""
-  iamRoleArn: String!
-
-  """Load balancers for this Cloud Router"""
-  loadbalancers: [AwsLoadBalancer!]!
-
-  """ID of the security group for the load balancer"""
-  loadbalancerSecurityGroupId: String!
-
-  """
-  ARN of the IAM permissions boundaries for IAM roles provisioned in this shard
-  """
-  permissionsBoundaryArn: String!
-
-  """IDs of the subnets"""
-  subnetIds: [String!]!
-
-  """ID of the VPC"""
-  vpcId: String!
-
-  """ARNs of the target groups for sleeping Cloud Routers"""
-  coldStartTargetGroupArns: [String!]
-}
-
-type BaseConnection implements SsoConnection {
-  domains: [String!]!
-  id: ID!
-  idpId: ID!
-  scim: SsoScimProvisioningDetails
-  state: SsoConnectionState! @deprecated(reason: "Use stateV2 instead")
-  stateV2: SsoConnectionStateV2!
-}
-
-type BillableMetricStats {
-  planThreshold: Int
-  stats: [MetricStatWindow!]!
-}
-
-type BillingAddress {
-  address1: String
-  address2: String
-  city: String
-  country: String
-  state: String
-  zip: String
-}
-
-"""Billing address input"""
-input BillingAddressInput {
-  address1: String!
-  address2: String
-  city: String!
-  country: String!
-  state: String!
-  zip: String!
-}
-
-type BillingAdminQuery {
-  """Look up the current plan of an account by calling the grpc service"""
-  currentPlanFromGrpc(internalAccountId: ID!): GQLBillingPlanFromGrpc
-}
-
-type BillingCapability {
-  defaultValue: Boolean!
-  intendedUse: String!
-  label: String!
-}
-
-"""Billing capability input"""
-input BillingCapabilityInput {
-  defaultValue: Boolean!
-  intendedUse: String!
-  label: String!
-}
-
-type BillingInfo {
-  address: BillingAddress!
-  cardType: String
-  firstName: String
-  lastFour: Int
-  lastName: String
-  month: Int
-  name: String
-  vatNumber: String
-  year: Int
-}
-
-type BillingInsights {
-  totalOperations: [BillingInsightsUsage!]!
-  totalSampledOperations: [BillingInsightsUsage!]!
-}
-
-type BillingInsightsUsage {
-  timestamp: Timestamp!
-  totalOperationCount: Long!
-}
-
-type BillingLimit {
-  defaultValue: Long!
-  intendedUse: String!
-  label: String!
-}
-
-"""Billing limit input"""
-input BillingLimitInput {
-  defaultValue: Long
-  intendedUse: String!
-  label: String!
-}
-
-enum BillingModel {
-  REQUEST_BASED
-  SEAT_BASED
-}
-
-type BillingMonth {
-  end: Timestamp!
-  requests: Long!
-  start: Timestamp!
-}
-
-type BillingMutation {
-  """
-  Temporary utility mutation to convert annual team plan orgs to monthly team plans
-  """
-  convertAnnualTeamOrgToMonthly(internalAccountId: ID!): Void
-  createSetupIntent(internalAccountId: ID!): SetupIntentResult
-
-  """
-  Admin mutation for manually creating usage exports for testing usage-based pricing of Scale plans.
-  """
-  createUsageExport(date: Date!, internalAccountIds: [ID!]!, startAtHour: Int!): Void
-  endPaidUsageBasedPlan(internalAccountId: ID!): EndUsageBasedPlanResult
-  reloadPlans: [BillingPlan!]!
-  startFreeUsageBasedPlan(internalAccountId: ID!): StartUsageBasedPlanResult
-  startUsageBasedPlan(internalAccountId: ID!, paymentMethodId: String!): StartUsageBasedPlanResult
-  syncAccountWithProviders(internalAccountId: ID!): SyncBillingAccountResult @deprecated(reason: "No longer supported")
-
-  """Mutation to sync an Apollo Plan with a Stripe product"""
-  syncStripePlan(planKind: BillingPlanKind!, planReadableId: String, stripeProductId: ID!): Void
-  updatePaymentMethod(internalAccountId: ID!, paymentMethodId: String!): UpdatePaymentMethodResult
-}
-
-enum BillingPeriod {
-  MONTHLY
-  QUARTERLY
-  SEMI_ANNUALLY
-  YEARLY
-}
-
-type BillingPlan {
-  addons: [BillingPlanAddon!]!
-
-  """Retrieve all capabilities for the plan"""
-  allCapabilities: [BillingPlanCapability!]!
-
-  """Retrieve a list of all effective capability limits for this plan"""
-  allLimits: [BillingPlanLimit!]!
-  billingModel: BillingModel!
-  billingPeriod: BillingPeriod
-  clientVersions: Boolean! @deprecated(reason: "use AccountCapabilities.clientVersions")
-  clients: Boolean! @deprecated(reason: "use AccountCapabilities.clients")
-  contracts: Boolean! @deprecated(reason: "use AccountCapabilities.contracts")
-  datadog: Boolean! @deprecated(reason: "use AccountCapabilities.datadog")
-  description: String
-
-  """Retrieve the limit applied to this plan for a capability"""
-  effectiveLimit(label: String!): Long
-  errors: Boolean!
-  federation: Boolean! @deprecated(reason: "use AccountCapabilities.federation")
-
-  """Check whether a capability is enabled for the plan"""
-  hasCapability(label: String!): Boolean
-  id: ID!
-  isTrial: Boolean!
-  kind: BillingPlanKind!
-  launches: Boolean! @deprecated(reason: "use AccountCapabilities.launches")
-  maxAuditInDays: Int! @deprecated(reason: "use AccountLimits.maxAuditInDays")
-  maxRangeInDays: Int @deprecated(reason: "use AccountLimits.maxRangeInDays")
-
-  """The maximum number of days that checks stats will be stored"""
-  maxRangeInDaysForChecks: Int @deprecated(reason: "use AccountLimits.maxRangeInDaysForChecks")
-  maxRequestsPerMonth: Long @deprecated(reason: "use AccountLimits.maxRequestsPerMonth")
-  metrics: Boolean! @deprecated(reason: "use AccountCapabilities.metrics")
-  name: String!
-  notifications: Boolean! @deprecated(reason: "use AccountCapabilities.notifications")
-  operationRegistry: Boolean! @deprecated(reason: "use AccountCapabilities.operationRegistry")
-  persistedQueries: Boolean! @deprecated(reason: "use AccountCapabilities.persistedQueries")
-
-  """The price of every seat"""
-  pricePerSeatInUsdCents: Int
-
-  """
-  The price of subscribing to this plan with a quantity of 1 (currently always the case)
-  """
-  pricePerUnitInUsdCents: Int!
-  provider: BillingProvider
-
-  """
-  Whether the plan is accessible by all users in QueryRoot.allPlans, QueryRoot.plan, or AccountMutation.setPlan
-  """
-  public: Boolean!
-  ranges: [String!]!
-  readableId: ID!
-  schemaValidation: Boolean! @deprecated(reason: "use AccountCapabilities.schemaValidation")
-  sso: Boolean @deprecated(reason: "use AccountCapabilities.sso")
-  tier: BillingPlanTier!
-  traces: Boolean! @deprecated(reason: "use AccountCapabilities.traces")
-  userRoles: Boolean! @deprecated(reason: "use AccountCapabilities.userRoles")
-  webhooks: Boolean! @deprecated(reason: "use AccountCapabilities.webhooks")
-}
-
-type BillingPlanAddon {
-  id: ID!
-  pricePerUnitInUsdCents: Int!
-}
-
-"""Billing plan addon input"""
-input BillingPlanAddonInput {
-  code: String
-  usdCentsPrice: Int
-}
-
-type BillingPlanCapability {
-  label: String!
-  plan: BillingPlan!
-  value: Boolean!
-}
-
-"""Billing plan input"""
-input BillingPlanInput {
-  addons: [BillingPlanAddonInput!]!
-  billingModel: BillingModel!
-  billingPeriod: BillingPeriod!
-  clientVersions: Boolean
-  clients: Boolean
-  contracts: Boolean
-  datadog: Boolean
-  description: String!
-  errors: Boolean
-  federation: Boolean
-  id: ID!
-  kind: BillingPlanKind!
-  launches: Boolean
-  maxAuditInDays: Int
-  maxRangeInDays: Int
-  maxRangeInDaysForChecks: Int
-  maxRequestsPerMonth: Long
-  metrics: Boolean
-  name: String!
-  notifications: Boolean
-  operationRegistry: Boolean
-  persistedQueries: Boolean
-  pricePerSeatInUsdCents: Int
-  pricePerUnitInUsdCents: Int
-  public: Boolean!
-  schemaValidation: Boolean
-  traces: Boolean
-  userRoles: Boolean
-  webhooks: Boolean
-}
-
-"""
-Overall class that a billing plan falls into. This is slightly more granular than BillingPlanTier
-because it differentiates between trials, pilots, internal-only plans, etc.
-"""
-enum BillingPlanKind {
-  """
-  Original version of the default free plan that we still support but is no longer offered
-  """
-  COMMUNITY
-
-  """
-  Custom plan for serverless customers that is configured and billed manually in Stripe
-  """
-  DEDICATED
-  ENTERPRISE_INTERNAL
-  ENTERPRISE_PAID
-  ENTERPRISE_PILOT
-  ENTERPRISE_TRIAL
-
-  """2025 version of the default free plan"""
-  FREE
-  ONE_FREE @deprecated(reason: "Part of initial 2022 serverless implementation; was never used in production")
-  ONE_PAID @deprecated(reason: "Part of initial 2022 serverless implementation; was never used in production")
-  PLACEHOLDER_FREE
-  PLACEHOLDER_PAID
-
-  """Sales assisted Scale plan currently configured in Recurly."""
-  SCALE
-  SCALE_ADVANCED
-
-  """New Scale plans configured in Stripe."""
-  SCALE_BASIC
-  SCALE_PLATFORM
-  SERVERLESS @deprecated(reason: "Part of initial 2022 serverless implementation; was never used in production")
-
-  """
-  2022 version of the 'serverless' free plan that we still support but is no longer offered
-  """
-  SERVERLESS_FREE
-
-  """
-  2022 version of the 'serverless' paid plan that we still support but is no longer offered
-  """
-  SERVERLESS_PAID
-  STARTER @deprecated(reason: "Part of initial 2022 serverless implementation; was never used in production")
-
-  """
-  Original version of the non-enterprise paid plan (configured in Recurly) that we still support but is no longer offered
-  """
-  TEAM_PAID
-
-  """
-  Original version of the non-enterprise trial plan (configured in Recurly) that we still support but is no longer offered
-  """
-  TEAM_TRIAL
-  UNKNOWN
-}
-
-type BillingPlanLimit {
-  label: String!
-  plan: BillingPlan!
-  value: Long
-}
-
-type BillingPlanMutation {
-  """Archive this billing plan"""
-  archive: Void
-
-  """Remove the specified capability from this plan"""
-  clearCapability(label: String!): Void
-
-  """Remove the specified limit from this plan"""
-  clearLimit(label: String!): Void
-  id: ID!
-
-  """
-  Reset the specified capability on this plan to the global default value for the capability
-  """
-  resetCapability(label: String!): BillingPlanCapability
-
-  """
-  Reset the specified limit on this plan to the global default value for the limit
-  """
-  resetLimit(label: String!): BillingPlanLimit
-
-  """Sets the specified capability on this plan to the provided value"""
-  setCapability(label: String!, value: Boolean!): BillingPlanCapability
-
-  """Sets the specified limit on this plan to the provided value"""
-  setLimit(label: String!, value: Long): BillingPlanLimit
-  updateDescriptors(input: UpdateBillingPlanDescriptorsInput): BillingPlan
-
-  """Update a plan"""
-  updatePlan(input: UpdateBillingPlanInput): BillingPlan
-
-  """Add Stripe pricing rates for this plan"""
-  upsertStripeRates(priceIds: [String!]!): Void
-}
-
-enum BillingPlanTier {
-  """
-  Original version of the default free plan that we still support but is no longer offered
-  """
-  COMMUNITY
-  ENTERPRISE
-
-  """2025 version of the 'serverless' free plan"""
-  FREE
-  ONE @deprecated(reason: "Part of initial 2022 serverless implementation; was never used in production")
-
-  """2025 version of the 'serverless' paid plan"""
-  SCALE
-
-  """
-  Original version of the non-enterprise paid plan (configured in Recurly) that we still support but is no longer offered
-  """
-  TEAM
-  UNKNOWN
-
-  """
-  2022 version of the 'serverless' free plan that we still support but is no longer offered
-  """
-  USAGE_BASED
-}
-
-enum BillingProvider {
-  APOLLO_NO_INVOICING
-  METRONOME
-  NONE
-  RECURLY
-  STRIPE
-}
-
-type BillingSubscription {
-  activatedAt: Timestamp!
-  addons: [BillingSubscriptionAddon!]!
-
-  """Retrieve all capabilities for this subscription"""
-  allCapabilities: [SubscriptionCapability!]!
-
-  """
-  Retrieve a list of all effective capability limits for this subscription
-  """
-  allLimits: [SubscriptionLimit!]!
-  autoRenew: Boolean!
-  canceledAt: Timestamp
-
-  """Draft invoice for this subscription"""
-  currentDraftInvoice: DraftInvoice @deprecated(reason: "This data came from Metronome and we no longer use Metronome")
-  currentPeriodEndsAt: Timestamp!
-  currentPeriodStartedAt: Timestamp!
-
-  """Retrieve the limit applied to this subscription for a capability"""
-  effectiveLimit(label: String!): Long
-  expiresAt: Timestamp
-
-  """Renewal grace time for updating seat count"""
-  graceTimeForNextRenewal: Timestamp
-
-  """Check whether a capability is enabled for the subscription"""
-  hasCapability(label: String!): Boolean
-  maxSelfHostedRequestsPerMonth: Int
-  maxServerlessRequestsPerMonth: Int
-  meteredBillingSummary: MeteredBillingSummary
-  plan: BillingPlan!
-
-  """The price of every seat"""
-  pricePerSeatInUsdCents: Int
-
-  """
-  The price of every unit in the subscription (hence multiplied by quantity to get to the basePriceInUsdCents)
-  """
-  pricePerUnitInUsdCents: Int!
-  promoCredits: CreditGrant
-  quantity: Int!
-
-  """
-  Total price of the subscription when it next renews, including add-ons (such as seats)
-  """
-  renewalTotalPriceInUsdCents: Long!
-  state: SubscriptionState!
-
-  """
-  When this subscription's trial period expires (if it is a trial). Not the same as the
-  subscription's Recurly expiration).
-  """
-  trialExpiresAt: Timestamp
-  uuid: ID!
-}
-
-type BillingSubscriptionAddon {
-  id: ID!
-  pricePerUnitInUsdCents: Int!
-  quantity: Int!
-}
-
-type BillingSubscriptionMutation {
-  """Remove the specified capability override for this subscription"""
-  clearCapability(label: String!): Void
-
-  """Remove the specified limit override for this subscription"""
-  clearLimit(label: String!): Void
-
-  """
-  Sets the capability override on this subscription to the provided value
-  """
-  setCapability(label: String!, value: Boolean!): SubscriptionCapability
-
-  """Sets the limit override on this subscription to the provided value"""
-  setLimit(label: String!, value: Long): SubscriptionLimit
-  uuid: ID!
-}
-
-type BillingTier {
-  tier: BillingPlanTier!
-  searchAccounts(search: String): [Account!]!
-}
-
-"""Columns of BillingUsageStats."""
-enum BillingUsageStatsColumn {
-  ACCOUNT_ID
-  AGENT_ID
-  AGENT_VERSION
-  GRAPH_DEPLOYMENT_TYPE
-  OPERATION_COUNT
-  OPERATION_COUNT_PROVIDED_EXPLICITLY
-  OPERATION_SUBTYPE
-  OPERATION_TYPE
-  ROUTER_FEATURES_ENABLED
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-}
-
-type BillingUsageStatsDimensions {
-  accountId: ID
-  agentId: String
-  agentVersion: String
-  graphDeploymentType: String
-  operationCountProvidedExplicitly: String
-  operationSubtype: String
-  operationType: String
-  routerFeaturesEnabled: String
-  schemaTag: String
-  serviceId: ID
-}
-
-"""
-Filter for data in BillingUsageStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input BillingUsageStatsFilter {
-  """
-  Selects rows whose accountId dimension equals the given value if not null. To query for the null value, use {in: {accountId: [null]}} instead.
-  """
-  accountId: ID
-
-  """
-  Selects rows whose agentId dimension equals the given value if not null. To query for the null value, use {in: {agentId: [null]}} instead.
-  """
-  agentId: String
-
-  """
-  Selects rows whose agentVersion dimension equals the given value if not null. To query for the null value, use {in: {agentVersion: [null]}} instead.
-  """
-  agentVersion: String
-  and: [BillingUsageStatsFilter!]
-
-  """
-  Selects rows whose graphDeploymentType dimension equals the given value if not null. To query for the null value, use {in: {graphDeploymentType: [null]}} instead.
-  """
-  graphDeploymentType: String
-  in: BillingUsageStatsFilterIn
-  not: BillingUsageStatsFilter
-
-  """
-  Selects rows whose operationCountProvidedExplicitly dimension equals the given value if not null. To query for the null value, use {in: {operationCountProvidedExplicitly: [null]}} instead.
-  """
-  operationCountProvidedExplicitly: String
-
-  """
-  Selects rows whose operationSubtype dimension equals the given value if not null. To query for the null value, use {in: {operationSubtype: [null]}} instead.
-  """
-  operationSubtype: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [BillingUsageStatsFilter!]
-
-  """
-  Selects rows whose routerFeaturesEnabled dimension equals the given value if not null. To query for the null value, use {in: {routerFeaturesEnabled: [null]}} instead.
-  """
-  routerFeaturesEnabled: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-}
-
-"""
-Filter for data in BillingUsageStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input BillingUsageStatsFilterIn {
-  """
-  Selects rows whose accountId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  accountId: [ID]
-
-  """
-  Selects rows whose agentId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  agentId: [String]
-
-  """
-  Selects rows whose agentVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  agentVersion: [String]
-
-  """
-  Selects rows whose graphDeploymentType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  graphDeploymentType: [String]
-
-  """
-  Selects rows whose operationCountProvidedExplicitly dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationCountProvidedExplicitly: [String]
-
-  """
-  Selects rows whose operationSubtype dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationSubtype: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose routerFeaturesEnabled dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  routerFeaturesEnabled: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-}
-
-type BillingUsageStatsMetrics {
-  operationCount: Long!
-}
-
-input BillingUsageStatsOrderBySpec {
-  column: BillingUsageStatsColumn!
-  direction: Ordering!
-}
-
-type BillingUsageStatsRecord {
-  """Dimensions of BillingUsageStats that can be grouped by."""
-  groupBy: BillingUsageStatsDimensions!
-
-  """Metrics of BillingUsageStats that can be aggregated over."""
-  metrics: BillingUsageStatsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-enum BillingUsageStatsWindowSize {
-  DAY
-  HOUR
-  MONTH
-  NONE
-}
-
-"""A blob (base64'ed in JSON & GraphQL)"""
-scalar Blob
-
 """
 The building of a Studio variant (including supergraph composition and any contract filtering) as part of a launch.
 """
 type Build {
-  """The unique identifier for this build."""
-  id: ID!
-
   """
   The inputs provided to the build, including subgraph and contract details.
   """
@@ -3774,76 +268,6 @@ type Build {
 
   """The result of the build. This value is null until the build completes."""
   result: BuildResult
-}
-
-interface BuildCheckFailed implements BuildCheckResult {
-  buildInputs: BuildInputs!
-  buildPipelineTrack: BuildPipelineTrack!
-
-  """A list of errors generated by this build."""
-  errors: [BuildError!]!
-  id: ID!
-  passed: Boolean!
-  workflowTask: BuildCheckTask!
-}
-
-interface BuildCheckPassed implements BuildCheckResult {
-  buildInputs: BuildInputs!
-  buildPipelineTrack: BuildPipelineTrack!
-  id: ID!
-  passed: Boolean!
-
-  """The SHA-256 of the supergraph schema document generated by this build."""
-  supergraphSchemaHash: SHA256!
-  workflowTask: BuildCheckTask!
-}
-
-interface BuildCheckResult {
-  """The input to the build task."""
-  buildInputs: BuildInputs!
-
-  """
-  The build pipeline track of the build task, which indicates what gateway/router versions the
-   build pipeline is intended to support (and accordingly controls the version of code).
-  """
-  buildPipelineTrack: BuildPipelineTrack!
-  id: ID!
-
-  """Whether the build task passed or failed."""
-  passed: Boolean!
-
-  """The workflow build task that generated this result."""
-  workflowTask: BuildCheckTask!
-}
-
-interface BuildCheckTask implements CheckWorkflowTask {
-  """
-  The result of the build check. This will be null when the task is initializing or running.
-  """
-  buildResult: BuildCheckResult
-  completedAt: Timestamp
-  createdAt: Timestamp!
-  id: ID!
-
-  """
-  The build input change proposed for this check workflow. Note that for triggered downstream
-   workflows, this is not the upstream variant's proposed change, but the changes for the downstream
-  variant that are derived from the upstream workflow's results (e.g. the input supergraph schema).
-  """
-  proposedBuildInputChanges: ProposedBuildInputChanges!
-  status: CheckWorkflowTaskStatus!
-  targetURL: String
-  workflow: CheckWorkflow!
-}
-
-"""The configuration for building a composition graph variant"""
-type BuildConfig {
-  buildPipelineTrack: BuildPipelineTrack!
-
-  """
-  Show all uses of @tag directives to consumers in Schema Reference and Explorer
-  """
-  tagInApiSchema: Boolean!
 }
 
 """
@@ -3882,8 +306,6 @@ type BuildFailure {
 
 union BuildInput = CompositionBuildInput | FilterBuildInput
 
-union BuildInputs = CompositionBuildInputs | FilterBuildInputs
-
 enum BuildPipelineTrack {
   FED_1_0
   FED_1_1
@@ -3898,60 +320,14 @@ enum BuildPipelineTrack {
   FED_2_7
   FED_2_8
   FED_2_9
-  FED_NEXT
-}
-
-enum BuildPipelineTrackBadge {
-  DEPRECATED
-  EXPERIMENTAL
-  LATEST
-  UNSUPPORTED
-}
-
-type BuildPipelineTrackDetails {
-  badge: BuildPipelineTrackBadge
-  buildPipelineTrack: BuildPipelineTrack!
-
-  """
-  currently running version of composition for this track, includes patch updates
-  """
-  compositionVersion: String!
-  deprecatedAt: Timestamp
-  displayName: String!
-  minimumGatewayVersion: String
-
-  """
-  Minimum supported router and gateway versions. Min router   version can be null since fed 1 doesn't have router support.
-  """
-  minimumRouterVersion: String
-  notSupportedAt: Timestamp
 }
 
 union BuildResult = BuildFailure | BuildSuccess
-
-input BuildRouterVersionInput {
-  routerRepository: String
-  routerBranch: String
-  cloudRouterBranch: String
-}
-
-union BuildRouterVersionResult = BuildRouterVersionSuccess | CloudRouterTestingInvalidInputErrors
-
-type BuildRouterVersionSuccess {
-  jobId: ID!
-}
 
 """Contains the details of an executed build that succeeded."""
 type BuildSuccess {
   """Contains the supergraph and API schemas created by composition."""
   coreSchema: CoreSchema!
-}
-
-enum CacheScope {
-  PRIVATE
-  PUBLIC
-  UNKNOWN
-  UNRECOGNIZED
 }
 
 """
@@ -3965,87 +341,8 @@ type CannotModifyOperationBodyError implements Error {
   message: String!
 }
 
-"""Columns of CardinalityStats."""
-enum CardinalityStatsColumn {
-  CLIENT_NAME_CARDINALITY
-  CLIENT_VERSION_CARDINALITY
-  OPERATION_SHAPE_CARDINALITY
-  SCHEMA_COORDINATE_CARDINALITY
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-}
-
-type CardinalityStatsDimensions {
-  schemaTag: String
-  serviceId: ID
-}
-
-"""
-Filter for data in CardinalityStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input CardinalityStatsFilter {
-  and: [CardinalityStatsFilter!]
-  in: CardinalityStatsFilterIn
-  not: CardinalityStatsFilter
-  or: [CardinalityStatsFilter!]
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-}
-
-"""
-Filter for data in CardinalityStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input CardinalityStatsFilterIn {
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-}
-
-type CardinalityStatsMetrics {
-  clientNameCardinality: Float!
-  clientVersionCardinality: Float!
-  operationShapeCardinality: Float!
-  schemaCoordinateCardinality: Float!
-}
-
-input CardinalityStatsOrderBySpec {
-  column: CardinalityStatsColumn!
-  direction: Ordering!
-}
-
-type CardinalityStatsRecord {
-  """Dimensions of CardinalityStats that can be grouped by."""
-  groupBy: CardinalityStatsDimensions!
-
-  """Metrics of CardinalityStats that can be aggregated over."""
-  metrics: CardinalityStatsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
 """A single change that was made to a definition in a schema."""
 type Change {
-  """
-  Indication of the success of the overall change, either failure, warning, or notice.
-  """
-  type: ChangeType! @deprecated(reason: "use severity instead")
-
   """The severity of the change (e.g., `FAILURE` or `NOTICE`)"""
   severity: ChangeSeverity!
 
@@ -4254,30 +551,6 @@ type ChangeOnOperation {
   impact: String
 }
 
-interface ChangeProposalComment implements ProposalComment {
-  createdAt: Timestamp!
-
-  """null if the user is deleted"""
-  createdBy: Identity
-  id: ID!
-  message: String!
-
-  """
-  true if the schemaCoordinate this comment is on doesn't exist in the diff between the most recent revision & the base sdl
-  """
-  outdated: Boolean!
-  schemaCoordinate: String!
-
-  """
-  '#@!api!@#' for api schema, '#@!supergraph!@#' for supergraph schema, subgraph otherwise
-  """
-  schemaScope: String!
-  status: CommentStatus!
-
-  """null if never updated"""
-  updatedAt: Timestamp
-}
-
 enum ChangeSeverity {
   FAILURE
   NOTICE
@@ -4313,20 +586,6 @@ type ChangeSummary {
 enum ChangeType {
   FAILURE
   NOTICE
-}
-
-"""Destination for notifications"""
-interface Channel {
-  id: ID!
-  name: String!
-  subscriptions: [ChannelSubscription!]!
-}
-
-interface ChannelSubscription {
-  channels: [Channel!]!
-  enabled: Boolean!
-  id: ID!
-  variant: String
 }
 
 """Graph-level configuration of checks."""
@@ -4416,7 +675,6 @@ input CheckFilterInput {
   status: CheckFilterInputStatusOption
   variants: [String!]
   ids: [String!]
-  includeProposalChecks: Boolean = false
 }
 
 """
@@ -4432,15 +690,12 @@ enum CheckFilterInputStatusOption {
 """The result of performing a subgraph check, including all steps."""
 type CheckPartialSchemaResult {
   """Result of compostion run as part of the overall subgraph check."""
-  compositionValidationResult: CompositionValidationResult!
+  compositionValidationResult: CompositionCheckResult!
 
   """
   Overall result of the check. This will be null if composition validation was unsuccessful.
   """
   checkSchemaResult: CheckSchemaResult
-
-  """Check workflow associated with the overall subgraph check."""
-  workflow: CheckWorkflow
 
   """Whether any modifications were detected in the composed core schema."""
   coreSchemaModified: Boolean!
@@ -4488,36 +743,12 @@ input CheckSchemaAsyncInput {
 
 """The result of running schema checks on a graph variant."""
 type CheckSchemaResult {
-  """The unique ID of this execution of checks."""
-  operationsCheckID: ID!
-
   """The schema diff and affected operations generated by the schema check."""
   diffToPrevious: SchemaDiff!
 
   """The URL to view the schema diff in Studio."""
   targetUrl: String
-
-  """Workflow associated with this check result"""
-  workflow: CheckWorkflow
 }
-
-type CheckStepCompleted {
-  id: ID!
-  status: CheckStepStatus!
-}
-
-type CheckStepFailed {
-  message: String!
-}
-
-input CheckStepInput {
-  graphID: String!
-  graphVariant: String!
-  taskID: ID!
-  workflowID: ID!
-}
-
-union CheckStepResult = CheckStepCompleted | CheckStepFailed | PermissionError | ValidationError
 
 enum CheckStepStatus {
   FAILURE
@@ -4581,50 +812,20 @@ input CheckViolationInput {
 }
 
 type CheckWorkflow {
-  """The supergraph schema provided as the base to check against."""
-  baseSchemaHash: String
-
-  """The base subgraphs provided as the base to check against."""
-  baseSubgraphs: [Subgraph!]
-
   """
   The variant provided as a base to check against. Only the differences from the
   base schema will be tested in operations checks.
   """
   baseVariant: GraphVariant
 
-  """
-  The build task associated with this workflow, or null if no such task was scheduled.
-  """
-  buildTask: BuildCheckTask
-
   """The timestamp when the check workflow completed."""
   completedAt: Timestamp
-
-  """
-  The downstream task associated with this workflow, or null if no such task kind was scheduled.
-  """
-  downstreamTask: DownstreamCheckTask
-
-  """The graph this check workflow belongs to."""
-  graph: Service!
   id: ID!
 
   """
   The name of the implementing service that was responsible for triggering the validation.
   """
   implementingServiceName: String
-
-  """
-  The operations task associated with this workflow, or null if no such task was scheduled.
-  """
-  operationsTask: OperationsCheckTask
-
-  """The proposed supergraph schema being checked by this check workflow."""
-  proposedSchemaHash: String
-
-  """The proposed subgraphs for this check workflow."""
-  proposedSubgraphs: [Subgraph!]
 
   """
   If this check was created by rerunning, the original check workflow that was rerun.
@@ -4640,58 +841,16 @@ type CheckWorkflow {
   """Overall status of the workflow, based on the underlying task statuses."""
   status: CheckWorkflowStatus!
 
-  """The names of the subgraphs with changes that triggered the validation."""
-  subgraphNames: [String!]!
-
   """
   The set of check tasks associated with this workflow, e.g. composition, operations, etc.
   """
   tasks: [CheckWorkflowTask!]!
 
-  """Identity of the user who ran this check"""
-  triggeredBy: Identity
-
-  """
-  The upstream workflow that triggered this workflow, or null if such an upstream workflow does not exist.
-  """
-  upstreamWorkflow: CheckWorkflow
-
-  """
-  If this check came from a proposal, this is the revision that triggered the check.
-  """
-  proposalRevision: ProposalRevision
-
   """
   Contextual parameters supplied by the runtime environment where the check was run.
   """
   gitContext: GitContext
-
-  """Configuration of validation at the time the check was run."""
-  validationConfig: SchemaDiffValidationConfig
   createdAt: Timestamp!
-
-  """Only true if the check was triggered from Sandbox Checks page."""
-  isSandboxCheck: Boolean!
-
-  """Only true if the check was triggered from a proposal update."""
-  isProposalCheck: Boolean!
-
-  """
-  If this check is triggered for an sdl fetched using introspection, this is the endpoint where that schema was being served.
-  """
-  introspectionEndpoint: String
-}
-
-type CheckWorkflowMutation {
-  """The graph this check workflow belongs to."""
-  graph: Service!
-  id: ID!
-
-  """
-  Re-run a check workflow using the current check configuration. The result is either a workflow ID that
-  can be used to check the status or an error message that explains what went wrong.
-  """
-  rerunAsync(input: RerunAsyncInput): CheckRequestResult!
 }
 
 enum CheckWorkflowStatus {
@@ -4759,76 +918,6 @@ input ClientInfoFilter {
   version: String
 }
 
-"""
-Filter options to exclude clients. Used as an output type for SchemaDiffValidationConfig.
-"""
-type ClientInfoFilterOutput {
-  name: String!
-  version: String
-}
-
-"""Cloud queries"""
-type Cloud {
-  """Return all RouterConfigVersions"""
-  configVersions(first: Int, offset: Int): [RouterConfigVersion!]!
-
-  """Return a given RouterConfigVersion"""
-  configVersion(name: String!): RouterConfigVersion
-
-  """Cloud Router constants"""
-  constants: CloudConstants!
-
-  """The regions where a cloud router can be deployed"""
-  regions(provider: CloudProvider!, tier: CloudTier): [RegionDescription!]!
-  order(orderId: String!): Order
-
-  """A list of Cloud Router versions"""
-  versions(input: RouterVersionsInput!): RouterVersionsResult!
-
-  """Information about a specific Cloud Router version"""
-  version(version: String!): RouterVersionResult!
-
-  """Retrieve all routers"""
-  routers(first: Int, offset: Int, statuses: [RouterStatus!]): [Router!]!
-
-  """Return the Cloud Router associated with the provided graphRef"""
-  router(id: ID!): Router
-
-  """Retrieve a Cloud Router by its internal ID"""
-  routerByInternalId(internalId: ID!): Router
-
-  """Return the Shard associated with the provided id"""
-  shard(id: ID!): Shard
-
-  """Return all Shards"""
-  shards(provider: CloudProvider, tier: CloudTier, first: Int, offset: Int): [Shard!]!
-}
-
-"""Constants for Cloud Routers"""
-type CloudConstants {
-  """
-  Minimum duration between last request and auto-pausing a Serverless Cloud Router
-  """
-  durationBeforeSleepSecs: Int!
-
-  """
-  Minimum duration between last request and the auto-pause warning for a Serverless
-  Cloud Router
-  """
-  durationBeforeSleepWarningSecs: Int!
-
-  """
-  Minimum duration between last request and auto-deleting a Serverless Cloud Router
-  """
-  durationBeforeDeleteSecs: Int!
-
-  """
-  Minimum duration between last request and the auto-delete warning for a Serverless
-  Cloud Router
-  """
-  durationBeforeDeleteWarningSecs: Int!
-}
-
 """Invalid input error"""
 type CloudInvalidInputError {
   """Argument related to the error"""
@@ -4839,106 +928,6 @@ type CloudInvalidInputError {
 
   """Reason for the error"""
   reason: String!
-}
-
-"""Cloud mutations"""
-type CloudMutation {
-  """Create a new RouterConfigVersion"""
-  createConfigVersion(input: RouterConfigVersionInput!): RouterVersionConfigResult!
-
-  """Update a RouterConfigVersion"""
-  updateConfigVersion(input: RouterConfigVersionInput!): RouterVersionConfigResult!
-
-  """Create a new Shard"""
-  createShard(input: CreateShardInput!): ShardResult!
-
-  """Update an existing Shard"""
-  updateShard(input: UpdateShardInput!): ShardResult!
-  order(orderId: String!): OrderMutation
-
-  """Create a new router version"""
-  createVersion(version: RouterVersionCreateInput!): CreateRouterVersionResult!
-
-  """Update an existing router version"""
-  updateVersion(version: RouterVersionUpdateInput!): UpdateRouterVersionResult!
-
-  """Fetch a Cloud Router for mutations"""
-  router(id: ID!): RouterMutation
-
-  """Create a new Cloud Router"""
-  createRouter(id: ID!, input: CreateRouterInput!): CreateRouterResult!
-
-  """Destroy an existing Cloud Router"""
-  destroyRouter(id: ID!): DestroyRouterResult!
-
-  """Update an existing Cloud Router"""
-  updateRouter(id: ID!, input: UpdateRouterInput!): UpdateRouterResult!
-}
-
-"""Cloud onboarding information"""
-type CloudOnboarding {
-  """Graph variant reference for Cloud Onboarding"""
-  graphRef: String!
-
-  """Cloud provider for Cloud Onboarding"""
-  provider: CloudProvider!
-
-  """Tier for Cloud Onboarding"""
-  tier: CloudTier!
-
-  """Region for Cloud Onboarding"""
-  region: RegionDescription!
-}
-
-"""Input to create a new Cloud Onboarding"""
-input CloudOnboardingInput {
-  """graph variant name for the onboarding"""
-  graphRef: String!
-
-  """The cloud provider"""
-  provider: CloudProvider!
-
-  """Tier for the Cloud Onboarding"""
-  tier: CloudTier!
-
-  """Region for the Cloud Onboarding"""
-  region: String!
-}
-
-"""List of supported cloud providers"""
-enum CloudProvider {
-  """Amazon Web Services"""
-  AWS
-
-  """Fly.io"""
-  FLY
-}
-
-"""Generic input error"""
-type CloudRouterTestingInvalidInputErrors {
-  errors: [String!]!
-  message: String!
-}
-
-input CloudRouterTestingToolPaginationInput {
-  cursor: Cursor
-  limit: Int
-}
-
-type CloudTesting {
-  routerVersionBuilds(input: RouterVersionBuildsInput!): RouterVersionBuildPageResults!
-  routerVersionBuild(id: ID!): RouterVersionBuildResult
-  testRouter(id: ID!): TestRouter
-}
-
-type CloudTestingMutation {
-  launchTestRouter(input: LaunchTestRouterInput!): LaunchTestRouterResult!
-  deleteAllRouterLaunches: Boolean!
-  deleteTestRouter(id: ID!): DeleteTestRouterResult!
-  buildRouterVersion(input: BuildRouterVersionInput!): BuildRouterVersionResult!
-  cancelRouterVersionBuild(id: ID!): Boolean!
-  cancelAllRouterVersionBuilds: Boolean!
-  deleteAllRouterVersionBuilds: Boolean!
 }
 
 """Cloud Router tiers"""
@@ -4961,32 +950,10 @@ type CloudValidationSuccess {
   message: String!
 }
 
-input CommentFilter {
-  schemaScope: String
-  status: [CommentStatus!]
-  type: [CommentType!]!
-}
-
 enum CommentStatus {
   DELETED
   OPEN
   RESOLVED
-}
-
-enum CommentType {
-  CHANGE
-  GENERAL
-  REVIEW
-}
-
-enum ComparisonOperator {
-  EQUALS
-  GREATER_THAN
-  GREATER_THAN_OR_EQUAL_TO
-  LESS_THAN
-  LESS_THAN_OR_EQUAL_TO
-  NOT_EQUALS
-  UNRECOGNIZED
 }
 
 type ComposeAndFilterPreviewBuildResults {
@@ -5080,10 +1047,7 @@ type ComposeAndFilterPreviewSuccess {
 """
 The result of supergraph composition that Studio performed in response to an attempted deletion of a subgraph.
 """
-type CompositionAndRemoveResult {
-  """The produced composition config. Will be null if there are any errors"""
-  compositionConfig: CompositionConfig
-
+type SubgraphRemovalResult {
   """
   A list of errors that occurred during composition. Errors mean that Apollo was unable to compose the graph variant's subgraphs into a supergraph schema. If any errors are present, gateways / routers are not updated.
   """
@@ -5093,22 +1057,12 @@ type CompositionAndRemoveResult {
   Whether this composition result resulted in a new supergraph schema passed to Uplink (`true`), or the build failed for any reason (`false`). For dry runs, this value is `true` if Uplink _would have_ been updated with the result.
   """
   updatedGateway: Boolean!
-
-  """Whether the removed implementing service existed."""
-  didExist: Boolean!
-
-  """ID that points to the results of composition."""
-  graphCompositionID: String!
-
-  """List of subgraphs that are included in this composition."""
-  subgraphConfigs: [SubgraphConfig!]!
-  createdAt: Timestamp!
 }
 
 """
 The result of supergraph composition that Studio performed in response to an attempted publish of a subgraph.
 """
-type CompositionAndUpsertResult {
+type SubgraphPublicationResult {
   """The generated composition config, or null if any errors occurred."""
   compositionConfig: CompositionConfig
 
@@ -5134,12 +1088,6 @@ type CompositionAndUpsertResult {
   """All subgraphs that were updated from this mutation"""
   subgraphsUpdated: [String!]!
 
-  """ID that points to the results of composition."""
-  graphCompositionID: String!
-
-  """List of subgraphs that are included in this composition."""
-  subgraphConfigs: [SubgraphConfig!]!
-
   """The Launch result part of this subgraph publish."""
   launch: Launch
 
@@ -5152,38 +1100,6 @@ type CompositionAndUpsertResult {
   Human-readable text describing the launch result of the subgraph publish.
   """
   launchCliCopy: String
-  createdAt: Timestamp!
-}
-
-type CompositionBuildCheckFailed implements BuildCheckFailed & BuildCheckResult & CompositionBuildCheckResult {
-  buildInputs: CompositionBuildInputs!
-  buildPipelineTrack: BuildPipelineTrack!
-  compositionPackageVersion: String
-  errors: [BuildError!]!
-  id: ID!
-  passed: Boolean!
-  workflowTask: CompositionCheckTask!
-}
-
-type CompositionBuildCheckPassed implements BuildCheckPassed & BuildCheckResult & CompositionBuildCheckResult {
-  buildInputs: CompositionBuildInputs!
-  buildPipelineTrack: BuildPipelineTrack!
-  compositionPackageVersion: String
-  id: ID!
-  passed: Boolean!
-  supergraphSchemaHash: SHA256!
-  workflowTask: CompositionCheckTask!
-}
-
-interface CompositionBuildCheckResult implements BuildCheckResult {
-  buildInputs: CompositionBuildInputs!
-  buildPipelineTrack: BuildPipelineTrack!
-
-  """The version of the OSS apollo composition package used during build"""
-  compositionPackageVersion: String
-  id: ID!
-  passed: Boolean!
-  workflowTask: CompositionCheckTask!
 }
 
 type CompositionBuildInput {
@@ -5191,33 +1107,7 @@ type CompositionBuildInput {
   version: String
 }
 
-type CompositionBuildInputs {
-  """
-  The build pipeline track used for composition. Note this is also the build pipeline track used
-   for any triggered downstream check workflows as well.
-  """
-  buildPipelineTrack: BuildPipelineTrack!
-
-  """The subgraphs used for composition."""
-  subgraphs: [CompositionBuildInputSubgraph!]!
-}
-
-type CompositionBuildInputSubgraph {
-  """The name of the subgraph."""
-  name: String!
-
-  """The routing URL of the subgraph."""
-  routingUrl: String!
-
-  """The SHA-256 of the schema document of the subgraph."""
-  schemaHash: SHA256!
-}
-
-type CompositionCheckTask implements BuildCheckTask & CheckWorkflowTask {
-  """
-  The result of the composition build check. This will be null when the task is initializing or running.
-  """
-  buildResult: CompositionBuildCheckResult
+type CompositionCheckTask implements CheckWorkflowTask {
   completedAt: Timestamp
 
   """
@@ -5227,9 +1117,7 @@ type CompositionCheckTask implements BuildCheckTask & CheckWorkflowTask {
   """
   coreSchemaModified: Boolean!
   createdAt: Timestamp!
-  graphID: ID!
   id: ID!
-  proposedBuildInputChanges: ProposedCompositionBuildInputChanges!
   status: CheckWorkflowTaskStatus!
   targetURL: String
   workflow: CheckWorkflow!
@@ -5244,11 +1132,6 @@ type CompositionCheckTask implements BuildCheckTask & CheckWorkflowTask {
 """Composition configuration exposed to the gateway."""
 type CompositionConfig {
   """
-  List of GCS links for implementing services that comprise a composed graph. Is empty if tag/inaccessible is enabled.
-  """
-  implementingServiceLocations: [ImplementingServiceLocation!]! @deprecated(reason: "Soon we will stop writing to GCS locations")
-
-  """
   The resulting API schema's SHA256 hash, represented as a hexadecimal string.
   """
   schemaHash: String!
@@ -5262,36 +1145,14 @@ input CompositionConfigInput {
 type CompositionPublishResult implements CompositionResult {
   """The unique ID for this instance of composition."""
   graphCompositionID: ID!
-  graphID: ID!
-
-  """Null if CompositionPublishResult was not on a Proposal Variant"""
-  proposalRevision: ProposalRevision
-
-  """The generated composition config, or null if any errors occurred."""
-  compositionConfig: CompositionConfig
 
   """
   A list of errors that occurred during composition. Errors mean that Apollo was unable to compose the graph variant's subgraphs into a supergraph schema. If any errors are present, gateways / routers are not updated.
   """
   errors: [SchemaCompositionError!]!
 
-  """
-  Whether this composition result updated gateway/router instances via Uplink (`true`), or it was a dry run (`false`).
-  """
-  updatedGateway: Boolean!
-
   """The supergraph SDL generated by composition."""
   supergraphSdl: GraphQLDocument
-
-  """List of subgraphs that are included in this composition."""
-  subgraphConfigs: [SubgraphConfig!]!
-
-  """
-  Cloud router configuration associated with this build event.
-  It will be non-null for any cloud-router variant, and null for any not cloudy variant/graph
-  """
-  routerConfig: String
-  createdAt: Timestamp!
 }
 
 """
@@ -5308,37 +1169,12 @@ interface CompositionResult {
 
   """Supergraph SDL generated by composition."""
   supergraphSdl: GraphQLDocument
-
-  """List of subgraphs included in this composition."""
-  subgraphConfigs: [SubgraphConfig!]!
-
-  """
-  Cloud router configuration associated with this build event.
-  It will be non-null for any cloud-router variant, and null for any not cloudy variant/graph
-  """
-  routerConfig: String
-  createdAt: Timestamp!
-}
-
-type CompositionStatusSubscription implements ChannelSubscription {
-  channels: [Channel!]!
-  createdAt: Timestamp!
-  enabled: Boolean!
-  id: ID!
-  lastUpdatedAt: Timestamp!
-  variant: String
-}
-
-"""The composition config exposed to the gateway"""
-type CompositionValidationDetails {
-  """Hash of the composed schema"""
-  schemaHash: String
 }
 
 """
 The result of composition validation run by Apollo Studio during a subgraph check.
 """
-type CompositionValidationResult implements CompositionResult {
+type CompositionCheckResult implements CompositionResult {
   """The unique ID for this instance of composition."""
   graphCompositionID: ID!
 
@@ -5347,88 +1183,13 @@ type CompositionValidationResult implements CompositionResult {
   """
   errors: [SchemaCompositionError!]!
 
-  """
-  Akin to a composition config, represents the subgraph schemas and corresponding subgraphs that were used
-  in running composition. Will be null if any errors are encountered. Also may contain a schema hash if
-  one could be computed, which can be used for schema validation.
-  """
-  compositionValidationDetails: CompositionValidationDetails
-
-  """
-  DO NOT USE, NOT YET IMPLEMENTED. The subgraphs with changes that were responsible for triggering the validation
-  """
-  proposedSubgraphs: [FederatedImplementingServicePartialSchema!]!
-
-  """
-  The implementing service that was responsible for triggering the validation
-  """
-  proposedImplementingService: FederatedImplementingServicePartialSchema! @deprecated(reason: "The proposed subgraph is now exposed under proposedSubgraphs, a list. If a single subgraph check was run the list will be one subgraph long.")
-
-  """Describes whether composition succeeded."""
-  compositionSuccess: Boolean!
-
   """The supergraph schema document generated by composition."""
   supergraphSdl: GraphQLDocument
-
-  """List of subgraphs that are included in this composition."""
-  subgraphConfigs: [SubgraphConfig!]!
-
-  """If created as part of a check workflow, the associated workflow task."""
-  workflowTask: CompositionCheckTask
-
-  """
-  Cloud router configuration associated with this build event.
-  It will be non-null for any cloud-router variant, and null for any not cloudy variant/graph
-  """
-  routerConfig: String
-  createdAt: Timestamp!
 }
 
 input ContractConfigInput {
   baseGraphRef: String!
   filterConfigInput: FilterConfigInput!
-}
-
-type ContractPreview {
-  result: ContractPreviewResult!
-  upstreamLaunch: Launch!
-}
-
-type ContractPreviewErrors {
-  errors: [String!]!
-  failedAt: ContractVariantFailedStep!
-}
-
-union ContractPreviewResult = ContractPreviewErrors | ContractPreviewSuccess
-
-type ContractPreviewSuccess {
-  apiDocument: String!
-  coreDocument: String!
-  fieldCount: Int!
-  typeCount: Int!
-}
-
-enum ContractVariantFailedStep {
-  ADD_DIRECTIVE_DEFINITIONS_IF_NOT_PRESENT
-  ADD_INACCESSIBLE_SPEC_PURPOSE
-  DIRECTIVE_DEFINITION_LOCATION_AUGMENTING
-  EMPTY_ENUM_MASKING
-  EMPTY_INPUT_OBJECT_MASKING
-  EMPTY_OBJECT_AND_INTERFACE_FIELD_MASKING
-  EMPTY_OBJECT_AND_INTERFACE_MASKING
-  EMPTY_UNION_MASKING
-  INPUT_VALIDATION
-  PARSING
-  PARSING_TAG_DIRECTIVES
-  PARTIAL_INTERFACE_MASKING
-  SCHEMA_RETRIEVAL
-  TAG_INHERITING
-  TAG_MATCHING
-  TO_API_SCHEMA
-  TO_FILTER_SCHEMA
-  UNKNOWN
-  UNREACHABLE_TYPE_MASKING
-  VERSION_CHECK
 }
 
 type ContractVariantUpsertErrors {
@@ -5461,279 +1222,6 @@ type Coordinate {
   line: Int!
 }
 
-type CoordinateInsights {
-  """
-  If the first or last seen timestamps are earlier than this timestamp, we can't tell the exact date that we saw this coordinate since our data is bound by the retention period.
-  """
-  earliestRetentionTime: Timestamp
-
-  """
-  The earliest time we saw references or executions for this coordinate. Null if the coordinate has never been seen or it is not in the schema.
-  """
-  firstSeen: Timestamp
-
-  """
-  The most recent time we saw references or executions for this coordinate. Null if the coordinate has never been seen or it is not in the schema.
-  """
-  lastSeen: Timestamp
-}
-
-input CoordinateInsightsListFilterInInput {
-  clientName: [String]
-  clientVersion: [String]
-}
-
-input CoordinateInsightsListFilterInput {
-  clientName: String
-  clientVersion: String
-  coordinateKind: CoordinateKind
-  in: CoordinateInsightsListFilterInInput
-  isDeprecated: Boolean
-  isUnused: Boolean
-  or: [CoordinateInsightsListFilterInput!]
-
-  """Filters on partial string matches of Named Type and Named Attribute"""
-  search: String
-}
-
-type CoordinateInsightsListItem {
-  """
-  The estimated number of field executions for this field, based on the field execution sample rate. This can be null depending on the sort order.
-  """
-  estimatedExecutionCount: Long
-
-  """
-  The number of field executions recorded for this field. This can be null depending on the sort order.
-  """
-  executionCount: Long
-  isDeprecated: Boolean!
-  isUnused: Boolean!
-  namedAttribute: String!
-  namedType: String!
-
-  """
-  The count of operations that reference the coordinate. This can be null depending on the sort order.
-  """
-  referencingOperationCount: Long
-
-  """
-  The count of operations that reference the coordinate per minute. This can be null depending on the sort order.
-  """
-  referencingOperationCountPerMin: Float
-}
-
-enum CoordinateInsightsListOrderByColumn {
-  ESTIMATED_EXECUTION_COUNT
-  EXECUTION_COUNT
-  REFERENCING_OPERATION_COUNT
-  REFERENCING_OPERATION_COUNT_PER_MIN
-  SCHEMA_COORDINATE
-}
-
-input CoordinateInsightsListOrderByInput {
-  column: CoordinateInsightsListOrderByColumn!
-  direction: Ordering!
-}
-
-"""Information about pagination in a connection."""
-type CoordinateInsightsListPageInfo {
-  """When paginating forwards, the cursor to continue."""
-  endCursor: String
-
-  """When paginating backwards, the cursor to continue."""
-  startCursor: String
-}
-
-enum CoordinateKind {
-  ENUM_VALUE
-  INPUT_OBJECT_FIELD
-  OBJECT_FIELD
-}
-
-"""Columns of CoordinateUsage."""
-enum CoordinateUsageColumn {
-  CLIENT_NAME
-  CLIENT_VERSION
-  ESTIMATED_EXECUTION_COUNT
-  EXECUTION_COUNT
-  KIND
-  NAMED_ATTRIBUTE
-  NAMED_TYPE
-  OPERATION_SUBTYPE
-  OPERATION_TYPE
-  QUERY_ID
-  QUERY_NAME
-  REFERENCING_OPERATION_COUNT
-  REQUEST_COUNT_NULL
-  REQUEST_COUNT_UNDEFINED
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-}
-
-type CoordinateUsageDimensions {
-  clientName: String
-  clientVersion: String
-  kind: String
-  namedAttribute: String
-  namedType: String
-  operationSubtype: String
-  operationType: String
-  queryId: String
-  queryName: String
-  schemaTag: String
-  serviceId: ID
-}
-
-"""
-Filter for data in CoordinateUsage. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input CoordinateUsageFilter {
-  and: [CoordinateUsageFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-  in: CoordinateUsageFilterIn
-
-  """
-  Selects rows whose kind dimension equals the given value if not null. To query for the null value, use {in: {kind: [null]}} instead.
-  """
-  kind: String
-
-  """
-  Selects rows whose namedAttribute dimension equals the given value if not null. To query for the null value, use {in: {namedAttribute: [null]}} instead.
-  """
-  namedAttribute: String
-
-  """
-  Selects rows whose namedType dimension equals the given value if not null. To query for the null value, use {in: {namedType: [null]}} instead.
-  """
-  namedType: String
-  not: CoordinateUsageFilter
-
-  """
-  Selects rows whose operationSubtype dimension equals the given value if not null. To query for the null value, use {in: {operationSubtype: [null]}} instead.
-  """
-  operationSubtype: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [CoordinateUsageFilter!]
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: String
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-}
-
-"""
-Filter for data in CoordinateUsage. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input CoordinateUsageFilterIn {
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose kind dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  kind: [String]
-
-  """
-  Selects rows whose namedAttribute dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  namedAttribute: [String]
-
-  """
-  Selects rows whose namedType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  namedType: [String]
-
-  """
-  Selects rows whose operationSubtype dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationSubtype: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [String]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-}
-
-type CoordinateUsageMetrics {
-  estimatedExecutionCount: Long!
-  executionCount: Long!
-  referencingOperationCount: Long!
-  requestCountNull: Long!
-  requestCountUndefined: Long!
-}
-
-input CoordinateUsageOrderBySpec {
-  column: CoordinateUsageColumn!
-  direction: Ordering!
-}
-
-type CoordinateUsageRecord {
-  """Dimensions of CoordinateUsage that can be grouped by."""
-  groupBy: CoordinateUsageDimensions!
-
-  """Metrics of CoordinateUsage that can be aggregated over."""
-  metrics: CoordinateUsageMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
 """Contains the supergraph and API schemas generated by composition."""
 type CoreSchema {
   """The composed API schema document."""
@@ -5751,31 +1239,6 @@ type CoreSchema {
   The supergraph schema document's SHA256 hash, represented as a hexadecimal string.
   """
   coreHash: String!
-  fieldCount: Int!
-  tags: [String!]!
-  typeCount: Int!
-}
-
-"""Input to create a new AWS shard"""
-input CreateAwsShardInput {
-  region: String!
-  accountId: String!
-  iamRoleArn: String!
-  loadbalancers: [AwsLoadBalancerInput!]!
-  loadbalancerSecurityGroupId: String!
-  ecsClusterArn: String!
-  vpcId: String!
-  subnetIds: [String!]!
-  permissionsBoundaryArn: String!
-  coldStartTargetGroupArns: [String!]
-}
-
-"""Result from the createCloudOnboarding mutation"""
-union CreateOnboardingResult = CreateOnboardingSuccess | InvalidInputErrors | InternalServerError
-
-"""Success creating a CloudOnboarding"""
-type CreateOnboardingSuccess {
-  onboarding: CloudOnboarding!
 }
 
 union CreateOperationCollectionResult = NotFoundError | OperationCollection | PermissionError | ValidationError
@@ -5804,98 +1267,7 @@ input CreateProposalInput {
   sourceVariantName: String!
 }
 
-input CreateProposalLifecycleSubscriptionInput {
-  events: [ProposalLifecycleEvent!]!
-  webhookChannelID: ID!
-}
-
-union CreateProposalLifecycleSubscriptionResult = PermissionError | ProposalLifecycleSubscription | ValidationError
-
 union CreateProposalResult = CreateProposalError | GraphVariant | PermissionError | ValidationError
-
-"""Input to create a new Cloud Router"""
-input CreateRouterInput {
-  """Router version for the Cloud Router"""
-  routerVersion: String
-
-  """Configuration for the Cloud Router"""
-  routerConfig: String
-
-  """Graph composition ID, also known as launch ID"""
-  graphCompositionId: String
-
-  """
-  Number of GCUs allocated for the Cloud Router
-  
-  This is ignored for serverless Cloud Routers
-  """
-  gcus: Int
-
-  """Unique identifier for ordering orders"""
-  orderingId: String!
-}
-
-"""Represents the possible outcomes of a createRouter mutation"""
-union CreateRouterResult = CreateRouterSuccess | InvalidInputErrors | InternalServerError
-
-"""
-Success branch of a createRouter mutation
-
-id of the order can be polled
-via Query.cloud().order(id: ID!) to check-in on the progress
-of the underlying operation
-"""
-type CreateRouterSuccess {
-  order: Order!
-}
-
-"""Result of a createVersion mutation"""
-union CreateRouterVersionResult = RouterVersion | InvalidInputErrors | InternalServerError
-
-input CreateRuleEnforcementInput {
-  graphVariant: String
-  params: [StringToStringInput!]
-  policy: EnforcementPolicy!
-}
-
-"""Input to create a new Shard"""
-input CreateShardInput {
-  shardId: String!
-  gcuCapacity: Int
-  gcuUsage: Int
-  routerCapacity: Int
-  routerUsage: Int
-  provider: CloudProvider!
-  tier: CloudTier!
-  status: ShardStatus
-  reason: String
-  aws: CreateAwsShardInput
-}
-
-type CreditGrant {
-  expiresAt: Timestamp
-  remainingCreditsInUsdCents: Int!
-  totalCreditsInUsdCents: Int!
-}
-
-type CronExecution {
-  completedAt: Timestamp
-  failure: String
-  id: ID!
-  job: CronJob!
-  resolvedAt: Timestamp
-  resolvedBy: Actor
-  schedule: String!
-  startedAt: Timestamp!
-}
-
-type CronJob {
-  group: String!
-  name: String!
-  recentExecutions(n: Int): [CronExecution!]!
-}
-
-scalar Cursor
 
 input CustomCheckCallbackInput {
   """
@@ -5977,26 +1349,6 @@ type CustomCheckWebhookChannel {
   variant: String
 }
 
-enum DatadogApiRegion {
-  EU
-  EU1
-  US
-  US1
-  US1FED
-  US3
-  US5
-}
-
-type DatadogMetricsConfig {
-  apiKey: String!
-  apiRegion: DatadogApiRegion!
-  enabled: Boolean!
-  legacyMetricNames: Boolean!
-}
-
-"""ISO 8601 date format, e.g. 'yyyy-MM-dd'"""
-scalar Date
-
 """
 Implement the DateTime<Utc> scalar
 
@@ -6005,18 +1357,6 @@ The input/output is a string in RFC3339 format.
 scalar DateTime
   @specifiedBy(url: "https://datatracker.ietf.org/doc/html/rfc3339")
 
-input DeleteCommentInput {
-  id: String!
-}
-
-union DeleteCommentResult = DeleteCommentSuccess | NotFoundError | PermissionError | ValidationError
-
-type DeleteCommentSuccess {
-  comment: DeleteCommentSuccessResult
-}
-
-union DeleteCommentSuccessResult = ParentChangeProposalComment | ParentGeneralProposalComment
-
 union DeleteOperationCollectionResult = DeleteOperationCollectionSuccess | PermissionError
 
 type DeleteOperationCollectionSuccess {
@@ -6024,89 +1364,18 @@ type DeleteOperationCollectionSuccess {
   variants: [GraphVariant!]!
 }
 
-"""
-The result of a successful call to PersistedQueryListMutation.deleteOperationsByFilter.
-"""
-type DeleteOperationsByFilterResult {
-  """The build created by this delete operation."""
-  build: PersistedQueryListBuild
-
-  """
-  Returns `true` if no changes were made by this operation (and no new revision was created). Otherwise, returns `false`.
-  """
-  unchanged: Boolean!
-}
-
-"""
-The result/error union returned by PersistedQueryListMutation.deleteOperationsByFilter.
-"""
-union DeleteOperationsByFilterResultOrError = DeleteOperationsByFilterResult | PermissionError
-
 """The result of a successful call to PersistedQueryListMutation.delete."""
 type DeletePersistedQueryListResult {
-  graph: Service!
+  graph: Graph!
 }
 
 """The result/error union returned by PersistedQueryListMutation.delete."""
 union DeletePersistedQueryListResultOrError = CannotDeleteLinkedPersistedQueryListError | DeletePersistedQueryListResult | PermissionError
 
-input DeleteProposalLifecycleSubscriptionInput {
-  id: String!
-}
-
-union DeleteProposalLifecycleSubscriptionResult = DeleteProposalLifecycleSubscriptionSuccess | NotFoundError | PermissionError
-
-type DeleteProposalLifecycleSubscriptionSuccess {
-  """The id of the ProposalLifecycleSubscription that was deleted"""
-  id: ID!
-}
-
-input DeleteProposalSubgraphInput {
-  previousLaunchId: ID
-  subgraphName: String!
-  summary: String!
-}
-
-union DeleteProposalSubgraphResult = PermissionError | Proposal | ValidationError
-
 """The result of attempting to delete a graph variant."""
-type DeleteSchemaTagResult {
+type GraphVariantDeletionResult {
   """Whether the variant was deleted or not."""
   deleted: Boolean!
-}
-
-union DeleteTestRouterResult = DeleteTestRouterSuccess | CloudRouterTestingInvalidInputErrors
-
-type DeleteTestRouterSuccess {
-  jobId: String!
-}
-
-enum DeletionTargetType {
-  ACCOUNT
-  USER
-}
-
-"""Represents the possible outcomes of a destroyRouter mutation"""
-union DestroyRouterResult = DestroyRouterSuccess | InvalidInputErrors | InternalServerError
-
-"""Success branch of a destroyRouter mutation"""
-type DestroyRouterSuccess {
-  """
-  Order for the destroyRouter mutation
-  
-  This could be empty if the router is already destroyed or doesn't exist, but should still
-  be treated as a success.
-  """
-  order: Order
-}
-
-"""Support for a single directive on a graph variant"""
-type DirectiveSupportStatus {
-  """whether the directive is supported on the current graph variant"""
-  enabled: Boolean!
-
-  """name of the directive"""
-  name: String!
 }
 
 """
@@ -6174,564 +1443,9 @@ enum DownstreamLaunchInitiation {
   SYNC
 }
 
-type DraftInvoice {
-  billingPeriodEndsAt: Timestamp! @deprecated(reason: "This data came from Metronome and we no longer use Metronome")
-  billingPeriodStartsAt: Timestamp! @deprecated(reason: "This data came from Metronome and we no longer use Metronome")
-
-  """
-  The approximate date in the future we expect the customer to be billed if they fully complete the billing cycle
-  """
-  expectedInvoiceAt: Timestamp! @deprecated(reason: "This data came from Metronome and we no longer use Metronome")
-
-  """When this invoice was sent to the customer, if it's been sent"""
-  invoicedAt: Timestamp @deprecated(reason: "This data came from Metronome and we no longer use Metronome")
-
-  """
-  Breakdown of this invoice's charges. May be empty if we don't have a breakdown
-  """
-  lineItems: [InvoiceLineItem!] @deprecated(reason: "This data came from Metronome and we no longer use Metronome")
-  subtotalInCents: Int! @deprecated(reason: "This data came from Metronome and we no longer use Metronome")
-  totalInCents: Int! @deprecated(reason: "This data came from Metronome and we no longer use Metronome")
-}
-
-union DuplicateOperationCollectionResult = OperationCollection | PermissionError | ValidationError
-
-type DurationHistogram {
-  averageDurationMs: Float
-  buckets: [DurationHistogramBucket!]!
-  durationMs(
-    """Percentile (between 0 and 1)"""
-    percentile: Float!
-  ): Float
-
-  """
-  Counts per durationBucket, where sequences of zeroes are replaced with the negative of their size
-  """
-  sparseBuckets: [Long!]!
-  totalCount: Long!
-  totalDurationMs: Float!
-}
-
-type DurationHistogramBucket {
-  count: Long!
-  index: Int!
-  rangeBeginMs: Float!
-  rangeEndMs: Float!
-}
-
-input EdgeServerInfo {
-  """
-  A randomly generated UUID, immutable for the lifetime of the edge server runtime.
-  """
-  bootId: String!
-
-  """
-  A unique identifier for the executable GraphQL served by the edge server. length must be <= 64 characters.
-  """
-  executableSchemaId: String!
-
-  """The graph variant, defaults to 'current'"""
-  graphVariant: String! = "current"
-
-  """
-  The version of the edge server reporting agent, e.g. apollo-server-2.8, graphql-java-3.1, etc. length must be <= 256 characters.
-  """
-  libraryVersion: String
-
-  """
-  The infra environment in which this edge server is running, e.g. localhost, Kubernetes, AWS Lambda, Google CloudRun, AWS ECS, etc. length must be <= 256 characters.
-  """
-  platform: String
-
-  """
-  The runtime in which the edge server is running, e.g. node 12.03, zulu8.46.0.19-ca-jdk8.0.252-macosx_x64, etc. length must be <= 256 characters.
-  """
-  runtimeVersion: String
-
-  """
-  If available, an identifier for the edge server instance, such that when restarting this instance it will have the same serverId, with a different bootId. For example, in Kubernetes this might be the pod name. Length must be <= 256 characters.
-  """
-  serverId: String
-
-  """
-  An identifier used to distinguish the version (from the user's perspective) of the edge server's code itself. For instance, the git sha of the server's repository or the docker sha of the associated image this server runs with. Length must be <= 256 characters.
-  """
-  userVersion: String
-}
-
-"""Columns of EdgeServerInfos."""
-enum EdgeServerInfosColumn {
-  BOOT_ID
-  EXECUTABLE_SCHEMA_ID
-  LIBRARY_VERSION
-  PLATFORM
-  RUNTIME_VERSION
-  SCHEMA_TAG
-  SERVER_ID
-  SERVICE_ID
-  TIMESTAMP
-  USER_VERSION
-}
-
-type EdgeServerInfosDimensions {
-  bootId: ID
-  executableSchemaId: ID
-  libraryVersion: String
-  platform: String
-  runtimeVersion: String
-  schemaTag: String
-  serverId: ID
-  serviceId: ID
-  userVersion: String
-}
-
-"""
-Filter for data in EdgeServerInfos. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input EdgeServerInfosFilter {
-  and: [EdgeServerInfosFilter!]
-
-  """
-  Selects rows whose bootId dimension equals the given value if not null. To query for the null value, use {in: {bootId: [null]}} instead.
-  """
-  bootId: ID
-
-  """
-  Selects rows whose executableSchemaId dimension equals the given value if not null. To query for the null value, use {in: {executableSchemaId: [null]}} instead.
-  """
-  executableSchemaId: ID
-  in: EdgeServerInfosFilterIn
-
-  """
-  Selects rows whose libraryVersion dimension equals the given value if not null. To query for the null value, use {in: {libraryVersion: [null]}} instead.
-  """
-  libraryVersion: String
-  not: EdgeServerInfosFilter
-  or: [EdgeServerInfosFilter!]
-
-  """
-  Selects rows whose platform dimension equals the given value if not null. To query for the null value, use {in: {platform: [null]}} instead.
-  """
-  platform: String
-
-  """
-  Selects rows whose runtimeVersion dimension equals the given value if not null. To query for the null value, use {in: {runtimeVersion: [null]}} instead.
-  """
-  runtimeVersion: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serverId dimension equals the given value if not null. To query for the null value, use {in: {serverId: [null]}} instead.
-  """
-  serverId: ID
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-
-  """
-  Selects rows whose userVersion dimension equals the given value if not null. To query for the null value, use {in: {userVersion: [null]}} instead.
-  """
-  userVersion: String
-}
-
-"""
-Filter for data in EdgeServerInfos. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input EdgeServerInfosFilterIn {
-  """
-  Selects rows whose bootId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  bootId: [ID]
-
-  """
-  Selects rows whose executableSchemaId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  executableSchemaId: [ID]
-
-  """
-  Selects rows whose libraryVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  libraryVersion: [String]
-
-  """
-  Selects rows whose platform dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  platform: [String]
-
-  """
-  Selects rows whose runtimeVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  runtimeVersion: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serverId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serverId: [ID]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-
-  """
-  Selects rows whose userVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  userVersion: [String]
-}
-
-input EdgeServerInfosOrderBySpec {
-  column: EdgeServerInfosColumn!
-  direction: Ordering!
-}
-
-type EdgeServerInfosRecord {
-  """Dimensions of EdgeServerInfos that can be grouped by."""
-  groupBy: EdgeServerInfosDimensions!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-input EditCommentInput {
-  id: String!
-  message: String!
-  usersToNotify: [String!]
-}
-
-union EditCommentResult = NotFoundError | ParentChangeProposalComment | ParentGeneralProposalComment | PermissionError | ReplyChangeProposalComment | ReplyGeneralProposalComment | ValidationError
-
-type Education {
-  recentPages(limit: Int): [RecentPage!]!
-}
-
-enum EmailCategory {
-  EDUCATIONAL
-}
-
-type EmailPreferences {
-  email: String!
-  subscriptions: [EmailCategory!]!
-  unsubscribedFromAll: Boolean!
-}
-
-union EndUsageBasedPlanResult = Account | NotFoundError | PermissionError | ValidationError
-
-enum EnforcementPolicy {
-  CLIENT_NAME_CARDINALITY
-  CLIENT_VERSION_CARDINALITY
-  OPERATION_ID_CARDINALITY
-}
-
-type EntitiesError {
-  message: String!
-}
-
-type EntitiesErrorResponse {
-  errors: [EntitiesError!]!
-}
-
-type EntitiesResponse {
-  entities: [Entity!]!
-}
-
-union EntitiesResponseOrError = EntitiesResponse | EntitiesErrorResponse
-
-type Entity {
-  typename: String!
-  subgraphKeys: [SubgraphKeyMap!]
-}
-
 """GraphQL Error"""
 interface Error {
   message: String!
-}
-
-input ErrorInsightsListFilterInInput {
-  agent: [String]
-  clientName: [String]
-  clientVersion: [String]
-  code: [String]
-  service: [String]
-  serviceOrAgent: [String]
-}
-
-input ErrorInsightsListFilterInput {
-  agent: String
-  clientName: String
-  clientVersion: String
-  code: String
-  in: ErrorInsightsListFilterInInput
-  operationId: String
-  or: [ErrorInsightsListFilterInput!]
-  path: String
-  service: String
-  serviceOrAgent: String
-}
-
-enum ErrorInsightsListGroupByColumn {
-  AGENT
-  CLIENT_NAME
-  CLIENT_VERSION
-  CODE
-  OPERATION_ID
-  OPERATION_NAME
-  PATH
-  SERVICE
-  SERVICE_OR_AGENT
-  SEVERITY
-}
-
-type ErrorInsightsListItem {
-  agent: String
-  clientName: String
-  clientVersion: String
-  code: String
-  count: Long! @deprecated(reason: "Use errorCount instead")
-  errorCount: Long!
-  operationCount: Long
-  operationId: String
-  operationName: String
-  path: String
-  service: String
-  serviceOrAgent: String
-  severity: ErrorInsightsSeverity
-  traceRefs(limit: Int! = 3): ErrorTraceRefsResult
-}
-
-enum ErrorInsightsListOrderByColumn {
-  AGENT
-  CLIENT_NAME
-  CLIENT_VERSION
-  CODE
-  COUNT
-  OPERATION_ID
-  OPERATION_NAME
-  PATH
-  SERVICE_OR_AGENT
-  SEVERITY
-  TIMESTAMP
-}
-
-input ErrorInsightsListOrderByInput {
-  column: ErrorInsightsListOrderByColumn!
-  direction: Ordering!
-}
-
-"""Information about pagination in a connection."""
-type ErrorInsightsListPageInfo {
-  """When paginating forwards, the cursor to continue."""
-  endCursor: String
-
-  """When paginating backwards, the cursor to continue."""
-  startCursor: String
-}
-
-enum ErrorInsightsSeverity {
-  ERROR
-  UNKNOWN
-  WARN
-}
-
-enum ErrorInsightsStrategy {
-  ERROR_STATS
-  FEDERATED_ERROR_STATS
-  MIXED
-}
-
-type ErrorInsightsTimeseriesRecord {
-  data: ErrorInsightsListItem!
-  strategy: ErrorInsightsStrategy!
-  timestamp: Timestamp!
-}
-
-type ErrorInsightsTimeseriesResult {
-  records: [ErrorInsightsTimeseriesRecord!]!
-  roundedDownFrom: Timestamp!
-  roundedUpTo: Timestamp!
-  totalErrors: Int!
-}
-
-"""Columns of ErrorStats."""
-enum ErrorStatsColumn {
-  ACCOUNT_ID
-  CLIENT_NAME
-  CLIENT_VERSION
-  ERRORS_COUNT
-  PATH
-  QUERY_ID
-  QUERY_NAME
-  REQUESTS_WITH_ERRORS_COUNT
-  SCHEMA_HASH
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-}
-
-type ErrorStatsDimensions {
-  accountId: ID
-  clientName: String
-  clientVersion: String
-  path: String
-  queryId: ID
-  queryName: String
-  schemaHash: String
-  schemaTag: String
-  serviceId: ID
-}
-
-"""
-Filter for data in ErrorStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input ErrorStatsFilter {
-  """
-  Selects rows whose accountId dimension equals the given value if not null. To query for the null value, use {in: {accountId: [null]}} instead.
-  """
-  accountId: ID
-  and: [ErrorStatsFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-  in: ErrorStatsFilterIn
-  not: ErrorStatsFilter
-  or: [ErrorStatsFilter!]
-
-  """
-  Selects rows whose path dimension equals the given value if not null. To query for the null value, use {in: {path: [null]}} instead.
-  """
-  path: String
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: ID
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead.
-  """
-  schemaHash: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-}
-
-"""
-Filter for data in ErrorStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input ErrorStatsFilterIn {
-  """
-  Selects rows whose accountId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  accountId: [ID]
-
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  path: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [ID]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaHash: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-}
-
-type ErrorStatsMetrics {
-  errorsCount: Long!
-  requestsWithErrorsCount: Long!
-}
-
-input ErrorStatsOrderBySpec {
-  column: ErrorStatsColumn!
-  direction: Ordering!
-}
-
-type ErrorStatsRecord {
-  """Dimensions of ErrorStats that can be grouped by."""
-  groupBy: ErrorStatsDimensions!
-
-  """Metrics of ErrorStats that can be aggregated over."""
-  metrics: ErrorStatsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-type ErrorTraceRef {
-  errorMessage: String
-  operationId: String!
-  timestamp: Timestamp!
-  traceId: String!
-}
-
-type ErrorTraceRefsResult {
-  items: [ErrorTraceRef!]!
-  totalCount: Int!
-}
-
-""" Input parameters for run explorer operation event."""
-enum EventEnum {
-  CLICK_CHECK_LIST
-  CLICK_GO_TO_GRAPH_SETTINGS
-  RUN_EXPLORER_OPERATION
 }
 
 """Excluded operation for a graph."""
@@ -6746,222 +1460,10 @@ input ExcludedOperationInput {
   ID: ID!
 }
 
-type ExtendedRefsUsage {
-  """
-  The first time usage of this feature was reported for this variant to Apollo by the Router, or null if such usage has never been reported.
-  """
-  firstSeenAt: Timestamp
-
-  """
-  The last time usage of this feature was reported for this variant to Apollo by the Router, or null if such usage has never been reported.
-  """
-  lastSeenAt: Timestamp
-}
-
-type FeatureIntros {
-  devGraph: Boolean! @deprecated(reason: "No longer supported")
-  federatedGraph: Boolean!
-  freeConsumerSeats: Boolean!
-}
-
-"""Feature Intros Input Type"""
-input FeatureIntrosInput {
-  devGraph: Boolean @deprecated(reason: "No longer supported")
-  federatedGraph: Boolean
-  freeConsumerSeats: Boolean
-}
-
-"""Columns of FederatedErrorStats."""
-enum FederatedErrorStatsColumn {
-  AGENT_VERSION
-  CLIENT_NAME
-  CLIENT_VERSION
-  ERROR_CODE
-  ERROR_COUNT
-  ERROR_PATH
-  ERROR_SERVICE
-  OPERATION_ID
-  OPERATION_NAME
-  OPERATION_TYPE
-  SCHEMA_TAG
-  SERVICE_ID
-  SEVERITY
-  TIMESTAMP
-}
-
-type FederatedErrorStatsDimensions {
-  agentVersion: String
-  clientName: String
-  clientVersion: String
-  errorCode: String
-  errorPath: String
-  errorService: String
-  operationId: String
-  operationName: String
-  operationType: String
-  schemaTag: String
-  serviceId: ID
-  severity: String
-}
-
-"""
-Filter for data in FederatedErrorStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input FederatedErrorStatsFilter {
-  """
-  Selects rows whose agentVersion dimension equals the given value if not null. To query for the null value, use {in: {agentVersion: [null]}} instead.
-  """
-  agentVersion: String
-  and: [FederatedErrorStatsFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-
-  """
-  Selects rows whose errorCode dimension equals the given value if not null. To query for the null value, use {in: {errorCode: [null]}} instead.
-  """
-  errorCode: String
-
-  """
-  Selects rows whose errorPath dimension equals the given value if not null. To query for the null value, use {in: {errorPath: [null]}} instead.
-  """
-  errorPath: String
-
-  """
-  Selects rows whose errorService dimension equals the given value if not null. To query for the null value, use {in: {errorService: [null]}} instead.
-  """
-  errorService: String
-  in: FederatedErrorStatsFilterIn
-  not: FederatedErrorStatsFilter
-
-  """
-  Selects rows whose operationId dimension equals the given value if not null. To query for the null value, use {in: {operationId: [null]}} instead.
-  """
-  operationId: String
-
-  """
-  Selects rows whose operationName dimension equals the given value if not null. To query for the null value, use {in: {operationName: [null]}} instead.
-  """
-  operationName: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [FederatedErrorStatsFilter!]
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-
-  """
-  Selects rows whose severity dimension equals the given value if not null. To query for the null value, use {in: {severity: [null]}} instead.
-  """
-  severity: String
-}
-
-"""
-Filter for data in FederatedErrorStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input FederatedErrorStatsFilterIn {
-  """
-  Selects rows whose agentVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  agentVersion: [String]
-
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose errorCode dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  errorCode: [String]
-
-  """
-  Selects rows whose errorPath dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  errorPath: [String]
-
-  """
-  Selects rows whose errorService dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  errorService: [String]
-
-  """
-  Selects rows whose operationId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationId: [String]
-
-  """
-  Selects rows whose operationName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationName: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-
-  """
-  Selects rows whose severity dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  severity: [String]
-}
-
-type FederatedErrorStatsMetrics {
-  errorCount: Long!
-}
-
-input FederatedErrorStatsOrderBySpec {
-  column: FederatedErrorStatsColumn!
-  direction: Ordering!
-}
-
-type FederatedErrorStatsRecord {
-  """Dimensions of FederatedErrorStats that can be grouped by."""
-  groupBy: FederatedErrorStatsDimensions!
-
-  """Metrics of FederatedErrorStats that can be aggregated over."""
-  metrics: FederatedErrorStatsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
 """
 A single subgraph in a supergraph. Every supergraph managed by Apollo Studio includes at least one subgraph. See https://www.apollographql.com/docs/federation/managed-federation/overview/ for more information.
 """
-type FederatedImplementingService {
+type GraphVariantSubgraph {
   """The subgraph's name."""
   name: String!
 
@@ -6982,7 +1484,7 @@ type FederatedImplementingService {
   """
   The subgraph's current active schema, used in supergraph composition for the the associated variant.
   """
-  activePartialSchema: PartialSchema!
+  activePartialSchema: SubgraphSchema!
 
   """The timestamp when the subgraph was created."""
   createdAt: Timestamp!
@@ -6996,25 +1498,11 @@ type FederatedImplementingService {
   updatedAt: Timestamp!
 }
 
-"""
-A minimal representation of a federated implementing service, using only a name and partial schema SDL
-"""
-type FederatedImplementingServicePartialSchema {
-  """The name of the implementing service"""
-  name: String!
-
-  """The partial schema of the implementing service"""
-  sdl: String!
-}
-
 """Container for a list of subgraphs composing a supergraph."""
-type FederatedImplementingServices {
+type GraphVariantSubgraphs {
   """The list of underlying subgraphs."""
-  services: [FederatedImplementingService!]!
+  services: [GraphVariantSubgraph!]!
 }
-
-"""The Federation Version of a Supergraph."""
-scalar FederationVersion
 
 """
 Counts of changes at the field level, including objects, interfaces, and input fields.
@@ -7036,515 +1524,6 @@ type FieldChangeSummaryCounts {
   field changes.
   """
   edits: Int!
-}
-
-"""Columns of FieldExecutions."""
-enum FieldExecutionsColumn {
-  ERRORS_COUNT
-  ESTIMATED_EXECUTION_COUNT
-  FIELD_NAME
-  OBSERVED_EXECUTION_COUNT
-  PARENT_TYPE
-  REFERENCING_OPERATION_COUNT
-  REQUESTS_WITH_ERRORS_COUNT
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-}
-
-type FieldExecutionsDimensions {
-  fieldName: String
-  parentType: String
-  schemaTag: String
-  serviceId: ID
-}
-
-"""
-Filter for data in FieldExecutions. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input FieldExecutionsFilter {
-  and: [FieldExecutionsFilter!]
-
-  """
-  Selects rows whose fieldName dimension equals the given value if not null. To query for the null value, use {in: {fieldName: [null]}} instead.
-  """
-  fieldName: String
-  in: FieldExecutionsFilterIn
-  not: FieldExecutionsFilter
-  or: [FieldExecutionsFilter!]
-
-  """
-  Selects rows whose parentType dimension equals the given value if not null. To query for the null value, use {in: {parentType: [null]}} instead.
-  """
-  parentType: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-}
-
-"""
-Filter for data in FieldExecutions. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input FieldExecutionsFilterIn {
-  """
-  Selects rows whose fieldName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  fieldName: [String]
-
-  """
-  Selects rows whose parentType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  parentType: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-}
-
-type FieldExecutionsMetrics {
-  errorsCount: Long!
-  estimatedExecutionCount: Long!
-  observedExecutionCount: Long!
-  referencingOperationCount: Long!
-  requestsWithErrorsCount: Long!
-}
-
-input FieldExecutionsOrderBySpec {
-  column: FieldExecutionsColumn!
-  direction: Ordering!
-}
-
-type FieldExecutionsRecord {
-  """Dimensions of FieldExecutions that can be grouped by."""
-  groupBy: FieldExecutionsDimensions!
-
-  """Metrics of FieldExecutions that can be aggregated over."""
-  metrics: FieldExecutionsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-type FieldInsights {
-  """
-  If the first or last seen timestamps are earlier than this timestamp, we can't tell the exact date that we saw this field since our data is bound by the retention period.
-  """
-  earliestRetentionTime: Timestamp
-
-  """
-  The earliest time we saw references or executions for this field. Null if the field has never been seen or it is not in the schema.
-  """
-  firstSeen: Timestamp
-
-  """
-  The most recent time we saw references or executions for this field. Null if the field has never been seen or it is not in the schema.
-  """
-  lastSeen: Timestamp
-}
-
-input FieldInsightsListFilterInInput {
-  clientName: [String]
-  clientVersion: [String]
-}
-
-input FieldInsightsListFilterInput {
-  clientName: String
-  clientVersion: String
-  in: FieldInsightsListFilterInInput
-  isDeprecated: Boolean
-  isUnused: Boolean
-  or: [FieldInsightsListFilterInput!]
-
-  """Filters on partial string matches of Parent Type and Field Name"""
-  search: String
-}
-
-type FieldInsightsListItem {
-  """
-  The count of errors seen for this field. This can be null depending on the sort order.
-  """
-  errorCount: Long
-
-  """
-  The count of errors seen for this field per minute. This can be null depending on the sort order.
-  """
-  errorCountPerMin: Float
-
-  """
-  The percentage of errors vs successful resolutions for this field. This can be null depending on the sort order.
-  """
-  errorPercentage: Float
-
-  """
-  The estimated number of field executions for this field, based on the field execution sample rate. This can be null depending on the sort order.
-  """
-  estimatedExecutionCount: Long
-
-  """
-  The number of field executions recorded for this field. This can be null depending on the sort order.
-  """
-  executionCount: Long
-  fieldName: String!
-  isDeprecated: Boolean!
-  isUnused: Boolean!
-
-  """
-  The p50 of the latency of the resolution of this field. This can be null depending on the filter and sort order.
-  """
-  p50LatencyMs: Float
-
-  """
-  The p90 of the latency of the resolution of this field. This can be null depending on the filter and sort order.
-  """
-  p90LatencyMs: Float
-
-  """
-  The p95 of the latency of the resolution of this field. This can be null depending on the filter and sort order.
-  """
-  p95LatencyMs: Float
-
-  """
-  The p99 of the latency of the resolution of this field. This can be null depending on the filter and sort order.
-  """
-  p99LatencyMs: Float
-  parentType: String!
-
-  """
-  The count of operations that reference the field. This can be null depending on the sort order.
-  """
-  referencingOperationCount: Long
-
-  """
-  The count of operations that reference the field per minute. This can be null depending on the sort order.
-  """
-  referencingOperationCountPerMin: Float
-}
-
-enum FieldInsightsListOrderByColumn {
-  ERROR_COUNT
-  ERROR_COUNT_PER_MIN
-  ERROR_PERCENTAGE
-  ESTIMATED_EXECUTION_COUNT
-  EXECUTION_COUNT
-  PARENT_TYPE_AND_FIELD_NAME
-  REFERENCING_OPERATION_COUNT
-  REFERENCING_OPERATION_COUNT_PER_MIN
-  SERVICE_TIME_P50
-  SERVICE_TIME_P90
-  SERVICE_TIME_P95
-  SERVICE_TIME_P99
-}
-
-input FieldInsightsListOrderByInput {
-  column: FieldInsightsListOrderByColumn!
-  direction: Ordering!
-}
-
-"""Information about pagination in a connection."""
-type FieldInsightsListPageInfo {
-  """When paginating forwards, the cursor to continue."""
-  endCursor: String
-
-  """When paginating backwards, the cursor to continue."""
-  startCursor: String
-}
-
-"""Columns of FieldLatencies."""
-enum FieldLatenciesColumn {
-  FIELD_HISTOGRAM
-  FIELD_NAME
-  PARENT_TYPE
-  SCHEMA_HASH
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-}
-
-type FieldLatenciesDimensions {
-  field: String
-  fieldName: String
-  parentType: String
-  schemaHash: String
-  schemaTag: String
-  serviceId: ID
-}
-
-"""
-Filter for data in FieldLatencies. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input FieldLatenciesFilter {
-  and: [FieldLatenciesFilter!]
-
-  """
-  Selects rows whose fieldName dimension equals the given value if not null. To query for the null value, use {in: {fieldName: [null]}} instead.
-  """
-  fieldName: String
-  in: FieldLatenciesFilterIn
-  not: FieldLatenciesFilter
-  or: [FieldLatenciesFilter!]
-
-  """
-  Selects rows whose parentType dimension equals the given value if not null. To query for the null value, use {in: {parentType: [null]}} instead.
-  """
-  parentType: String
-
-  """
-  Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead.
-  """
-  schemaHash: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-}
-
-"""
-Filter for data in FieldLatencies. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input FieldLatenciesFilterIn {
-  """
-  Selects rows whose fieldName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  fieldName: [String]
-
-  """
-  Selects rows whose parentType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  parentType: [String]
-
-  """
-  Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaHash: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-}
-
-type FieldLatenciesMetrics {
-  fieldHistogram: DurationHistogram!
-}
-
-input FieldLatenciesOrderBySpec {
-  column: FieldLatenciesColumn!
-  direction: Ordering!
-}
-
-type FieldLatenciesRecord {
-  """Dimensions of FieldLatencies that can be grouped by."""
-  groupBy: FieldLatenciesDimensions!
-
-  """Metrics of FieldLatencies that can be aggregated over."""
-  metrics: FieldLatenciesMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of FieldUsage."""
-enum FieldUsageColumn {
-  CLIENT_NAME
-  CLIENT_VERSION
-  ESTIMATED_EXECUTION_COUNT
-  EXECUTION_COUNT
-  FIELD_NAME
-  OPERATION_SUBTYPE
-  OPERATION_TYPE
-  PARENT_TYPE
-  QUERY_ID
-  QUERY_NAME
-  REFERENCING_OPERATION_COUNT
-  SCHEMA_HASH
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-}
-
-type FieldUsageDimensions {
-  clientName: String
-  clientVersion: String
-  fieldName: String
-  operationSubtype: String
-  operationType: String
-  parentType: String
-  queryId: ID
-  queryName: String
-  schemaHash: String
-  schemaTag: String
-  serviceId: ID
-}
-
-"""
-Filter for data in FieldUsage. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input FieldUsageFilter {
-  and: [FieldUsageFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-
-  """
-  Selects rows whose fieldName dimension equals the given value if not null. To query for the null value, use {in: {fieldName: [null]}} instead.
-  """
-  fieldName: String
-  in: FieldUsageFilterIn
-  not: FieldUsageFilter
-
-  """
-  Selects rows whose operationSubtype dimension equals the given value if not null. To query for the null value, use {in: {operationSubtype: [null]}} instead.
-  """
-  operationSubtype: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [FieldUsageFilter!]
-
-  """
-  Selects rows whose parentType dimension equals the given value if not null. To query for the null value, use {in: {parentType: [null]}} instead.
-  """
-  parentType: String
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: ID
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead.
-  """
-  schemaHash: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-}
-
-"""
-Filter for data in FieldUsage. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input FieldUsageFilterIn {
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose fieldName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  fieldName: [String]
-
-  """
-  Selects rows whose operationSubtype dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationSubtype: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose parentType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  parentType: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [ID]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaHash: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-}
-
-type FieldUsageMetrics {
-  estimatedExecutionCount: Long!
-  executionCount: Long!
-  referencingOperationCount: Long!
-}
-
-input FieldUsageOrderBySpec {
-  column: FieldUsageColumn!
-  direction: Ordering!
-}
-
-type FieldUsageRecord {
-  """Dimensions of FieldUsage that can be grouped by."""
-  groupBy: FieldUsageDimensions!
-
-  """Metrics of FieldUsage that can be aggregated over."""
-  metrics: FieldUsageMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
 }
 
 type FileCoordinate {
@@ -7571,32 +1550,6 @@ input FileLocationInput {
   subgraphName: String
 }
 
-type FilterBuildCheckFailed implements BuildCheckFailed & BuildCheckResult & FilterBuildCheckResult {
-  buildInputs: FilterBuildInputs!
-  buildPipelineTrack: BuildPipelineTrack!
-  errors: [BuildError!]!
-  id: ID!
-  passed: Boolean!
-  workflowTask: FilterCheckTask!
-}
-
-type FilterBuildCheckPassed implements BuildCheckPassed & BuildCheckResult & FilterBuildCheckResult {
-  buildInputs: FilterBuildInputs!
-  buildPipelineTrack: BuildPipelineTrack!
-  id: ID!
-  passed: Boolean!
-  supergraphSchemaHash: SHA256!
-  workflowTask: FilterCheckTask!
-}
-
-interface FilterBuildCheckResult implements BuildCheckResult {
-  buildInputs: FilterBuildInputs!
-  buildPipelineTrack: BuildPipelineTrack!
-  id: ID!
-  passed: Boolean!
-  workflowTask: FilterCheckTask!
-}
-
 """
 Inputs provided to the build for a contract variant, which filters types and fields from a source variant's schema.
 """
@@ -7612,52 +1565,10 @@ type FilterBuildInput {
   schemaHash: String!
 }
 
-type FilterBuildInputs {
-  """
-  The build pipeline track used for filtering. Note this is taken from upstream check workflow
-  or launch.
-  """
-  buildPipelineTrack: BuildPipelineTrack!
-
-  """The exclude filters used for filtering."""
-  exclude: [String!]!
-
-  """
-  Whether to hide unreachable objects, interfaces, unions, inputs, enums and scalars from
-  the resulting contract schema.
-  """
-  hideUnreachableTypes: Boolean!
-
-  """The include filters used for filtering."""
-  include: [String!]!
-
-  """The SHA-256 of the supergraph schema document used for filtering."""
-  supergraphSchemaHash: SHA256!
-}
-
-input FilterCheckAsyncInput {
-  config: HistoricQueryParametersInput!
-  filterChanges: FilterCheckFilterChanges!
-  gitContext: GitContextInput!
-}
-
-input FilterCheckFilterChanges {
-  excludeAdditions: [String!]
-  excludeRemovals: [String!]
-  hideUnreachableTypesChange: Boolean
-  includeAdditions: [String!]
-  includeRemovals: [String!]
-}
-
-type FilterCheckTask implements BuildCheckTask & CheckWorkflowTask {
-  """
-  The result of the filter build check. This will be null when the task is initializing or running.
-  """
-  buildResult: FilterBuildCheckResult
+type FilterCheckTask implements CheckWorkflowTask {
   completedAt: Timestamp
   createdAt: Timestamp!
   id: ID!
-  proposedBuildInputChanges: ProposedFilterBuildInputChanges!
   status: CheckWorkflowTaskStatus!
   targetURL: String
   workflow: CheckWorkflow!
@@ -7669,11 +1580,6 @@ The filter configuration used to build a contract schema. The configuration cons
 type FilterConfig {
   """Tags of schema elements to exclude from the contract schema."""
   exclude: [String!]!
-
-  """
-  Whether to hide unreachable objects, interfaces, unions, inputs, enums and scalars from the resulting contract schema.
-  """
-  hideUnreachableTypes: Boolean!
 
   """Tags of schema elements to include in the contract schema."""
   include: [String!]!
@@ -7940,7 +1846,7 @@ type FlatDiffRemoveValidLocation implements FlatDiffItem & FlatDiffItemCoordinat
   value: String!
 }
 
-union FlatDiffResult = FlatDiff | NotFoundError | SchemaValidationError
+union FlatDiffResult = FlatDiff | NotFoundError
 
 """Represents a summary of a diff between two versions of a schema."""
 type FlatDiffSummary {
@@ -8003,18 +1909,6 @@ type FlatDiffTypeSummary {
   typeCount: Int!
 }
 
-"""Fly-specific information for a Shard"""
-type FlyShard {
-  """DNS endpoint for the orchestrator"""
-  endpoint: String!
-
-  """Fly organization ID"""
-  organizationId: String!
-
-  """Endpoints of the Etcd cluster"""
-  etcdEndpoints: [String!]!
-}
-
 interface GeneralProposalComment implements ProposalComment {
   createdAt: Timestamp!
 
@@ -8029,13 +1923,7 @@ interface GeneralProposalComment implements ProposalComment {
 }
 
 type GitContext {
-  remoteUrl: String
-  remoteHost: GitRemoteHost
   commit: ID
-  commitUrl: String
-  committer: String
-  message: String
-  branch: String
 }
 
 """This is stored with a schema when it is uploaded"""
@@ -8054,18 +1942,6 @@ input GitContextInput {
 
   """The Git repository's remote URL."""
   remoteUrl: String
-}
-
-enum GitRemoteHost {
-  BITBUCKET
-  GITHUB
-  GITLAB
-}
-
-type GQLBillingPlanFromGrpc {
-  dbPlan: BillingPlan
-  matchesDbPlan: Boolean
-  rawProtoJson: String
 }
 
 """
@@ -8092,234 +1968,26 @@ type GraphApiKey implements ApiKey {
   token: String!
 }
 
-type GraphCapabilities {
-  """ False if this graph is a cloud supergraph."""
-  canPublishMonograph: Boolean!
-
-  """ Currently, graph URL is not updatable for cloud supergraphs."""
-  canUpdateURL: Boolean!
-
-  """ Minimum Federation Version track required for all variants of this graph.
-  """
-  minimumBuildPipelineTrack: BuildPipelineTrack!
-}
-
 """The timing details for the build step of a launch."""
 type GraphCreationError {
   message: String!
 }
 
-union GraphCreationResult = GraphCreationError | Service
-
-"""Filtering options for graph connections."""
-input GraphFilter {
-  """Only include graphs in a certain state."""
-  state: GraphState
-
-  """Only include graphs of certain types."""
-  type: [GraphType!]
-}
+union GraphCreationResult = GraphCreationError | Graph
 
 """
 A union of all containers that can comprise the components of a Studio graph
 """
-union GraphImplementors = NonFederatedImplementingService | FederatedImplementingServices
-
-"""The linter configuration for this graph."""
-type GraphLinterConfiguration {
-  """The set of @tag names allowed in the schema."""
-  allowedTagNames: [String!]!
-
-  """Whether to ignore @deprecated elements from linting violations."""
-  ignoreDeprecated: Boolean!
-
-  """Whether to ignore @inaccessible elements from linting violations."""
-  ignoreInaccessible: Boolean!
-
-  """The set of lint rules configured for this graph."""
-  rules: [LinterRuleLevelConfiguration!]!
-}
-
-"""The changes to the linter configuration for this graph."""
-input GraphLinterConfigurationChangesInput {
-  """
-  A set of allowed @tag names to be added to the linting configuration for this graph or null if no changes should be made.
-  """
-  allowedTagNameAdditions: [String!]
-
-  """
-  A set of @tag names to be removed from the allowed @tag list for this graphs linting configuration or null if no changes should be made.
-  """
-  allowedTagNameRemovals: [String!]
-
-  """
-  Change whether @deprecated elements should be linted or null if no changes should be made.
-  """
-  ignoreDeprecated: Boolean
-
-  """
-  Change whether @inaccessible elements should be linted or null if no changes should be made.
-  """
-  ignoreInaccessible: Boolean
-
-  """A set of rule changes or null if no changes should be made."""
-  rules: [LinterRuleLevelConfigurationChangesInput!]
-}
-
-"""Columns of GraphosCloudMetrics."""
-enum GraphosCloudMetricsColumn {
-  ACCOUNT_ID
-  AGENT_VERSION
-  CLOUD_PROVIDER
-  RESPONSE_SIZE
-  RESPONSE_SIZE_THROTTLED
-  ROUTER_ID
-  ROUTER_OPERATIONS
-  ROUTER_OPERATIONS_THROTTLED
-  SCHEMA_TAG
-  SERVICE_ID
-  SUBGRAPH_FETCHES
-  SUBGRAPH_FETCHES_THROTTLED
-  TIER
-  TIMESTAMP
-}
-
-type GraphosCloudMetricsDimensions {
-  accountId: ID
-  agentVersion: String
-  cloudProvider: String
-  routerId: String
-  schemaTag: String
-  serviceId: ID
-  tier: String
-}
-
-"""
-Filter for data in GraphosCloudMetrics. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input GraphosCloudMetricsFilter {
-  """
-  Selects rows whose accountId dimension equals the given value if not null. To query for the null value, use {in: {accountId: [null]}} instead.
-  """
-  accountId: ID
-
-  """
-  Selects rows whose agentVersion dimension equals the given value if not null. To query for the null value, use {in: {agentVersion: [null]}} instead.
-  """
-  agentVersion: String
-  and: [GraphosCloudMetricsFilter!]
-
-  """
-  Selects rows whose cloudProvider dimension equals the given value if not null. To query for the null value, use {in: {cloudProvider: [null]}} instead.
-  """
-  cloudProvider: String
-  in: GraphosCloudMetricsFilterIn
-  not: GraphosCloudMetricsFilter
-  or: [GraphosCloudMetricsFilter!]
-
-  """
-  Selects rows whose routerId dimension equals the given value if not null. To query for the null value, use {in: {routerId: [null]}} instead.
-  """
-  routerId: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-
-  """
-  Selects rows whose tier dimension equals the given value if not null. To query for the null value, use {in: {tier: [null]}} instead.
-  """
-  tier: String
-}
-
-"""
-Filter for data in GraphosCloudMetrics. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input GraphosCloudMetricsFilterIn {
-  """
-  Selects rows whose accountId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  accountId: [ID]
-
-  """
-  Selects rows whose agentVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  agentVersion: [String]
-
-  """
-  Selects rows whose cloudProvider dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  cloudProvider: [String]
-
-  """
-  Selects rows whose routerId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  routerId: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-
-  """
-  Selects rows whose tier dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  tier: [String]
-}
-
-type GraphosCloudMetricsMetrics {
-  responseSize: Long!
-  responseSizeThrottled: Long!
-  routerOperations: Long!
-  routerOperationsThrottled: Long!
-  subgraphFetches: Long!
-  subgraphFetchesThrottled: Long!
-}
-
-input GraphosCloudMetricsOrderBySpec {
-  column: GraphosCloudMetricsColumn!
-  direction: Ordering!
-}
-
-type GraphosCloudMetricsRecord {
-  """Dimensions of GraphosCloudMetrics that can be grouped by."""
-  groupBy: GraphosCloudMetricsDimensions!
-
-  """Metrics of GraphosCloudMetrics that can be aggregated over."""
-  metrics: GraphosCloudMetricsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
+union GraphImplementors = GraphVariantSubgraphs
 
 type GraphQLDoc {
-  graph: Service!
+  graph: Graph!
   hash: ID!
   source: GraphQLDocument!
 }
 
 """A GraphQL document, such as the definition of an operation or schema."""
 scalar GraphQLDocument
-
-"""Various states a graph can be in."""
-enum GraphState {
-  """The graph has not been configured with any variants."""
-  CONFIGURED
-
-  """The graph has not been configured with any variants."""
-  NOT_CONFIGURED
-}
 
 enum GraphType {
   CLASSIC
@@ -8329,14 +1997,8 @@ enum GraphType {
 
 """A graph variant"""
 type GraphVariant {
-  """The default collection MCP servers will use if no explicit collection is provided"""
-
-  mcpDefaultCollection: OperationCollection
   """The variant's global identifier in the form `graphID@variant`."""
   id: ID!
-
-  """Graph ID of the variant. Prefer using graph { id } when feasible."""
-  graphId: String!
 
   """The variant's name (e.g., `staging`)."""
   name: String!
@@ -8352,26 +2014,7 @@ type GraphVariant {
   customCheckConfiguration: CustomCheckConfiguration
 
   """The graph that this variant belongs to."""
-  graph: Service!
-
-  """The list of rule enforcements for this variant, if any."""
-  ruleEnforcements: [RuleEnforcement!]!
-
-  """
-  The list of BuildPipelineTracks and their associated details that this variant is allowed to set in their build configuration.
-  """
-  allowedTracks: [BuildPipelineTrackDetails]!
-
-  """
-  If this variant doesn't conduct a build (monograph) then this field will be null
-  For contract variants the build config is set based on the upstream composition variant.
-  """
-  buildConfig: BuildConfig
-
-  """
-  The time the variant's federation version and/or the supported directives was last updated
-  """
-  buildConfigUpdatedAt: Timestamp
+  graph: Graph!
 
   """
   Compose and filter preview contract schema built from this source variant.
@@ -8388,9 +2031,6 @@ type GraphVariant {
     subgraphChanges: [ComposeAndFilterPreviewSubgraphChange!]
   ): ComposeAndFilterPreviewResult
 
-  """Federation version this variant uses"""
-  compositionVersion: String @deprecated(reason: "Use federationVersion instead.")
-
   """
   The filter configuration used to build a contract schema. The configuration consists of lists of tags for schema elements to include or exclude in the resulting schema.
   """
@@ -8402,113 +2042,14 @@ type GraphVariant {
   """
   contractFilterConfigDescription: String
 
-  """Preview a Contract schema built from this source variant."""
-  contractPreview(filters: FilterConfigInput!): ContractPreview!
-
-  """
-  Returns details about a coordinate in the schema. Unless an error occurs, we will currently always return a non-null
-  response here, with the timestamps set to null if there is no usage of the coordinate or if coordinate doesn't exist in the
-  schema. However, we are keeping the return type as nullable in case we want to update this later in a
-  backwards-compatible way (e.g. a null response meaning that the coordinate doesn't exist in the schema at all).
-  """
-  coordinateInsights(coordinateKind: CoordinateKind!, namedAttribute: String!, namedType: String!): CoordinateInsights
-
-  """
-  Returns a paginated list of coordinate insights list items, including all coordinates from the active schema for this variant.
-  """
-  coordinateInsightsList(after: String, before: String, filter: CoordinateInsightsListFilterInput, first: Int, from: Timestamp!, last: Int, orderBy: CoordinateInsightsListOrderByInput, to: Timestamp!): GraphVariantCoordinateInsightsListItemConnection!
-
   """Time the variant was created"""
   createdAt: Timestamp!
-  derivedVariantCount: Int!
-
-  """
-  Returns the list of variants derived from this variant. This currently includes contracts only.
-  """
-  derivedVariants: [GraphVariant!]
-
-  """
-  Returns a paginated list of error insights list items, including service and code for which the error originated from.
-  """
-  errorInsightsList(
-    after: String
-    before: String
-    filter: ErrorInsightsListFilterInput
-    first: Int
-    from: Timestamp!
-
-    """
-    Defines how to group the data. Order matters for nesting and structuring the results.
-    """
-    groupBy: [ErrorInsightsListGroupByColumn!]
-    last: Int
-    orderBy: ErrorInsightsListOrderByInput
-    to: Timestamp!
-  ): GraphVariantErrorInsightsListItemConnection!
-
-  """
-  Returns a time series list of error counts over time for this variant within a given time range.
-  """
-  errorInsightsTimeseries(filter: ErrorInsightsListFilterInput, from: Timestamp!, groupBy: ErrorInsightsListGroupByColumn!, resolution: Resolution!, to: Timestamp!): ErrorInsightsTimeseriesResult!
-
-  """
-  Details about 'enhanced reference' reporting for traces sent to Apollo by Router for this variant.
-  """
-  extendedRefsUsage: ExtendedRefsUsage!
 
   """Federation version this variant uses"""
   federationVersion: String
 
-  """
-  The last instant that field execution information (resolver execution via field-level instrumentation) was reported for this variant
-  """
-  fieldExecutionsLastReportedAt: Timestamp
-
-  """
-  Returns details about a field in the schema. Unless an error occurs, we will currently always return a non-null
-  response here, with the timestamps set to null if there is no usage of the field or if field doesn't exist in the
-  schema. However, we are keeping the return type as nullable in case we want to update this later in a
-  backwards-compatible way (e.g. a null response meaning that the field doesn't exist in the schema at all).
-  """
-  fieldInsights(fieldName: String!, parentType: String!): FieldInsights
-
-  """
-  Returns a paginated list of field insights list items, including all fields from the active schema for this variant.
-  """
-  fieldInsightsList(after: String, before: String, filter: FieldInsightsListFilterInput, first: Int, from: Timestamp!, last: Int, orderBy: FieldInsightsListOrderByInput, to: Timestamp!): GraphVariantFieldInsightsListItemConnection!
-
-  """
-  The last instant that field usage information (usage of fields via referencing operations) was reported for this variant
-  """
-  fieldUsageLastReportedAt: Timestamp
-
-  """
-  Represents whether this variant has a supergraph schema. Note that this can only be true for variants with build steps
-  (running e.g. federation composition or contracts filtering). This will be false for a variant with a build step if it
-  has never successfully published.
-  """
-  hasSupergraphSchema: Boolean!
-  internalVariantUUID: String!
-
-  """Represents whether this variant is a Contract."""
-  isContract: Boolean
-
-  """Is this variant one of the current user's favorite variants?"""
-  isFavoriteOfCurrentUser: Boolean!
-
   """Represents whether this variant is a Proposal."""
   isProposal: Boolean
-  isPublic: Boolean!
-
-  """
-  Represents whether this variant should be listed in the public variants directory. This can only be true if the variant is also public.
-  """
-  isPubliclyListed: Boolean!
-
-  """
-  Represents whether Apollo has verified the authenticity of this public variant. This can only be true if the variant is also public.
-  """
-  isVerified: Boolean!
 
   """
   Latest approved launch for the variant, and what is served through Uplink.
@@ -8522,26 +2063,9 @@ type GraphVariant {
   launch(id: ID!): Launch
 
   """
-  A list of launches ordered by date, asc or desc depending on orderBy. The maximum limit is 100.
-  """
-  launchHistory(limit: Int! = 100, offset: Int! = 0, orderBy: LaunchHistoryOrder! = CREATED_DESC): [Launch!]
-
-  """Count of total launch history"""
-  launchHistoryLength: Long
-
-  """
   A list of launches metadata ordered by date, asc or desc depending on orderBy. The maximum limit is 100.
   """
   launchSummaries(limit: Int! = 100, offset: Int! = 0, orderBy: LaunchHistoryOrder! = CREATED_DESC): [LaunchSummary!]
-  links: [LinkInfo!]
-
-  """Returns a paginated list of operation insights list items."""
-  operationInsightsList(after: String, before: String, filter: OperationInsightsListFilterInput, first: Int, from: Timestamp!, last: Int, orderBy: OperationInsightsListOrderByInput, to: Timestamp!): GraphVariantOperationInsightsListItemConnection!
-
-  """
-  The merged/computed/effective check configuration for the operations check task.
-  """
-  operationsCheckConfiguration(overrides: OperationsCheckConfigurationOverridesInput): OperationsCheckConfiguration
 
   """
   Which permissions the current user has for interacting with this variant
@@ -8549,25 +2073,10 @@ type GraphVariant {
   permissions: GraphVariantPermissions!
   readme: Readme!
 
-  """The total number of requests for this variant in the last 24 hours"""
-  requestsInLastDay: Long
-
-  """The first time the Router reported usage of this variant to Apollo."""
-  routerFirstSeenAt: Timestamp
-
-  """The last time the Router reported usage of this variant to Apollo."""
-  routerLastSeenAt: Timestamp
-
   """
   The variant this variant is derived from. This property currently only exists on contract variants.
   """
   sourceVariant: GraphVariant
-
-  """A list of supported directives"""
-  supportedDirectives: [DirectiveSupportStatus!]
-
-  """Returns the top N operations by a few different metrics"""
-  topNOperations(filter: TopNOperationsFilterInput, from: Timestamp!, to: Timestamp!, topN: Int): TopNOperationsResult!
 
   """
   Returns a list of the top operations reported for this variant within a given time range. This API is rate limited,
@@ -8581,7 +2090,8 @@ type GraphVariant {
     The starting timestamp for the report.
     
     - Must be in the format: 2025-01-01T00:00:00Z (ISO 8601).
-    - The duration between 'from' and 'to' must not exceed 8 days.
+      - Must be within the last 549 days.
+      - The duration between 'from' and 'to' must not exceed 31 days.
     """
     from: Timestamp!
 
@@ -8595,37 +2105,28 @@ type GraphVariant {
     The ending timestamp for the report.
     
     - Must be in the format: 2025-01-01T08:00:00Z (ISO 8601).
-    - 'to' must be at least 6 hours from the current time.
-    - The duration between 'from' and 'to' must not exceed 8 days.
+    - Must be at least 6 hours from the current time.
+      - The duration between 'from' and 'to' must not exceed 31 days.
     """
     to: Timestamp!
   ): [TopOperationRecord!]!
 
   """
-  A list of the subgraphs that have been published to since the variant was created. Does not include subgraphs that were created & deleted since the variant was created since that is not a change compared to initial; however includes subgraphs that were only deleted because that is a change compared to the initial.
+  The default collection MCP servers will use if no explicit collection is provided. null if no default collection is set.
   """
-  updatedSubgraphsSinceCreation: [Subgraph!]
-
-  """
-  The last instant that usage information (e.g. operation stat, client stats) was reported for this variant
-  """
-  usageLastReportedAt: Timestamp
+  mcpDefaultCollection: McpDefaultCollectionResult
 
   """
   A list of the saved [operation collections](https://www.apollographql.com/docs/studio/explorer/operation-collections/) associated with this variant.
+  This field accepts up to 400 requests per minute. This rate may be temporarily adjusted based on system conditions.
   """
   operationCollections: [OperationCollection!]!
-
-  """
-  A list of the saved [operation collections](https://www.apollographql.com/docs/studio/explorer/operation-collections/) associated with this variant, paged.
-  """
-  operationCollectionsConnection(after: String, before: String, first: Int, last: Int): GraphVariantOperationCollectionConnection
 
   """The Persisted Query List linked to this variant, if any."""
   persistedQueryList: PersistedQueryList
 
   """
-  Returns the proposal-related fields for this graph variant if the variant is a proposal; otherwise, returns null.
+  Returns the proposal-related fields for this graph variant if the variant is a proposal; otherwise, returns null. This field accepts up to 1000 requests per minute. This rate may be temporarily adjusted based on system conditions.
   """
   proposal: Proposal
 
@@ -8634,49 +2135,16 @@ type GraphVariant {
   """
   url: String
 
-  """If the graphql endpoint is set up to accept cookies."""
-  sendCookies: Boolean
-
   """The URL of the variant's GraphQL endpoint for subscription operations."""
   subscriptionUrl: String
 
-  """
-  Explorer setting for preflight script to run before the actual GraphQL operations is run.
-  """
-  preflightScript: String
-
-  """
-  Explorer setting for postflight script to run before the actual GraphQL operations is run.
-  """
-  postflightScript: String
-
-  """Explorer setting for shared headers for a graph"""
-  sharedHeaders: String
-
-  """
-  As new schema tags keep getting published, activeSchemaPublish refers to the latest.
-  """
-  activeSchemaPublish: SchemaTag
-
   """The details of the variant's most recent publication."""
-  latestPublication: SchemaTag
-
-  """If the variant is protected"""
-  isProtected: Boolean!
-
-  """Generate a federated operation plan for a given operation"""
-  plan(document: GraphQLDocument!, operationName: String): QueryPlan
-
-  """If the variant has managed subgraphs."""
-  isFederated: Boolean @deprecated(reason: "Replaced by hasManagedSubgraphs")
-
-  """If the variant has managed subgraphs."""
-  hasManagedSubgraphs: Boolean
+  latestPublication: SchemaPublication
 
   """
   A list of the subgraphs included in this variant. This value is null for non-federated variants. Set `includeDeleted` to `true` to include deleted subgraphs.
   """
-  subgraphs(includeDeleted: Boolean! = false): [FederatedImplementingService!]
+  subgraphs(includeDeleted: Boolean! = false): [GraphVariantSubgraph!]
 
   """
   A list of the subgraphs that have been published to since the variant was created.
@@ -8684,112 +2152,13 @@ type GraphVariant {
   
   TODO: @deprecated(reason: "use GraphVariant.updatedSubgraphsSinceCreation instead")
   """
-  updatedSubgraphs: [FederatedImplementingService!]
-
-  """
-  A list of the entities across all subgraphs, exposed to consumers & up. This value is null for non-federated variants.
-  """
-  entities: EntitiesResponseOrError
+  updatedSubgraphs: [GraphVariantSubgraph!]
 
   """
   Returns the details of the subgraph with the provided `name`, or null if this variant doesn't include a subgraph with that name.
   """
-  subgraph(name: ID!): FederatedImplementingService
-
-  """Registry stats for this particular graph variant"""
-  registryStatsWindow(from: Timestamp!, resolution: Resolution, to: Timestamp): RegistryStatsWindow
+  subgraph(name: ID!): GraphVariantSubgraph
   routerConfig: String
-}
-
-type GraphVariantCoordinateInsightsListItemConnection {
-  """
-  A list of edges from the graph variant to its coordinate insights list items.
-  """
-  edges: [GraphVariantCoordinateInsightsListItemEdge!]
-
-  """
-  A list of coordinate insights list items that belong to a graph variant.
-  """
-  nodes: [CoordinateInsightsListItem!]
-
-  """Information to aid in pagination."""
-  pageInfo: CoordinateInsightsListPageInfo!
-
-  """
-  The total number of coordinate insights list items connected to the graph variant
-  """
-  totalCount: Int!
-}
-
-"""An edge between a graph variant and a coordinate insights list item."""
-type GraphVariantCoordinateInsightsListItemEdge {
-  """A cursor for use in pagination."""
-  cursor: String!
-
-  """A coordinate insights list item attached to the graph variant."""
-  node: CoordinateInsightsListItem
-}
-
-type GraphVariantErrorInsightsListItemConnection {
-  """
-  A list of edges from the graph variant to its error insights list items.
-  """
-  edges: [GraphVariantErrorInsightsListItemEdge!]
-
-  """A list of error insights list items that belong to a graph variant."""
-  nodes: [ErrorInsightsListItem!]
-
-  """Information to aid in pagination."""
-  pageInfo: ErrorInsightsListPageInfo!
-
-  """
-  The total number of error insights list items connected to the graph variant.
-  """
-  totalCount: Int!
-}
-
-type GraphVariantErrorInsightsListItemEdge {
-  """A cursor for use in pagination."""
-  cursor: String!
-
-  """A error insights list items attached to the graph variant."""
-  node: ErrorInsightsListItem
-}
-
-type GraphVariantFieldInsightsListItemConnection {
-  """
-  A list of edges from the graph variant to its field insights list items.
-  """
-  edges: [GraphVariantFieldInsightsListItemEdge!]
-
-  """A list of field insights list items that belong to a graph variant."""
-  nodes: [FieldInsightsListItem!]
-
-  """Information to aid in pagination."""
-  pageInfo: FieldInsightsListPageInfo!
-
-  """
-  The total number of field insights list items connected to the graph variant
-  """
-  totalCount: Int!
-}
-
-"""An edge between a graph variant and a field insights list item."""
-type GraphVariantFieldInsightsListItemEdge {
-  """A cursor for use in pagination."""
-  cursor: String!
-
-  """A field insights list item attached to the graph variant."""
-  node: FieldInsightsListItem
-}
-
-"""Ways to filter graph variants."""
-enum GraphVariantFilter {
-  """All Variants"""
-  ALL
-
-  """Variants favorited by the current user"""
-  FAVORITES
 }
 
 """Result of looking up a variant by ref"""
@@ -8799,14 +2168,8 @@ union GraphVariantLookup = GraphVariant | InvalidRefFormat
 Modifies a variant of a graph, also called a schema tag in parts of our product.
 """
 type GraphVariantMutation {
-  """Global identifier for the graph variant, in the form `graph@variant`."""
-  id: ID!
-
   """Gets the router attached to a graph variant"""
   router: RouterMutation
-  createRouter(input: CreateRouterInput!): CreateRouterResult!
-  destroyRouter: DestroyRouterResult!
-  updateRouter(input: UpdateRouterInput!): UpdateRouterResult!
 
   """
   Callback mutation for submitting custom check results once your validation has run.
@@ -8816,30 +2179,7 @@ type GraphVariantMutation {
   After 10 minutes have passed without a callback request being received, the task will be marked as timed out.
   """
   customCheckCallback(input: CustomCheckCallbackInput!): CustomCheckCallbackResult!
-
-  """Graph ID of the variant"""
-  graphId: String!
-
-  """Name of the variant, like `variant`."""
-  name: String!
-
-  """
-  Send a custom check request with a fake task id to your configured endpoint.
-  """
-  queueTestCustomChecksRequest: QueueTestCustomChecksRequestResult!
   setCustomCheckConfiguration(input: SetCustomCheckConfigurationInput!): CustomCheckConfigurationResult!
-  variant: GraphVariant!
-  addLinkToVariant(title: String, type: LinkInfoType!, url: String!): GraphVariant!
-  buildConfig(
-    """When this flag is true, indicates to skip the new launch initiation"""
-    skipLaunch: Boolean = false
-    tagInApiSchema: Boolean! = false
-    version: BuildPipelineTrack!
-  ): GraphVariant
-  relaunch: RelaunchResult!
-  removeLinkFromVariant(linkInfoId: ID!): GraphVariant!
-  service: Service!
-  setIsFavoriteOfCurrentUser(favorite: Boolean!): GraphVariant!
 
   """
   _Asynchronously_ kicks off operation checks for a proposed non-federated
@@ -8851,11 +2191,6 @@ type GraphVariantMutation {
   Rate limited to 3000 per min. Schema checks cannot be performed on contract variants.
   """
   submitCheckSchemaAsync(input: CheckSchemaAsyncInput!): CheckRequestResult!
-
-  """
-  Submit a request for a Filter Schema Check and receive a result with a workflow ID that can be used to check status, or an error message that explains what went wrong.
-  """
-  submitFilterCheckAsync(input: FilterCheckAsyncInput!): CheckRequestResult!
 
   """
    _Asynchronously_ kicks off composition and operation checks for all proposed subgraphs schema changes against its associated supergraph.
@@ -9014,9 +2349,6 @@ type GraphVariantMutation {
   Updates the [federation version](https://www.apollographql.com/docs/graphos/reference/router/federation-version-support) of this variant
   """
   updateVariantFederationVersion(version: BuildPipelineTrack!): GraphVariant
-  updateVariantIsPublic(isPublic: Boolean!): GraphVariant
-  updateVariantIsPubliclyListed(isPubliclyListed: Boolean!): GraphVariant
-  updateVariantIsVerified(isVerified: Boolean!): GraphVariant
 
   """
   Updates the [README](https://www.apollographql.com/docs/studio/org/graphs/#the-readme-page) of this variant.
@@ -9025,7 +2357,6 @@ type GraphVariantMutation {
     """The full new text of the README, as a Markdown-formatted string."""
     readme: String!
   ): GraphVariant
-  runLintCheck(input: RunLintCheckInput!): CheckStepResult!
 
   """
   Links a specified PersistedQueryList to the variant of the parent GraphVariantMutation.
@@ -9041,77 +2372,11 @@ type GraphVariantMutation {
   Provides access to mutation fields for modifying a GraphOS Schema Proposal, if this GraphVariant is a proposal variant; else returns NotFoundError. Learn more at https://www.apollographql.com/docs/graphos/delivery/schema-proposals
   """
   proposal: ProposalMutationResult!
-
-  """
-  Mutation called by CheckCoordinator to find associated proposals to the schema diffs in a check workflow
-  """
-  runProposalsCheck(input: RunProposalsCheckInput!): CheckStepResult!
-
-  """
-  Triggers the Proposals implementation check for active proposals that are sourced from this variant for a given graph composition id
-  """
-  triggerProposalsImplementationHandler(graphCompositionId: ID!): GraphVariant
-  internalVariantUUID: String!
   updateURL(url: String): GraphVariant
-  updateSubscriptionURL(subscriptionUrl: String): GraphVariant
-  updateSendCookies(sendCookies: Boolean!): GraphVariant
-  updateIsProtected(isProtected: Boolean!): GraphVariant
-  updatePreflightScript(preflightScript: String): GraphVariant
-  updatePostflightScript(postflightScript: String): GraphVariant
-  updateSharedHeaders(sharedHeaders: String): GraphVariant
 
   """Delete the variant."""
-  delete: DeleteSchemaTagResult!
+  delete: GraphVariantDeletionResult!
   upsertRouterConfig(configuration: String!): UpsertRouterResult
-}
-
-type GraphVariantOperationCollectionConnection {
-  """A list of edges from the graph variant to its operation collections."""
-  edges: [GraphVariantOperationCollectionEdge!]
-
-  """A list of operation collections attached to a graph variant."""
-  nodes: [OperationCollection!]
-
-  """Information to aid in pagination."""
-  pageInfo: PageInfo!
-  totalCount: Int!
-}
-
-"""An edge between a graph variant and an operation collection."""
-type GraphVariantOperationCollectionEdge {
-  """A cursor for use in pagination."""
-  cursor: String!
-
-  """An operation collection attached to a graph variant."""
-  node: OperationCollection
-}
-
-type GraphVariantOperationInsightsListItemConnection {
-  """
-  A list of edges from the graph variant to its operation insights list items.
-  """
-  edges: [GraphVariantOperationInsightsListItemEdge!]
-
-  """
-  A list of operation insights list items that belong to a graph variant.
-  """
-  nodes: [OperationInsightsListItem!]
-
-  """Information to aid in pagination."""
-  pageInfo: OperationInsightsListPageInfo!
-
-  """
-  The total number of operation insights list items connected to the graph variant.
-  """
-  totalCount: Int!
-}
-
-type GraphVariantOperationInsightsListItemEdge {
-  """A cursor for use in pagination."""
-  cursor: String!
-
-  """A operation insights list items attached to the graph variant."""
-  node: OperationInsightsListItem
 }
 
 """
@@ -9139,11 +2404,6 @@ type GraphVariantPermissions {
   canPushSchemas: Boolean!
 
   """
-  Whether the currently authenticated user can read any information about this variant.
-  """
-  canQuery: Boolean!
-
-  """
   Whether the currently authenticated user is permitted to view this variant's build configuration details (e.g., build pipeline version).
   """
   canQueryBuildConfig: Boolean!
@@ -9167,13 +2427,11 @@ type GraphVariantPermissions {
   Whether the currently authenticated user is permitted to download schemas associated to this variant.
   """
   canQuerySchemas: Boolean!
-  canUpdateVariantLinkInfo: Boolean!
 
   """
   Whether the currently authenticated user is permitted to update the README for this variant.
   """
   canUpdateVariantReadme: Boolean!
-  variantId: ID!
   canCreateCollectionInVariant: Boolean!
   canShareCollectionInVariant: Boolean!
 
@@ -9256,20 +2514,6 @@ input HistoricQueryParametersInput {
   to: String
 }
 
-enum HTTPMethod {
-  CONNECT
-  DELETE
-  GET
-  HEAD
-  OPTIONS
-  PATCH
-  POST
-  PUT
-  TRACE
-  UNKNOWN
-  UNRECOGNIZED
-}
-
 """
 An identity (such as a `User` or `Graph`) in Apollo Studio. See implementing types for details.
 """
@@ -9284,66 +2528,12 @@ interface Identity {
   name: String!
 }
 
-"""
-An actor's identity and info about the client they used to perform the action
-"""
-type IdentityAndClientInfo {
-  """Identity info about the actor"""
-  identity: Identity
-
-  """Client name provided when the actor performed the action"""
-  clientName: String
-
-  """Client version provided when the actor performed the action"""
-  clientVersion: String
-}
-
-union IdentityMutation = ServiceMutation | UserMutation
-
-type IgnoredRule {
-  ignoredRule: LintRule!
-  schemaCoordinate: String!
-  subgraphName: String
-}
-
-input IgnoredRuleInput {
-  ignoredRule: LintRule!
-  schemaCoordinate: String!
-  subgraphName: String
-}
-
-type IgnoreOperationsInChecksResult {
-  graph: Service!
-}
-
-"""The location of the implementing service config file in storage"""
-type ImplementingServiceLocation {
-  """The name of the implementing service"""
-  name: String!
-
-  """The path in storage to access the implementing service config file"""
-  path: String!
-}
-
-type InternalAdminUser {
-  role: InternalMdgAdminRole!
-  userID: String!
-}
-
 type InternalIdentity implements Identity {
   asActor: Actor!
   id: ID!
   name: String!
   email: String
-  accounts: [Account!]!
-}
-
-enum InternalMdgAdminRole {
-  INTERNAL_MDG_ADMIN
-  INTERNAL_MDG_READ_ONLY
-  INTERNAL_MDG_SALES
-  INTERNAL_MDG_SUPER_ADMIN
-  INTERNAL_MDG_SUPPORT
+  accounts: [Organization!]!
 }
 
 """
@@ -9352,13 +2542,6 @@ Generic server error. This should only ever return 'internal server error' as a 
 type InternalServerError implements Error {
   """Message related to the internal error"""
   message: String!
-}
-
-type IntrospectionDirective {
-  name: String!
-  description: String
-  locations: [IntrospectionDirectiveLocation!]!
-  args: [IntrospectionInputValue!]!
 }
 
 input IntrospectionDirectiveInput {
@@ -9429,29 +2612,10 @@ enum IntrospectionDirectiveLocation {
   INPUT_FIELD_DEFINITION
 }
 
-"""Values associated with introspection result for an enum value"""
-type IntrospectionEnumValue {
-  name: String!
-  description: String
-  isDeprecated: Boolean!
-  depreactionReason: String @deprecated(reason: "Use deprecationReason instead")
-  deprecationReason: String
-}
-
 """__EnumValue introspection type"""
 input IntrospectionEnumValueInput {
   name: String!
   description: String
-  isDeprecated: Boolean!
-  deprecationReason: String
-}
-
-"""Values associated with introspection result for field"""
-type IntrospectionField {
-  name: String!
-  description: String
-  args: [IntrospectionInputValue!]!
-  type: IntrospectionType!
   isDeprecated: Boolean!
   deprecationReason: String
 }
@@ -9466,14 +2630,6 @@ input IntrospectionFieldInput {
   deprecationReason: String
 }
 
-"""Values associated with introspection result for an input field"""
-type IntrospectionInputValue {
-  name: String!
-  description: String
-  type: IntrospectionType!
-  defaultValue: String
-}
-
 """__Value introspection type"""
 input IntrospectionInputValueInput {
   name: String!
@@ -9484,14 +2640,6 @@ input IntrospectionInputValueInput {
   deprecationReason: String
 }
 
-type IntrospectionSchema {
-  types(filter: TypeFilterConfig = {includeBuiltInTypes: true, includeIntrospectionTypes: true}): [IntrospectionType!]!
-  queryType: IntrospectionType!
-  mutationType: IntrospectionType
-  subscriptionType: IntrospectionType
-  directives: [IntrospectionDirective!]!
-}
-
 """__Schema introspection type"""
 input IntrospectionSchemaInput {
   types: [IntrospectionTypeInput!]
@@ -9500,29 +2648,6 @@ input IntrospectionSchemaInput {
   subscriptionType: IntrospectionTypeRefInput
   directives: [IntrospectionDirectiveInput!]!
   description: String
-}
-
-"""Object containing all possible values for an introspectionType"""
-type IntrospectionType {
-  kind: IntrospectionTypeKind
-  name: String
-
-  """
-  printed representation of type, including nested nullability and list ofTypes
-  """
-  printed: String!
-
-  """
-  the base kind of the type this references, ignoring lists and nullability
-  """
-  baseKind: IntrospectionTypeKind
-  description: String
-  fields: [IntrospectionField!]
-  interfaces: [IntrospectionType!]
-  possibleTypes: [IntrospectionType!]
-  enumValues(includeDeprecated: Boolean = false): [IntrospectionEnumValue!]
-  inputFields: [IntrospectionInputValue!]
-  ofType: IntrospectionType
 }
 
 """__Type introspection type"""
@@ -9592,67 +2717,12 @@ type InvalidInputErrors implements Error {
   message: String!
 }
 
-type InvalidOperation {
-  signature: ID!
-  errors: [OperationValidationError!]
-}
-
 """
 This object is returned when a request to fetch a Studio graph variant provides an invalid graph ref.
 """
 type InvalidRefFormat implements Error {
   message: String!
 }
-
-type InvalidTarget implements Error {
-  message: String!
-}
-
-type Invoice {
-  closedAt: Timestamp
-  collectionMethod: String
-  createdAt: Timestamp!
-  id: ID!
-  invoiceNumber: Int!
-  invoiceNumberV2: String!
-  state: InvoiceState!
-  totalInCents: Int!
-  updatedAt: Timestamp!
-  uuid: ID!
-}
-
-type InvoiceLineItem {
-  """
-  Line items may be grouped to help the customer better understand their charges
-  """
-  groupKey: String @deprecated(reason: "This data came from Metronome and we no longer use Metronome")
-
-  """
-  Line items may be grouped to help the customer better understand their charges
-  """
-  groupValue: String @deprecated(reason: "This data came from Metronome and we no longer use Metronome")
-  name: String! @deprecated(reason: "This data came from Metronome and we no longer use Metronome")
-
-  """
-  The quantity of 'things' in this line item. (e.g. number of operations, seats, etc).
-  May be null for flat charges.
-  """
-  quantity: Int @deprecated(reason: "This data came from Metronome and we no longer use Metronome")
-
-  """The amount this line item costs."""
-  totalInCents: Int! @deprecated(reason: "This data came from Metronome and we no longer use Metronome")
-}
-
-enum InvoiceState {
-  COLLECTED
-  FAILED
-  OPEN
-  PAST_DUE
-  UNKNOWN
-  VOID
-}
-
-scalar JSON
 
 """
 Represents the complete process of making a set of updates to a deployed graph variant.
@@ -9717,7 +2787,7 @@ type Launch {
   ): Launch
 
   """A specific publication of a graph variant pertaining to this launch."""
-  publication: SchemaTag
+  publication: SchemaPublication
 
   """
   A list of results from the completed launch. The items included in this list vary depending on whether the launch succeeded, failed, or was superseded.
@@ -9728,7 +2798,6 @@ type Launch {
   Cloud router configuration associated with this build event. It will be non-null for any cloud-router variant, and null for any not cloudy variant/graph.
   """
   routerConfig: String
-  schemaTag: SchemaTag
 
   """
   A list of all serial steps in the launch sequence. This list can change as the launch progresses. For example, a `LaunchCompletedStep` is appended after a launch completes.
@@ -9762,6 +2831,10 @@ type Launch {
   The source variant launch that caused this launch to be initiated. This value is present only for contract variant launches. Otherwise, it's null.
   """
   upstreamLaunch: Launch
+
+  """
+  Returns the proposal revision associated with this launch, if it exists. This field accepts up to 1000 requests per minute. This rate may be temporarily adjusted based on system conditions.
+  """
   proposalRevision: ProposalRevision
 }
 
@@ -9869,43 +2942,10 @@ type LaunchSummary {
   status: LaunchStatus!
 }
 
-input LaunchTestRouterInput {
-  routerVersion: String!
-  provider: CloudProvider
-  tier: CloudTier
-  config: JSON
-}
-
-union LaunchTestRouterResult = LaunchTestRouterSuccess | CloudRouterTestingInvalidInputErrors
-
-type LaunchTestRouterSuccess {
-  jobId: ID!
-  graphRef: String!
-}
-
-type LinkInfo {
-  createdAt: Timestamp!
-  id: ID!
-  title: String
-  type: LinkInfoType!
-  url: String!
-}
-
-enum LinkInfoType {
-  DEVELOPER_PORTAL
-  OTHER
-  REPOSITORY
-}
-
-type LinkPersistedQueryListResult {
-  graphVariant: GraphVariant!
-  persistedQueryList: PersistedQueryList!
-}
-
 """
 The result/error union returned by GraphVariantMutation.linkPersistedQueryList.
 """
-union LinkPersistedQueryListResultOrError = LinkPersistedQueryListResult | ListNotFoundError | PermissionError | VariantAlreadyLinkedError
+union LinkPersistedQueryListResultOrError = ListNotFoundError | PermissionError | VariantAlreadyLinkedError
 
 type LintCheckTask implements CheckWorkflowTask {
   completedAt: Timestamp
@@ -9920,9 +2960,6 @@ type LintCheckTask implements CheckWorkflowTask {
 
 """A single rule violation."""
 type LintDiagnostic {
-  """The category used for grouping similar rules."""
-  category: LinterRuleCategory!
-
   """The schema coordinate of this diagnostic."""
   coordinate: String!
 
@@ -9944,52 +2981,6 @@ enum LintDiagnosticLevel {
   ERROR
   IGNORED
   WARNING
-}
-
-input LinterIgnoredRuleChangesInput {
-  ruleViolationsToEnable: [IgnoredRuleInput!]!
-  ruleViolationsToIgnore: [IgnoredRuleInput!]!
-}
-
-"""The category used for grouping similar rules."""
-enum LinterRuleCategory {
-  """These rules are generated during composition."""
-  COMPOSITION
-
-  """These rules enforce naming conventions."""
-  NAMING
-
-  """
-  These rules define conventions for the entire schema and directive usage outside of composition.
-  """
-  OTHER
-}
-
-type LinterRuleLevelConfiguration {
-  """Illustrative code showcasing the potential violation of this rule."""
-  badExampleCode: String
-
-  """The category used for grouping similar rules."""
-  category: LinterRuleCategory!
-
-  """A human readable description of the rule."""
-  description: String!
-
-  """
-  Illustrative code showcasing the fix for the potential violation of this rule.
-  """
-  goodExampleCode: String
-
-  """The configured level for the rule."""
-  level: LintDiagnosticLevel!
-
-  """The name for this lint rule."""
-  rule: LintRule!
-}
-
-input LinterRuleLevelConfigurationChangesInput {
-  level: LintDiagnosticLevel!
-  rule: LintRule!
 }
 
 """The result of linting a schema."""
@@ -10087,10 +3078,6 @@ type Location {
   subgraphName: String
 }
 
-enum LoginFlowSource {
-  INTERNAL_SSO
-}
-
 """Level of the log entry"""
 enum LogLevel {
   """Debug log entry"""
@@ -10121,97 +3108,7 @@ type LogMessage {
 """Long type"""
 scalar Long
 
-type MarkChangesForOperationAsSafeResult {
-  success: Boolean!
-  message: String!
-
-  """
-  Nice to have for the frontend since the Apollo cache is already watching for AffectedQuery to update.
-  This might return null if no behavior changes were found for the affected operation ID.
-  This is a weird situation that should never happen.
-  """
-  affectedOperation: AffectedQuery
-}
-
-type MediaUploadInfo {
-  csrfToken: String!
-  maxContentLength: Int!
-  url: String!
-}
-
-"""
-This type represents a conflict between two versions of a schema i.e. the current proposal and the updated source variant schema
-"""
-type MergeConflict {
-  """The diffs that caused the conflict"""
-  diffItems: [FlatDiffItem!]!
-
-  """location of conflicts in the partialMergeSdl"""
-  locationCoordinate: ParsedSchemaCoordinate
-
-  """message explaining the conflict"""
-  message: String
-}
-
-type MergedSdlWithConflictsData {
-  subgraphsWithConflicts: [SubgraphWithConflicts!]!
-}
-
-union MergedSdlWithConflictsResult = MergedSdlWithConflictsData | NotFoundError
-
-type MeteredBillCreditGrantLineItem {
-  amountInCents: Int!
-}
-
-type MeteredBillFlatFeeLineItem {
-  amountInCents: Int!
-  name: String!
-}
-
-type MeteredBillingSummary {
-  """
-  Aggregated meter usage that has already been exported to our third-party billing provider (e.g. Stripe).
-  Currently only supports monthly granularity.
-  """
-  exportedMeterValues(end: Date, start: Date!): [MeterSummaries!]!
-  upcomingBill: UpcomingMeteredBill!
-}
-
-type MeteredBillMeteredLineItem {
-  amountInCents: Int!
-  meterKind: MeterKind!
-}
-
-enum MeterKind {
-  PERFORMANCE_ADDON_OPERATIONS
-  STANDARD_OPERATIONS
-  SUBSCRIPTION_MESSAGES
-}
-
-type MeterSummaries {
-  aggregatedValues: [MeterValue!]!
-  end: Date!
-  start: Date!
-}
-
-type MeterValue {
-  meterKind: MeterKind!
-  value: Long!
-}
-
-type MetricStatWindow {
-  timestamp: Timestamp!
-  value: Long!
-  windowSize: BillingUsageStatsWindowSize!
-}
-
-union MoveOperationCollectionEntryResult = InvalidTarget | MoveOperationCollectionEntrySuccess | PermissionError
-
-type MoveOperationCollectionEntrySuccess {
-  operation: OperationCollectionEntry!
-  originCollection: OperationCollection!
-  targetCollection: OperationCollection!
-}
+union McpDefaultCollectionResult = OperationCollection | PermissionError
 
 """
 Input type to provide when running schema checks against multiple subgraph changes asynchronously for a federated supergraph.
@@ -10255,58 +3152,10 @@ input MultiSubgraphCheckAsyncInput {
 
 """GraphQL mutations"""
 type Mutation {
-  billing: BillingMutation
-
-  """Define a new billing plan"""
-  newBillingPlan(plan: BillingPlanInput!): BillingPlan
-
-  """
-  Define a new boolean capability to be applied to billing plans and subscriptions
-  """
-  newCapability(capability: BillingCapabilityInput!): BillingCapability
-
-  """
-  Define a new numeric limit to be applied to billing plans and subscriptions
-  """
-  newLimit(limit: BillingLimitInput!): BillingLimit
-  plan(id: ID!): BillingPlanMutation
-  updateSurvey(internalAccountId: String!, surveyId: String!, surveyIdVersion: Int!, surveyState: [SurveyQuestionInput!]!): Survey!
-
-  """Cloud mutations"""
-  cloud: CloudMutation!
-  cloudTesting: CloudTestingMutation!
-  account(id: ID!): AccountMutation @deprecated(reason: "Use Mutation.organization instead.")
-  addOidcConfigurationToBaseConnection(config: OidcConfigurationInput!, configurationKey: String!): SsoConnection
-
-  """
-  Allows the frontend to check if a SSO configuration key is valid.
-  This helps restrict access to the public SSO configuration page.
-  """
-  checkSsoConfigurationKey(key: String!): Boolean!
-
-  """
-  Finalize a password reset with a token included in the E-mail link,
-  returns the corresponding login email when successful
-  """
-  finalizePasswordReset(newPassword: String!, resetToken: String!): String
-
-  """Join an account with a token"""
-  joinAccount(accountId: ID!, joinToken: String!): Account
-  me: IdentityMutation
-  newAccount(companyUrl: String, id: ID!, organizationName: String, planId: String): Account
-
   """
   Provides access to mutation fields for modifying a an organization with the provided ID.
   """
-  organization(id: ID!): AccountMutation
-
-  """Ask for a user's password to be reset by E-mail"""
-  resetPassword(email: String!): Void
-
-  """Set the studio settings for the current user"""
-  setUserSettings(newSettings: UserSettingsInput): UserSettings
-  signUp(email: String!, fullName: String!, password: String!, referrer: String, trackingGoogleClientId: String, trackingMarketoClientId: String, trackingValues: UserTrackingInput, userSegment: UserSegment, utmCampaign: String, utmMedium: String, utmSource: String): User
-  ssoV2: SsoMutation!
+  organization(id: ID!): OrganizationMutation
 
   """
   Provides access to mutation fields for modifying an Apollo user with the
@@ -10317,99 +3166,10 @@ type Mutation {
   """
   Provides access to mutation fields for modifying a Studio graph with the provided ID.
   """
-  graph(id: ID!): ServiceMutation
-  newService(accountId: ID!, description: String, hiddenFromUninvitedNonAdminAccountMembers: Boolean! = false, id: ID!, isDev: Boolean = false @deprecated(reason: "No longer supported"), name: String, onboardingArchitecture: OnboardingArchitecture, title: String): Service
-
-  """Report a running GraphQL server's schema."""
-  reportSchema(
-    """
-    Only sent if previously requested i.e. received ReportSchemaResult with withCoreSchema = true. This is a GraphQL schema document as a string. Note that for a GraphQL server with a core schema, this should be the core schema, not the API schema.
-    """
-    coreSchema: String
-
-    """Information about server and its schema."""
-    report: SchemaReport!
-  ): ReportSchemaResult
-  resolveAllInternalCronExecutions(group: String, name: String): Void
-  resolveInternalCronExecution(id: ID!): CronExecution
-  service(id: ID!): ServiceMutation
-
-  """Set the subscriptions for a given email"""
-  setSubscriptions(email: String!, subscriptions: [EmailCategory!]!, token: String!): EmailPreferences
+  graph(id: ID!): GraphMutation
 
   """
-  This is called by the form shown to users after they delete their user or organization account.
-  """
-  submitPostDeletionFeedback(feedback: String!, targetIdentifier: ID!, targetType: DeletionTargetType!): Void
-
-  """Mutation for basic engagement tracking in studio"""
-  track(event: EventEnum!, graphID: String!, graphVariant: String! = "current"): Void
-
-  """Apollo Kotlin usage tracking."""
-  trackApolloKotlinUsage(
-    """Events to log"""
-    events: [ApolloKotlinUsageEventInput!]!
-
-    """
-    A random ID that is generated on first initialization of the Apollo Kotlin IJ/AS plugin on a given project
-    """
-    instanceId: ID!
-
-    """Properties to log"""
-    properties: [ApolloKotlinUsagePropertyInput!]!
-  ): Void
-
-  """
-  Router usage tracking. Reserved to https://router.apollo.dev/telemetry (https://github.com/apollographql/orbiter).
-  """
-  trackRouterUsage(
-    """
-    If we think the router is being run on continuous integration then this will be populated
-    """
-    ci: String
-
-    """The OS that the router is running on"""
-    os: String!
-
-    """
-    A random ID that is generated on first startup of the Router. It is not persistent between restarts of the Router, but will be persistent for hot reloads
-    """
-    sessionId: ID!
-
-    """
-    A list of key count pairs that represents the a path into the config/arguments and the number of times that it occurred
-    """
-    usage: [RouterUsageInput!]!
-
-    """The version of the Router"""
-    version: String!
-  ): Void
-
-  """
-  Rover session tracking. Reserved to https://rover.apollo.dev/telemetry (https://github.com/apollographql/orbiter).
-  """
-  trackRoverSession(anonymousId: ID!, arguments: [RoverArgumentInput!]!, ci: String, command: String!, cwdHash: SHA256!, os: String!, remoteUrlHash: SHA256, sessionId: ID!, version: String!): Void
-
-  """Unsubscribe a given email from all emails"""
-  unsubscribeFromAll(email: String!, token: String!): EmailPreferences
-
-  """Push a lead to Marketo by program ID"""
-  pushMarketoLead(
-    """Marketo program ID"""
-    programId: ID!
-
-    """Marketo program status"""
-    programStatus: String
-
-    """Marketo lead source"""
-    source: String
-    input: PushMarketoLeadInput!
-  ): Boolean!
-  transferOdysseyProgress(from: ID!, to: ID!): Boolean!
-  publishEDUEvent(type: String!, data: String!): Boolean!
-
-  """
-  Creates an [operation collection](https://www.apollographql.com/docs/studio/explorer/operation-collections/) for a given variant, or creates a [sandbox collection](https://www.apollographql.com/docs/studio/explorer/operation-collections/#sandbox-collections) without an associated variant.
+  Creates an [operation collection](https://www.apollographql.com/docs/studio/explorer/operation-collections/) for a given variant, or creates a [sandbox collection](https://www.apollographql.com/docs/studio/explorer/operation-collections/#sandbox-collections) without an associated variant. This field accepts up to 200 requests per minute. This rate may be temporarily adjusted based on system conditions.
   """
   createOperationCollection(
     """The collection's description."""
@@ -10442,7 +3202,6 @@ type Mutation {
   Provides access to mutation fields for modifying a GraphOS Schema Proposals with the provided ID. Learn more at https://www.apollographql.com/docs/graphos/delivery/schema-proposals
   """
   proposal(id: ID!): ProposalMutationResult! @deprecated(reason: "Use GraphVariantMutation.proposal instead")
-  proposalByVariantRef(variantRef: ID!): ProposalMutationResult! @deprecated(reason: "Use GraphVariantMutation.proposal instead")
 }
 
 """
@@ -10457,10 +3216,6 @@ scalar NaiveDateTime
 type NamedIntrospectionArg {
   name: String
   description: String
-}
-
-type NamedIntrospectionArgNoDescription {
-  name: String
 }
 
 """
@@ -10478,10 +3233,6 @@ type NamedIntrospectionType {
   description: String
 }
 
-type NamedIntrospectionTypeNoDescription {
-  name: String
-}
-
 """
 Introspection values that can be children of other types for changes, such
 as input fields, objects in interfaces, enum values. In the future, this
@@ -10494,304 +3245,10 @@ type NamedIntrospectionValue {
   printedType: String
 }
 
-type NamedIntrospectionValueNoDescription {
-  name: String
-  printedType: String
-}
-
-"""A non-federated service for a monolithic graph."""
-type NonFederatedImplementingService {
-  """Timestamp of when this implementing service was created."""
-  createdAt: Timestamp!
-
-  """
-  Identifies which graph this non-implementing service belongs to.
-  Formerly known as "service_id".
-  """
-  graphID: String!
-
-  """
-  Specifies which variant of a graph this implementing service belongs to".
-  Formerly known as "tag".
-  """
-  graphVariant: String!
-}
-
 """An error that occurs when a requested object is not found."""
 type NotFoundError implements Error {
   """The error message."""
   message: String!
-}
-
-enum NotificationStatus {
-  ALL
-  NONE
-}
-
-"""An arbitrary JSON object."""
-scalar Object
-
-type OdysseyAttempt {
-  id: ID!
-  testId: String!
-  startedAt: Timestamp!
-  completedAt: Timestamp
-  responses: [OdysseyResponse!]!
-  pass: Boolean
-}
-
-type OdysseyCertification {
-  id: ID!
-  certificationId: String!
-  earnedAt: Timestamp!
-  owner: OdysseyCertificationOwner
-  source: String
-  icon: String
-}
-
-type OdysseyCertificationOwner {
-  id: ID!
-  fullName: String!
-}
-
-type OdysseyCourse {
-  id: ID!
-  enrolledAt: Timestamp
-  completedAt: Timestamp
-  language: String
-}
-
-input OdysseyCourseInput {
-  courseId: String!
-  completedAt: Timestamp
-  isBeta: Boolean
-  language: String
-}
-
-type OdysseyResponse {
-  id: ID!
-  questionId: String!
-  values: [OdysseyValue!]!
-  correct: Boolean
-}
-
-input OdysseyResponseCorrectnessInput {
-  id: ID!
-  correct: Boolean!
-}
-
-input OdysseyResponseInput {
-  attemptId: ID!
-  questionId: String!
-  correct: Boolean
-  values: [String!]!
-}
-
-type OdysseyTask {
-  id: ID!
-  value: String
-  completedAt: Timestamp
-}
-
-input OdysseyTaskInput {
-  taskId: String!
-  value: String
-  completedAt: Timestamp
-}
-
-type OdysseyValue {
-  id: ID!
-  value: String!
-}
-
-input OidcConfigurationInput {
-  clientId: String!
-  clientSecret: String!
-  discoveryURI: String
-  issuer: String!
-}
-
-input OidcConfigurationUpdateInput {
-  clientId: String!
-  clientSecret: String
-  discoveryURI: String
-  issuer: String!
-}
-
-type OidcConnection implements SsoConnection {
-  clientId: ID!
-  discoveryUri: String
-  domains: [String!]!
-  id: ID!
-  idpId: ID!
-  issuer: String!
-  scim: SsoScimProvisioningDetails
-  state: SsoConnectionState! @deprecated(reason: "Use stateV2 instead")
-  stateV2: SsoConnectionStateV2!
-}
-
-enum OnboardingArchitecture {
-  MONOLITH
-  SUPERGRAPH
-}
-
-type Operation {
-  id: ID!
-  name: String
-  signature: String
-  truncated: Boolean!
-}
-
-type OperationAcceptedChange {
-  id: ID!
-  graphID: ID!
-  checkID: ID!
-  operationID: String!
-  change: StoredApprovedChange!
-  acceptedAt: Timestamp!
-  acceptedBy: Identity
-}
-
-"""Columns of OperationCheckStats."""
-enum OperationCheckStatsColumn {
-  CACHED_REQUESTS_COUNT
-  CLIENT_NAME
-  CLIENT_VERSION
-  OPERATION_SUBTYPE
-  OPERATION_TYPE
-  QUERY_ID
-  QUERY_NAME
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-  UNCACHED_REQUESTS_COUNT
-}
-
-type OperationCheckStatsDimensions {
-  clientName: String
-  clientVersion: String
-  operationSubtype: String
-  operationType: String
-  queryId: ID
-  queryName: String
-  schemaTag: String
-  serviceId: ID
-}
-
-"""
-Filter for data in OperationCheckStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input OperationCheckStatsFilter {
-  and: [OperationCheckStatsFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-  in: OperationCheckStatsFilterIn
-  not: OperationCheckStatsFilter
-
-  """
-  Selects rows whose operationSubtype dimension equals the given value if not null. To query for the null value, use {in: {operationSubtype: [null]}} instead.
-  """
-  operationSubtype: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [OperationCheckStatsFilter!]
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: ID
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-}
-
-"""
-Filter for data in OperationCheckStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input OperationCheckStatsFilterIn {
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose operationSubtype dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationSubtype: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [ID]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-}
-
-type OperationCheckStatsMetrics {
-  cachedRequestsCount: Long!
-  uncachedRequestsCount: Long!
-}
-
-input OperationCheckStatsOrderBySpec {
-  column: OperationCheckStatsColumn!
-  direction: Ordering!
-}
-
-type OperationCheckStatsRecord {
-  """Dimensions of OperationCheckStats that can be grouped by."""
-  groupBy: OperationCheckStatsDimensions!
-
-  """Metrics of OperationCheckStats that can be aggregated over."""
-  metrics: OperationCheckStatsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
 }
 
 """A list of saved GraphQL operations."""
@@ -10806,12 +3263,6 @@ type OperationCollection {
   The collection's description. A `null` description was never set, and empty string description was set to be empty string by a user, or other entity.
   """
   description: String
-
-  """
-  If a user has any of these roles, they will be able to edit this
-  collection.
-  """
-  editRoles: [UserPermission!] @deprecated(reason: "deprecated in favour of minEditRole")
   id: ID!
 
   """Whether the current user has marked the collection as a favorite."""
@@ -10847,13 +3298,10 @@ type OperationCollection {
 
   """The permissions that the current user has for the collection."""
   permissions: OperationCollectionPermissions!
-  variants: [GraphVariant!]!
 }
 
 """A saved operation entry within an Operation Collection."""
 type OperationCollectionEntry {
-  collection: OperationCollection!
-
   """The timestamp when the entry was created."""
   createdAt: Timestamp!
 
@@ -10883,9 +3331,6 @@ type OperationCollectionEntry {
 
 """Provides fields for modifying an operation in a collection."""
 type OperationCollectionEntryMutation {
-  moveToCollection(collectionId: ID!, lowerOrderingBound: String, upperOrderingBound: String): MoveOperationCollectionEntryResult!
-  reorderEntry(lowerOrderingBound: String, upperOrderingBound: String): UpdateOperationCollectionResult
-
   """Updates the name of an operation."""
   updateName(name: String!): UpdateOperationCollectionEntryResult
 
@@ -10907,24 +3352,8 @@ type OperationCollectionEntryState {
   """The raw body of the entry's GraphQL operation."""
   body: String!
 
-  """The timestamp when the entry state was created."""
-  createdAt: Timestamp!
-
-  """The user or other entity that created this entry state."""
-  createdBy: Identity
-
   """Headers for the entry's GraphQL operation."""
   headers: [OperationHeader!]
-
-  """
-  The post operation workflow automation script for this entry's GraphQL operation
-  """
-  postflightOperationScript: String
-
-  """
-  The pre operation workflow automation script for this entry's GraphQL operation
-  """
-  script: String
 
   """Variables for the entry's GraphQL operation, as a JSON string."""
   variables: String
@@ -10938,18 +3367,12 @@ input OperationCollectionEntryStateInput {
   """The operation's headers."""
   headers: [OperationHeaderInput!]
 
-  """The operation's postflight workflow script"""
-  postflightOperationScript: String
-
-  """The operation's preflight workflow script"""
-  script: String
-
   """The operation's variables."""
   variables: String
 }
 
 """
-Provides fields for modifying an [operation collection](https://www.apollographql.com/docs/studio/explorer/operation-collections/).
+Provides fields for modifying an [operation collection](https://www.apollographql.com/docs/studio/explorer/operation-collections/). This fields on this type accepts up to 200 requests per minute combined. This rate may be temporarily adjusted based on system conditions.
 """
 type OperationCollectionMutation {
   """Adds an operation to this collection."""
@@ -10957,7 +3380,6 @@ type OperationCollectionMutation {
 
   """Adds operations to this collection."""
   addOperations(operations: [AddOperationInput!]!): AddOperationCollectionEntriesResult
-  addToVariant(variantRef: ID!): AddOperationCollectionToVariantResult! @deprecated(reason: "Will throw NotImplemented")
 
   """
   Deletes this operation collection. This also deletes all of the collection's associated operations.
@@ -10966,9 +3388,7 @@ type OperationCollectionMutation {
 
   """Deletes an operation from this collection."""
   deleteOperation(id: ID!): RemoveOperationCollectionEntryResult
-  duplicateCollection(description: String, isSandbox: Boolean!, isShared: Boolean!, name: String!, variantRef: ID): DuplicateOperationCollectionResult!
   operation(id: ID!): OperationCollectionEntryMutationResult
-  removeFromVariant(variantRef: ID!): RemoveOperationCollectionFromVariantResult! @deprecated(reason: "Will throw NotImplemented")
 
   """
   Updates the minimum role a user needs to be able to modify this collection.
@@ -11014,35 +3434,6 @@ type OperationCollectionPermissions {
 
 union OperationCollectionResult = NotFoundError | OperationCollection | PermissionError | ValidationError
 
-type OperationDetails {
-  """
-  A hashed representation of the signature, commonly used as the operation ID.
-  """
-  id: String!
-
-  """The operation name or null if the operation is unnamed."""
-  name: String
-
-  """First 128 characters of query signature for display."""
-  signature: String
-}
-
-type OperationDocument {
-  """Operation document body"""
-  body: String!
-
-  """Operation name"""
-  name: String
-}
-
-input OperationDocumentInput {
-  """Operation document body"""
-  body: String!
-
-  """Operation name"""
-  name: String
-}
-
 """Saved headers on a saved operation."""
 type OperationHeader {
   """The header's name."""
@@ -11066,116 +3457,6 @@ type OperationInfoFilter {
 
 input OperationInfoFilterInput {
   id: String!
-}
-
-input OperationInsightsListFilterInInput {
-  clientName: [String]
-  clientVersion: [String]
-}
-
-input OperationInsightsListFilterInput {
-  clientName: String
-  clientVersion: String
-  in: OperationInsightsListFilterInInput
-  isUnnamed: Boolean
-  isUnregistered: Boolean
-  operationTypes: [OperationType!]
-  or: [OperationInsightsListFilterInput!]
-  search: String
-}
-
-type OperationInsightsListItem {
-  cacheHitRate: Float!
-
-  """
-  The p50 of the latency across cached requests. This can be null depending on the filter and sort order.
-  """
-  cacheTtlP50Ms: Float
-
-  """
-  A substring of the query signature for unnamed operations, otherwise the operation name.
-  """
-  displayName: String!
-  errorCount: Long!
-  errorCountPerMin: Float!
-  errorPercentage: Float!
-
-  """The unique id for this operation."""
-  id: ID!
-
-  """The operation name or null if the operation is unnamed."""
-  name: String
-  requestCount: Long!
-  requestCountPerMin: Float!
-
-  """
-  The p50 of the latency across all requests. This can be null depending on the filter and sort order.
-  """
-  serviceTimeP50Ms: Float
-
-  """
-  The p90 of the latency across all requests. This can be null depending on the filter and sort order.
-  """
-  serviceTimeP90Ms: Float
-
-  """
-  The p95 of the latency across all requests. This can be null depending on the filter and sort order.
-  """
-  serviceTimeP95Ms: Float
-
-  """
-  The p99 of the latency across all requests. This can be null depending on the filter and sort order.
-  """
-  serviceTimeP99Ms: Float
-
-  """
-  The query signature size as a number of UTF8 bytes. This can be null if the sort order is not SIGNATURE_BYTES.
-  """
-  signatureBytes: Long
-
-  """
-  The total duration across all requests. This can be null depending on the filter and sort order.
-  """
-  totalDurationMs: Float
-  type: OperationType
-}
-
-enum OperationInsightsListOrderByColumn {
-  CACHE_HIT_RATE
-  CACHE_TTL_P50
-  ERROR_COUNT
-  ERROR_COUNT_PER_MIN
-  ERROR_PERCENTAGE
-  OPERATION_NAME
-  REQUEST_COUNT
-  REQUEST_COUNT_PER_MIN
-  SERVICE_TIME_P50
-  SERVICE_TIME_P90
-  SERVICE_TIME_P95
-  SERVICE_TIME_P99
-  SIGNATURE_BYTES
-  TOTAL_DURATION_MS
-}
-
-input OperationInsightsListOrderByInput {
-  """
-  The order column used for the operation results. Defaults to ordering by operation names.
-  """
-  column: OperationInsightsListOrderByColumn!
-
-  """
-  The direction used to order operation results. Defaults to ascending order.
-  """
-  direction: Ordering!
-}
-
-"""Information about pagination in a connection."""
-type OperationInsightsListPageInfo {
-  """When paginating forwards, the cursor to continue."""
-  endCursor: String
-
-  """When paginating backwards, the cursor to continue."""
-  startCursor: String
 }
 
 """Operation name filter configuration for a graph."""
@@ -11221,13 +3502,6 @@ type OperationsCheckConfiguration {
   """
   excludedOperations: [OperationInfoFilter!]!
 
-  """
-  The start of the time range for the operations check, expressed as an offset from the time the
-  check request was received (in seconds) or an ISO-8601 timestamp. This was either provided by the
-  user or computed from variant- or graph-level settings.
-  """
-  from: String! @deprecated(reason: "Use fromNormalized instead")
-
   """The start of the time range for the operations check."""
   fromNormalized: Timestamp!
 
@@ -11248,13 +3522,6 @@ type OperationsCheckConfiguration {
   <operationCountThresholdPercentage>% of the operations in the time range.
   """
   operationCountThresholdPercentage: Float!
-
-  """
-  The end of the time range for the operations check, expressed as an offset from the time the
-  check request was received (in seconds) or an ISO-8601 timestamp. This was either provided by the
-  user or computed from variant- or graph-level settings.
-  """
-  to: String! @deprecated(reason: "Use toNormalized instead")
 
   """The end of the time range for the operations check."""
   toNormalized: Timestamp!
@@ -11323,15 +3590,7 @@ input OperationsCheckConfigurationOverridesInput {
 }
 
 type OperationsCheckResult {
-  """Graph ID of the variant"""
-  graphID: String!
   id: ID!
-
-  """Operations checked against but not affecting the diff."""
-  unaffectedOperations: [OperationDetails!]
-
-  """The variant that was used as a base to check against"""
-  checkedVariant: GraphVariant!
 
   """
   Indication of the success of the change, either failure, warning, or notice.
@@ -11356,17 +3615,33 @@ type OperationsCheckResult {
   areChangesTruncated: Boolean!
 
   """Operations affected by all changes in diff"""
-  affectedQueries: [AffectedQuery!]
+  affectedQueries(
+    """The maximum number of affected queries to return. Must be 50 or fewer."""
+    limit: Int
+
+    """
+    How many items to skip before starting to return results.
+    For example, with `limit: 10` and `offset: 10`, you get items 11–20.
+    """
+    offset: Int
+
+    """Optional filters to narrow down which affected queries are returned."""
+    filter: AffectedQueriesFilterInput
+  ): [AffectedQuery!]
+
+  """Returns an affected operation and its changes for this check"""
+  affectedQuery(id: ID!): AffectedQuery
 
   """
-  Number of affected query operations that are neither marked as SAFE or IGNORED
+  Number of affected operations that are neither marked as SAFE or IGNORED.
   """
   numberOfAffectedOperations: Int!
-  workflowTask: OperationsCheckTask!
-  createdAt: Timestamp!
 
-  """The threshold that was crossed; null if the threshold was not exceeded"""
-  crossedOperationThreshold: Int
+  """
+  Total number of affected operations including ones marked SAFE or IGNORED.
+  """
+  totalNumberOfAffectedOperations: Int!
+  createdAt: Timestamp!
 }
 
 type OperationsCheckTask implements CheckWorkflowTask {
@@ -11389,10 +3664,6 @@ enum OperationType {
   MUTATION
   QUERY
   SUBSCRIPTION
-}
-
-type OperationValidationError {
-  message: String!
 }
 
 """Cloud Router order"""
@@ -11425,29 +3696,6 @@ type Order {
 
   """Router associated with this Order"""
   router: Router!
-
-  """Shard associated with this Order"""
-  shard: Shard!
-
-  """Checks if the service is updated"""
-  serviceReady: Boolean!
-
-  """Introspect why call to `ready` failed"""
-  introspectReady: String!
-
-  """Checks if we can serve requests through the external endpoint"""
-  readyExternal: Boolean!
-}
-
-"""The order does not exist"""
-type OrderDoesNotExistError {
-  tryAgainSeconds: Int!
-}
-
-"""Catch-all failure result of a failed order mutation."""
-type OrderError {
-  """Error message"""
-  message: String!
 }
 
 enum Ordering {
@@ -11455,120 +3703,8 @@ enum Ordering {
   DESCENDING
 }
 
-enum OrderingDirection {
-  ASC
-  DESC
-}
-
-type OrderMutation {
-  """Set default environment variables"""
-  setDefaultVars: OrderResult!
-
-  """Update secrets"""
-  updateSecrets: OrderResult!
-
-  """Create CNAME record"""
-  createCname: OrderResult!
-
-  """Delete API key"""
-  deleteApiKey: OrderResult!
-
-  """Delete CNAME"""
-  deleteCname: OrderResult!
-
-  """Rollback CNAME record"""
-  rollbackCname: OrderResult!
-
-  """Rollback router information"""
-  rollbackInfo: OrderResult!
-
-  """Rollback router information"""
-  rollbackSecrets: OrderResult!
-
-  """Update router information"""
-  updateInfo: OrderResult!
-
-  """Update order status"""
-  updateStatus(status: OrderStatus!, updateRouter: Boolean): OrderResult!
-
-  """Update order status with a reason and cause"""
-  updateStatusWithReason(status: OrderStatus!, reason: String!, cause: ReasonCause!, updateRouter: Boolean): OrderResult!
-
-  """Force rollback of the order"""
-  forceRollback: OrderResult!
-
-  """Create an ALB rule"""
-  createAlbRule: OrderResult!
-
-  """Create an IAM Role"""
-  createIamRole: OrderResult!
-
-  """Create a security group"""
-  createSecurityGroup: OrderResult!
-
-  """Create an ECS service"""
-  createService: OrderResult!
-
-  """Create a target group"""
-  createTargetGroup: OrderResult!
-
-  """Create a task definition"""
-  createTaskDefinition: OrderResult!
-
-  """Delete an ALB rule"""
-  deleteAlbRule: OrderResult!
-
-  """Delete an IAM Role"""
-  deleteIamRole: OrderResult!
-
-  """Delete a security group"""
-  deleteSecurityGroup: OrderResult!
-
-  """Delete an ECS service"""
-  deleteService: OrderResult!
-
-  """Delete a target group"""
-  deleteTargetGroup: OrderResult!
-
-  """Delete a task definition"""
-  deleteTaskDefinition: OrderResult!
-
-  """Update an ALB rule"""
-  updateAlbRule: OrderResult!
-
-  """Rollback an ALB rule"""
-  rollbackAlbRule: OrderResult!
-
-  """Rollback an IAM Role"""
-  rollbackIamRole: OrderResult!
-
-  """Rollback a security group"""
-  rollbackSecurityGroup: OrderResult!
-
-  """Rollback an ECS service"""
-  rollbackService: OrderResult!
-
-  """Rollback a target group"""
-  rollbackTargetGroup: OrderResult!
-
-  """Rollback a task definition"""
-  rollbackTaskDefinition: OrderResult!
-
-  """Update an IAM Role"""
-  updateIamRole: OrderResult!
-
-  """Update a Service"""
-  updateService: OrderResult!
-
-  """Update a task definition"""
-  updateTaskDefinition: OrderResult!
-}
-
 """Return an Order or an error"""
-union OrderOrError = Order | OrderDoesNotExistError
-
-"""Represents the possible outcomes of an order mutation"""
-union OrderResult = Order | InvalidInputErrors | OrderError
+union OrderOrError = Order
 
 """Represents the different status for an order"""
 enum OrderStatus {
@@ -11609,31 +3745,6 @@ enum OrderType {
   UPDATE_ROUTER
 }
 
-"""A reusable invite link for an organization."""
-type OrganizationInviteLink {
-  createdAt: Timestamp!
-
-  """
-  A joinToken that can be passed to Mutation.joinAccount to join the organization.
-  """
-  joinToken: String!
-
-  """
-  The role that the user will receive if they join the organization with this link.
-  """
-  role: UserPermission!
-}
-
-type OrganizationSSO {
-  defaultRole: UserPermission!
-  idpid: ID!
-  provider: OrganizationSSOProvider!
-}
-
-enum OrganizationSSOProvider {
-  APOLLO
-}
-
 """Information about pagination in a connection."""
 type PageInfo {
   """When paginating forwards, the cursor to continue."""
@@ -11649,21 +3760,7 @@ type PageInfo {
   startCursor: String
 }
 
-"""PagerDuty notification channel"""
-type PagerDutyChannel implements Channel {
-  id: ID!
-  name: String!
-  routingKey: String!
-  subscriptions: [ChannelSubscription!]!
-}
-
-"""PagerDuty notification channel parameters"""
-input PagerDutyChannelInput {
-  name: String
-  routingKey: String!
-}
-
-type ParentChangeProposalComment implements ChangeProposalComment & ProposalComment {
+type ParentChangeProposalComment implements ProposalComment {
   createdAt: Timestamp!
 
   """null if the user is deleted"""
@@ -11704,44 +3801,10 @@ type ParentGeneralProposalComment implements GeneralProposalComment & ProposalCo
   updatedAt: Timestamp
 }
 
-union ParentProposalComment = ParentChangeProposalComment | ParentGeneralProposalComment
-
-"""SAML certificate information parsed from an IdP's metadata XML"""
-type ParsedSamlCertInfo {
-  notAfter: Timestamp!
-  notBefore: Timestamp!
-  pem: String!
-  subjectDN: String!
-}
-
-"""SAML metadata parsed from an IdP's metadata XML"""
-type ParsedSamlIdpMetadata {
-  encryptionCerts: [ParsedSamlCertInfo!]!
-  entityId: String!
-  ssoUrl: String!
-  verificationCerts: [ParsedSamlCertInfo!]!
-  wantsSignedRequests: Boolean!
-}
-
-type ParsedSchemaCoordinate {
-  argName: String
-  fieldName: String
-  isDirective: Boolean
-  typeName: String!
-}
-
 """The schema for a single published subgraph in Studio."""
-type PartialSchema {
+type SubgraphSchema {
   """The subgraph schema document as SDL."""
   sdl: String!
-
-  """Timestamp for when the partial schema was created"""
-  createdAt: Timestamp!
-
-  """
-  If this sdl is currently actively composed in the gateway, this is true
-  """
-  isLive: Boolean!
 }
 
 """
@@ -11780,7 +3843,6 @@ type PermissionError implements Error {
 """Information about the act of publishing operations to the list"""
 type PersistedQueriesPublish {
   operationCounts: PersistedQueriesPublishOperationCounts!
-  publishedAt: Timestamp!
 }
 
 type PersistedQueriesPublishOperationCounts {
@@ -11804,53 +3866,6 @@ type PersistedQueriesPublishOperationCounts {
   The number of operations whose metadata or body were changed by this publish.
   """
   updated: Int!
-}
-
-type PersistedQuery {
-  body: GraphQLDocument!
-
-  """
-  An optional client name associated with the operation. Two operations with the same ID but different client names are treated as distinct operations. An operation with the same ID and a null client name is treated as a distinct operation as well.
-  """
-  clientName: String
-  firstPublishedAt: Timestamp!
-
-  """
-  An opaque identifier for this operation. For a given client name, this should map uniquely to an operation body; editing the body should generally result in a new ID. Apollo's tools generally use the lowercase hex SHA256 of the operation body. Note that for (eg) Apollo Client keyFields, you should use both `id` and `clientName`.
-  """
-  id: ID!
-  lastPublishedAt: Timestamp!
-
-  """The GraphQL operation name for this operation."""
-  name: String!
-  type: OperationType!
-}
-
-type PersistedQueryConnection {
-  edges: [PersistedQueryEdge!]!
-  pageInfo: PageInfo!
-  totalCount: Int!
-}
-
-type PersistedQueryEdge {
-  cursor: String!
-  node: PersistedQuery!
-}
-
-"""Filter options for persisted query operations"""
-input PersistedQueryFilterInput {
-  """Only include operations whose client name is included in this list"""
-  clients: [String]
-
-  """
-  Only include operations whose last published date is before or after the given date
-  """
-  lastPublishedAt: TimestampFilterInput
-
-  """
-  Only include operations whose names contain this case-insensitive substring
-  """
-  name: String
 }
 
 """Full identifier for an operation in a Persisted Query List."""
@@ -11894,65 +3909,23 @@ input PersistedQueryInput {
 
 """A Persisted Query List for a graph."""
 type PersistedQueryList {
-  builds(after: String, before: String, first: Int, last: Int): PersistedQueryListBuildConnection!
-
-  """
-  Distinct client names associated with all operations in this Persisted Query List, if any.
-  """
-  clientNames(first: Int): StringConnection!
-  createdAt: Timestamp!
-  createdBy: User
-
   """The current build of this PQL."""
   currentBuild: PersistedQueryListBuild!
-  description: String!
-  graph: Service!
 
   """The immutable ID for this Persisted Query List."""
   id: ID!
-  lastUpdatedAt: Timestamp!
 
   """All variants linked to this Persisted Query List, if any."""
   linkedVariants: [GraphVariant!]!
 
   """The list's name; can be changed and does not need to be unique."""
   name: String!
-  operation(
-    """
-    An optional client name associated with the operation. Two operations with the same ID but different client names are treated as distinct operations. An operation with the same ID and a null client name is treated as a distinct operation as well.
-    """
-    clientName: String
-
-    """
-    An opaque identifier for this operation. For a given client name, this should map uniquely to an operation body; editing the body should generally result in a new ID. Apollo's tools generally use the lowercase hex SHA256 of the operation body.
-    """
-    id: ID!
-  ): PersistedQuery
-
-  """All operations in this Persisted Query List, if any."""
-  operations(
-    after: String
-    before: String
-
-    """Filter criteria for persisted query operations"""
-    filter: PersistedQueryFilterInput
-    first: Int
-    last: Int
-
-    """Sort criteria for persisted query operations"""
-    sort: PersistedQuerySortInput
-  ): PersistedQueryConnection!
 }
 
 """
 Information about a particular revision of the list, as produced by a particular publish.
 """
 type PersistedQueryListBuild {
-  """
-  A unique ID for this build revision; primarily useful as a client cache ID.
-  """
-  id: String!
-
   """The persisted query list that this build built."""
   list: PersistedQueryList!
 
@@ -11975,23 +3948,11 @@ type PersistedQueryListBuild {
   totalOperationsInList: Int!
 }
 
-type PersistedQueryListBuildConnection {
-  edges: [PersistedQueryListBuildEdge!]!
-  pageInfo: PageInfo!
-}
-
-type PersistedQueryListBuildEdge {
-  cursor: String!
-  node: PersistedQueryListBuild!
-}
-
 type PersistedQueryListManifestChunk {
   """
   An immutable identifier for this particular chunk of a PQL. The contents referenced by this ID will never change.
   """
   id: ID!
-  json: String!
-  list: PersistedQueryList!
 
   """
   The chunk can be downloaded from any of these URLs, which might be transient.
@@ -12002,18 +3963,6 @@ type PersistedQueryListManifestChunk {
 type PersistedQueryListMutation {
   """Deletes this Persisted Query List."""
   delete: DeletePersistedQueryListResultOrError!
-
-  """
-  Deletes operations from this Persisted Query List based on filter criteria, with the ability to exclude specific operations.
-  """
-  deleteOperationsByFilter(
-    """Operations to exclude from deletion, even if they match the filter"""
-    exclude: [PersistedQueryIdInput!]
-
-    """Filter criteria to select operations for deletion"""
-    filter: PersistedQueryFilterInput!
-  ): DeleteOperationsByFilterResultOrError!
-  id: ID!
 
   """
   Updates this Persisted Query List by publishing a set of operations and removing other operations. Operations not mentioned remain in the list unchanged.
@@ -12033,101 +3982,11 @@ type PersistedQueryListMutation {
   updateMetadata(description: String, name: String): UpdatePersistedQueryListMetadataResultOrError!
 }
 
-"""Columns available for sorting persisted query operations"""
-enum PersistedQuerySortColumn {
-  """Sort by the first published date"""
-  FIRST_PUBLISHED_AT
-
-  """Sort by the last published date"""
-  LAST_PUBLISHED_AT
-
-  """Sort by name"""
-  NAME
-}
-
-"""Sort options for persisted query operations"""
-input PersistedQuerySortInput {
-  """The column to sort by"""
-  column: PersistedQuerySortColumn!
-
-  """The direction of sorting"""
-  direction: Ordering!
-}
-
 """An error related to an organization's Apollo Studio plan."""
 type PlanError {
   """The error message."""
   message: String!
 }
-
-"""GraphQL representation of an AWS private subgraph"""
-type PrivateSubgraph {
-  """The name of the subgraph, if set"""
-  name: String
-
-  """The cloud provider where the subgraph is hosted"""
-  cloudProvider: CloudProvider!
-
-  """The private subgraph's region"""
-  region: RegionDescription!
-
-  """The domain URL of the private subgraph"""
-  domainUrl: String
-
-  """The status of the resource share"""
-  status: PrivateSubgraphShareStatus!
-}
-
-type PrivateSubgraphMutation {
-  """Synchronize private subgraphs to your Apollo account"""
-  sync(input: SyncPrivateSubgraphsInput!): [PrivateSubgraph!]!
-}
-
-"""
-The status of an association between a private subgraph and your Apollo account
-"""
-enum PrivateSubgraphShareStatus {
-  """The private subgraph is connected to the Apollo service network"""
-  CONNECTED
-
-  """The private subgraph's connection is pending"""
-  PENDING
-
-  """The private subgraph's disconnection is pending"""
-  PENDING_DISCONNECTION
-
-  """The private subgraph is disconnected to the Apollo service network"""
-  DISCONNECTED
-
-  """
-  The private subgraph's connection to the Apollo service network has errored
-  """
-  ERRORED
-
-  """The current state of the association is unknown"""
-  UNKNOWN
-}
-
-type PromoteSchemaError {
-  code: PromoteSchemaErrorCode!
-  message: String!
-}
-
-enum PromoteSchemaErrorCode {
-  CANNOT_PROMOTE_SCHEMA_FOR_FEDERATED_GRAPH
-}
-
-type PromoteSchemaResponse {
-  code: PromoteSchemaResponseCode!
-  tag: SchemaTag!
-}
-
-enum PromoteSchemaResponseCode {
-  PROMOTION_SUCCESS
-  NO_CHANGES_DETECTED
-}
-
-union PromoteSchemaResponseOrError = PromoteSchemaResponse | PromoteSchemaError
 
 type Proposal {
   """
@@ -12143,8 +4002,6 @@ type Proposal {
   Can the current user can edit THIS proposal, either by authorship or role level
   """
   canEditProposal: Boolean!
-  changes: [ProposalChange!]!
-  comment(id: ID!): ProposalCommentResult
   createdAt: Timestamp!
 
   """
@@ -12171,23 +4028,7 @@ type Proposal {
   """
   isPartiallyImplemented: Boolean!
   latestRevision: ProposalRevision!
-  mergeBaseCompositionId: ID
-
-  """Use mergedSdlWithConflicts instead."""
-  mergedSdl: [SubgraphWithConflicts!]! @deprecated(reason: "Use mergedSdlWithConflicts instead")
-
-  """
-  Returns a partially merged sdl string and list of conflicts in the sdl by merging the proposals's current sdl and the source variant's current sdl against the source variant's sdl at the time of the last merge or proposal creation.
-  """
-  mergedSdlWithConflicts: MergedSdlWithConflictsResult
-  parentComments(filter: CommentFilter): [ParentProposalComment!]!
-  rebaseConflicts: RebaseConflictResult
-
-  """ null if user deleted or removed from org"""
-  requestedReviewers: [ProposalRequestedReviewer]!
   reviews: [ProposalReview!]!
-  revision(id: ID!): ProposalRevisionResult
-  revisionHistory(limit: Int! = 100, offset: Int! = 0, orderBy: ProposalRevisionHistoryOrder = CREATED_DESC): ProposalRevisionHistoryResult!
 
   """The variant this Proposal was cloned/sourced from."""
   sourceVariant: GraphVariant!
@@ -12276,11 +4117,6 @@ type ProposalActivityEdge {
 
 union ProposalActivityTarget = ParentChangeProposalComment | ParentGeneralProposalComment | Proposal | ProposalFullImplementationProposalOrigin | ProposalFullImplementationVariantOrigin | ProposalPartialImplementationProposalOrigin | ProposalPartialImplementationVariantOrigin | ProposalReview | ProposalRevision
 
-type ProposalChange {
-  diffItem: FlatDiffItem!
-  implemented: Boolean!
-}
-
 enum ProposalChangeMismatchSeverity {
   ERROR
   OFF
@@ -12300,8 +4136,6 @@ interface ProposalComment {
   updatedAt: Timestamp
 }
 
-union ProposalCommentResult = NotFoundError | ParentChangeProposalComment | ParentGeneralProposalComment | ReplyChangeProposalComment | ReplyGeneralProposalComment | ReviewProposalComment
-
 enum ProposalCoverage {
   FULL
   NONE
@@ -12310,7 +4144,7 @@ enum ProposalCoverage {
   PENDING
 }
 
-type ProposalFullImplementationProposalOrigin implements ProposalImplementation {
+type ProposalFullImplementationProposalOrigin {
   """
   the time this Proposal became implemented in the implementation target variant.
   """
@@ -12331,7 +4165,7 @@ type ProposalFullImplementationProposalOrigin implements ProposalImplementation 
   variant: GraphVariant!
 }
 
-type ProposalFullImplementationVariantOrigin implements ProposalImplementation {
+type ProposalFullImplementationVariantOrigin {
   """
   the time this Proposal became implemented in the implementation target variant.
   """
@@ -12352,127 +4186,50 @@ type ProposalFullImplementationVariantOrigin implements ProposalImplementation {
   variant: GraphVariant!
 }
 
-interface ProposalImplementation {
-  """
-  the time this Proposal became implemented in the implementation target variant.
-  """
-  createdAt: Timestamp!
-  id: ID!
-
-  """
-  the diff that was matched between the Proposal and the implementation target variant
-  """
-  jsonDiff: [String!]!
-
-  """the target variant this Proposal became implemented in."""
-  variant: GraphVariant!
-}
-
 type ProposalImplementedChange {
   diffItem: FlatDiffItem!
   launchId: ID!
   subgraph: String!
 }
 
-enum ProposalLifecycleEvent {
-  PROPOSAL_CREATED
-  REVISION_SAVED
-  STATUS_CHANGE
-}
-
-type ProposalLifecycleSubscription implements ChannelSubscription {
-  """The channels that will be notified on this subscription."""
-  channels: [Channel!]!
-
-  """The time when this ProposalLifecycleSubscription was created."""
-  createdAt: Timestamp!
-
-  """
-  The Identity that created this ProposalLifecycleSubscription. null if the Identity has been deleted.
-  """
-  createdBy: Identity
-
-  """
-  True if this ProposalLifecycleSubscription is actively sending notifications.
-  """
-  enabled: Boolean!
-
-  """
-  The ProposalLifecycleEvents that will trigger notifications on this subscription.
-  """
-  events: [ProposalLifecycleEvent!]!
-  id: ID!
-
-  """
-  The last time this subscription was updated, if never updated will be the createdAt time.
-  """
-  lastUpdatedAt: Timestamp!
-
-  """
-  The Identity that last updated this ProposalLifecycleSubscription, or the creator if no one has updated. null if the Identity has been deleted.
-  """
-  lastUpdatedBy: Identity
-
-  """Always null for ProposalLifecycleSubscription."""
-  variant: String
-}
-
 """
 Mutations for editing GraphOS Schema Proposals. See documentation at https://www.apollographql.com/docs/graphos/delivery/schema-proposals
 """
 type ProposalMutation {
-  addComment(input: AddCommentInput!): AddCommentResult!
-  deleteComment(input: DeleteCommentInput!): DeleteCommentResult!
-
-  """
-  Delete a subgraph from this proposal. This will write the summary to proposals, record the most up to date diff, and call registry's removeImplementingServiceAndTriggerComposition. If composition is successful, this will update running routers.
-  """
-  deleteSubgraph(input: DeleteProposalSubgraphInput!): DeleteProposalSubgraphResult!
-  editComment(input: EditCommentInput!): EditCommentResult!
-
   """
   The GraphOS Schema Proposal being modified by this mutation. See documentation at https://www.apollographql.com/docs/graphos/delivery/schema-proposals
   """
   proposal: Proposal
 
   """
-  This mutation creates a new revision of a proposal by publishing multiple subgraphs, saving the summary and recording a diff. If composition is successful, this will update running routers. See the documentation at https://www.apollographql.com/docs/graphos/delivery/schema-proposals/creation/#save-revisions
+  This mutation creates a new revision of a proposal by publishing multiple subgraphs, saving the summary and recording a diff. If composition is successful, this will update running routers. See the documentation at https://www.apollographql.com/docs/graphos/delivery/schema-proposals/creation/#save-revisions This field accepts up to 500 requests per minute. This rate may be temporarily adjusted based on system conditions.
   """
   publishSubgraphs(input: PublishProposalSubgraphsInput!): PublishProposalSubgraphResult!
-
-  """
-  If a check workflow is not found for a revision, it attempts to create one. If there is a check workflow present, it re-runs the check and associates the new check to the provided revision.
-  """
-  reRunCheckForRevision(input: ReRunCheckForRevisionInput!): ReRunCheckForRevisionResult!
-
-  """
-  Removes all requested reviewers and their reviews that are not part of the new set of default reviewers. Adds any new default reviewers to the list of requested reviewers for this proposal.
-  """
-  replaceReviewersWithDefaultReviewers: ReplaceReviewersWithDefaultReviewersResult!
-
-  """
-  Set the mergeBaseCompositionId of this Proposal, if it is null. Must be internal MDG user with sudo.
-  """
-  setMergeBaseCompositionId(input: SetMergeBaseCompositionIdInput!): SetMergeBaseCompositionIdResult!
 
   """
   Updates the description of this Proposal variant. Returns ValidationError if description exceeds max length of 10k characters.
   """
   updateDescription(input: UpdateDescriptionInput!): UpdateProposalResult!
 
-  """Update the title of this proposal."""
+  """
+  Update the title of this proposal. This field accepts up to 200 requests per minute. This rate may be temporarily adjusted based on system conditions.
+  """
   updateDisplayName(displayName: String!): UpdateProposalResult!
 
-  """Update the list of requested reviewers for this proposal."""
+  """
+  Update the list of requested reviewers for this proposal. This field accepts up to 500 requests per minute. This rate may be temporarily adjusted based on system conditions.
+  """
   updateRequestedReviewers(input: UpdateRequestedReviewersInput!): UpdateRequestedReviewersResult!
+
+  """
+  Update the status of this proposal. This field accepts up to 500 requests per minute. This rate may be temporarily adjusted based on system conditions.
+  """
   updateStatus(status: ProposalStatus!): UpdateProposalResult!
-  updateUpdatedByInfo(timestamp: Timestamp!): UpdateProposalResult!
-  upsertReview(input: UpsertReviewInput!): UpsertReviewResult!
 }
 
 union ProposalMutationResult = NotFoundError | PermissionError | ProposalMutation | ValidationError
 
-type ProposalPartialImplementationProposalOrigin implements ProposalImplementation {
+type ProposalPartialImplementationProposalOrigin {
   """
   the time this Proposal became partially implemented in the implementation target variant.
   """
@@ -12493,7 +4250,7 @@ type ProposalPartialImplementationProposalOrigin implements ProposalImplementati
   variant: GraphVariant!
 }
 
-type ProposalPartialImplementationVariantOrigin implements ProposalImplementation {
+type ProposalPartialImplementationVariantOrigin {
   """
   the time this Proposal became partially implemented in the implementation target variant.
   """
@@ -12514,11 +4271,6 @@ type ProposalPartialImplementationVariantOrigin implements ProposalImplementatio
   variant: GraphVariant!
 }
 
-type ProposalRequestedReviewer {
-  currentReview: ProposalReview
-  user: Identity
-}
-
 type ProposalReview {
   comment: ReviewProposalComment
   createdAt: Timestamp!
@@ -12534,11 +4286,6 @@ type ProposalRevision {
   id: ID!
 
   """
-  ID of the launch that this revision is associated with. For internal use only, correct schema usage would be to access through the Launch, but CONSUMER role has no access to launch, yet they need access to the schema publish.
-  """
-  launchId: ID!
-
-  """
   Latest composition ID of the proposal's source variant at the time this revision was created.
   """
   mergeBaseCompositionId: ID
@@ -12546,12 +4293,12 @@ type ProposalRevision {
   """
   The schema publish of the proposal's source variant at the time this revision was created. Null if the launch is PENDING.
   """
-  mergeBaseSchemaPublish: SchemaTag
+  mergeBaseSchemaPublish: SchemaPublication
 
   """
   The schema publish for this revision. Null while the launch is PENDING.
   """
-  schemaPublish: SchemaTag
+  schemaPublish: SchemaPublication
 
   """
   On publish, checks are triggered on a proposal automatically. However, if an error occurred triggering a check on publish, we skip attempting the check to avoid blocking the publish from succeeding. This is the only case this field would be null.
@@ -12562,38 +4309,9 @@ type ProposalRevision {
   isMerge: Boolean!
   launch: Launch
 
-  """
-  Latest launch of the proposal's source variant at the time this revision was created.
-  """
-  mergeBaseLaunch: Launch
-
   """null if this is the first revision"""
   previousRevision: ProposalRevision
   summary: String!
-}
-
-enum ProposalRevisionHistoryOrder {
-  """List revisions from oldest to newest."""
-  CREATED_ASC
-
-  """List revisions from newest to oldest, default."""
-  CREATED_DESC
-}
-
-type ProposalRevisionHistoryResult {
-  revisions: [ProposalRevision!]!
-
-  """
-  This is the total number of revisions for the proposal, regardless of the size of the returned list.
-  """
-  totalCount: Int!
-}
-
-union ProposalRevisionResult = NotFoundError | ProposalRevision
-
-type ProposalRoles {
-  create: UserPermission!
-  edit: UserPermission!
 }
 
 type ProposalsCheckTask implements CheckWorkflowTask {
@@ -12618,6 +4336,9 @@ type ProposalsCheckTask implements CheckWorkflowTask {
   """
   hasExceededMaxDiffs: Boolean
 
+  """True if this Proposal check passed with warnings, otherwise false."""
+  hasWarnings: Boolean!
+
   """
   Indicates the level of coverage a check's changeset is in approved Proposals. PENDING while Check is still running.
   """
@@ -12627,7 +4348,6 @@ type ProposalsCheckTask implements CheckWorkflowTask {
   Proposals with their state at the time the check was run associated to this check task.
   """
   relatedProposalResults: [RelatedProposalResult!]!
-  relatedProposals: [Proposal!]! @deprecated(reason: "use relatedProposalResults instead")
 
   """
   The configured severity at the time the check was run. If the check failed, this is the severity that should be shown. While this Check is PENDING defaults to Service's severityLevel.
@@ -12664,8 +4384,6 @@ input ProposalsFilterInput {
   subgraphs: [String!]
 }
 
-union ProposalsMustBeApprovedByADefaultReviewerResult = PermissionError | Service | ValidationError
-
 """
 Proposals, limited & offset based on Service.proposals & the total count
 """
@@ -12684,15 +4402,6 @@ enum ProposalStatus {
   IMPLEMENTED
   OPEN
 }
-
-type ProposalVariantCreationErrors {
-  """
-  A list of all errors that occurred when attempting to create a proposal variant.
-  """
-  errorMessages: [String!]!
-}
-
-union ProposalVariantCreationResult = GraphVariant | ProposalVariantCreationErrors
 
 """Filtering options for graph connections."""
 input ProposalVariantsFilter {
@@ -12717,72 +4426,6 @@ type ProposalVariantsResult {
   variants: [GraphVariant!]!
 }
 
-union ProposedBuildInputChanges = ProposedCompositionBuildInputChanges | ProposedFilterBuildInputChanges
-
-type ProposedCompositionBuildInputChanges {
-  """
-  The proposed new build pipeline track, or null if no such change was proposed.
-  """
-  buildPipelineTrackChange: BuildPipelineTrack
-
-  """
-  Any proposed upserts to subgraphs, or the empty list if no such changes were proposed.
-  """
-  subgraphUpserts: [ProposedCompositionBuildInputSubgraphUpsert!]!
-}
-
-type ProposedCompositionBuildInputSubgraphUpsert {
-  """The name of the subgraph changed in this subgraph upsert."""
-  name: String!
-
-  """The SHA-256 of the schema document in this subgraph upsert."""
-  schemaHash: SHA256
-}
-
-type ProposedFilterBuildInputChanges {
-  """
-  The proposed new build pipeline track, or null if no such change was proposed.
-  """
-  buildPipelineTrackChange: BuildPipelineTrack
-
-  """
-  Any proposed additions to exclude filters, or the empty list if no such changes were proposed.
-  """
-  excludeAdditions: [String!]!
-
-  """
-  Any proposed removals to exclude filters, or the empty list if no such changes were proposed.
-  """
-  excludeRemovals: [String!]!
-
-  """
-  The proposed value for whether to hide unreachable schema elements, or null if no such change was proposed.
-  """
-  hideUnreachableTypesChange: Boolean
-
-  """
-  Any proposed additions to include filters, or the empty list if no such changes were proposed.
-  """
-  includeAdditions: [String!]!
-
-  """
-  Any proposed removals to include filters, or the empty list if no such changes were proposed.
-  """
-  includeRemovals: [String!]!
-
-  """
-  The proposed new build pipeline track, or null if no such change was proposed.
-  """
-  supergraphSchemaHashChange: SHA256
-}
-
-type Protobuf {
-  json: String!
-  object: Object!
-  raw: Blob!
-  text: String!
-}
-
 """
 The result of a successful call to PersistedQueryListMutation.publishOperations.
 """
@@ -12801,35 +4444,14 @@ The result/error union returned by PersistedQueryListMutation.publishOperations.
 """
 union PublishOperationsResultOrError = CannotModifyOperationBodyError | PermissionError | PublishOperationsResult
 
-union PublishProposalSubgraphResult = NotFoundError | PermissionError | Proposal | SchemaValidationError | ValidationError
+union PublishProposalSubgraphResult = NotFoundError | PermissionError | Proposal | ValidationError
 
 input PublishProposalSubgraphsInput {
   gitContext: GitContextInput
-
-  """
-  Non null if this publish is a merge revision. The composition id of the source variant updated to. This is necessary to keep track of the last composition id this proposal is updated with.
-  """
-  mergeUpdateCompositionId: ID
   previousLaunchId: ID!
   revision: String!
   subgraphInputs: [PublishSubgraphsSubgraphInput!]!
   summary: String!
-}
-
-"""The result attempting to publish subgraphs with async build."""
-type PublishSubgraphsAsyncBuildResult {
-  """The Launch result part of this subgraph publish."""
-  launch: Launch
-
-  """
-  The URL of the Studio page for this update's associated launch, if available.
-  """
-  launchUrl: String
-
-  """
-  Human-readable text describing the launch result of the subgraph publish.
-  """
-  launchCliCopy: String
 }
 
 input PublishSubgraphsSubgraphInput {
@@ -12838,585 +4460,39 @@ input PublishSubgraphsSubgraphInput {
   url: String
 }
 
-input PushMarketoLeadInput {
-  """Email address"""
-  email: String
-
-  """First name"""
-  firstName: String
-
-  """Last name"""
-  lastName: String
-
-  """Phone number"""
-  phone: String
-
-  """Company name"""
-  company: String
-
-  """Company domain"""
-  Company_Domain__c: String
-
-  """Job Function"""
-  Job_Function__c: String
-
-  """GraphQL Production Stage"""
-  GraphQL_Production_Stage__c: String
-
-  """Country"""
-  country: String
-
-  """Lead Message"""
-  Lead_Message__c: String
-
-  """Clearbit enriched LinkedIn URL"""
-  Clearbit_LinkedIn_URL__c: String
-
-  """Lead Source Detail"""
-  Lead_Source_Detail__c: String
-
-  """Lead Source Most Recent Detail"""
-  Lead_Source_Most_Recent_Detail__c: String
-
-  """Lead Source Most Recent"""
-  Lead_Source_Most_Recent__c: String
-
-  """Studio User Id"""
-  Studio_User_Id__c: String
-
-  """UTM Medium"""
-  UTM_Medium__c: String
-
-  """UTM Source"""
-  UTM_Source__c: String
-
-  """UTM Campaign"""
-  UTM_Campaign__c: String
-
-  """UTM Term"""
-  UTM_Term__c: String
-
-  """UTM ICID"""
-  UTM_ICID__c: String
-
-  """Referrer"""
-  Referrer__c: String
-
-  """UTM Campaign First Touch"""
-  UTM_Campaign_First_Touch__c: String
-
-  """UTM Medium First Touch"""
-  UTM_Medium_First_Touch__c: String
-
-  """UTM Source First Touch"""
-  UTM_Source_First_Touch__c: String
-
-  """GA Client ID"""
-  Google_User_ID__c: String
-
-  """GDPR Explicit Opt in"""
-  Explicit_Opt_in__c: Boolean
-
-  """Google Click ID"""
-  Google_Click_ID__c: String
-
-  """Is Graph Champion"""
-  isGraphChampion: Boolean
-
-  """Studio Organization ID"""
-  Studio_Organization_ID__c: String
-
-  """UTM Campaign Capture Mkto Only"""
-  uTMCampaignCaptureMktoOnly: String
-
-  """UTM ICID Capture Mkto Only"""
-  uTMICIDCaptureMktoOnly: String
-
-  """UTM Medium Capture Mkto Only"""
-  uTMMediumCaptureMktoOnly: String
-
-  """UTM Source Capture Mkto Only"""
-  uTMSourceCaptureMktoOnly: String
-
-  """UTM Term Capture Mkto Only"""
-  uTMTermCaptureMktoOnly: String
-
-  """Notes Import"""
-  notesImport: String
-}
-
 """Queries defined by this subgraph"""
 type Query {
-  """All available billing plan capabilities"""
-  allBillingCapabilities: [BillingCapability!]!
-
-  """All available billing plan limits"""
-  allBillingLimits: [BillingLimit!]!
-
-  """All available plans"""
-  allBillingPlans: [BillingPlan!]!
-  allSelfHostedCommercialRuntimeEntitlements: [RouterEntitlement]!
-  billingAdmin: BillingAdminQuery
-
-  """
-  Retrieves all past and current subscriptions for an account, even if the account has been deleted
-  """
-  billingSubscriptionHistory(id: ID): [BillingSubscription]!
-  billingTier(tier: BillingPlanTier!): BillingTier
-
-  """
-  Escaped JSON string of the public key used for verifying entitlement JWTs
-  """
-  commercialRuntimePublicKey: String!
-
-  """Look up a plan by ID"""
-  plan(id: ID): BillingPlan
-
-  """Cloud queries"""
-  cloud: Cloud!
-  cloudTesting: CloudTesting!
-
-  """Account by ID"""
-  account(id: ID!): Account
-
-  """Retrieve account by internal id"""
-  accountByInternalID(id: ID!): Account
-
-  """Whether an account ID is available for mutation{newAccount(id:)}"""
-  accountIDAvailable(id: ID!): Boolean!
-
-  """All auto-renewing team accounts on active annual plans"""
-  allRenewingNonEnterpriseAnnualAccounts: [Account!]
-
-  """All users"""
-  allUsers(search: String): [User!]
-
-  """
-  If this is true, the user is an Apollo administrator who can ignore restrictions based purely on billing plan.
-  """
-  canBypassPlanRestrictions: Boolean!
-
-  """Past and current enterprise trial accounts"""
-  enterpriseTrialAccounts: [Account!]
-  internalAdminUsers: [InternalAdminUser!]
-
   """
   Returns details of the authenticated `User` or `Graph` executing this query. If this is an unauthenticated query (i.e., no API key is provided), this field returns null.
   """
   me: Identity
 
   """Returns details of the Studio organization with the provided ID."""
-  organization(id: ID!): Account
-
-  """
-  Accounts with enterprise subscriptions that have expired in the past 45 days
-  """
-  recentlyExpiredEnterpriseAccounts: [Account!]
-
-  """Search all accounts"""
-  searchAccounts(search: String): [Account!]!
-
-  """
-  Accounts with enterprise subscriptions that will expire within the next 30 days
-  """
-  soonToExpireEnterpriseAccounts: [Account!]
-  sso: SsoQuery!
-
-  """Get the studio settings for the current user"""
-  studioSettings: UserSettings
+  organization(id: ID!): Organization
 
   """Returns details of the Apollo user with the provided ID."""
   user(id: ID!): User
-
-  """Returns details of the Apollo users with the provided IDs."""
-  users(ids: [ID!]!): [User!]
-
-  """Retrieve account by billing provider identifier"""
-  accountByBillingCode(id: ID!): Account
-
-  """All accounts"""
-  allAccounts(search: String, tier: BillingPlanTier): [Account!]
-
-  """All accounts on team billable plans with active subscriptions"""
-  allActiveTeamBillingAccounts: [Account!]
-  allPublicVariants: [GraphVariant!]
-
-  """All services"""
-  allServices(search: String): [Service!]
-
-  """All timezones with their offsets from UTC"""
-  allTimezoneOffsets: [TimezoneOffset!]!
-
-  """Get the unsubscribe settings for a given email."""
-  emailPreferences(email: String!, token: String!): EmailPreferences
 
   """Returns the root URL of the Apollo Studio frontend."""
   frontendUrlRoot: String!
 
   """Returns details of the graph with the provided ID."""
-  graph(id: ID!): Service
-  internalActiveCronJobs: [CronJob!]!
-  internalUnresolvedCronExecutionFailures: [CronExecution!]!
-
-  """
-  A list of public variants that have been selected to be shown on our Graph Directory.
-  """
-  publiclyListedVariants: [GraphVariant!]
-
-  """Service by ID"""
-  service(id: ID!): Service
-
-  """
-  Query statistics across all services. For admins only; normal users must go through AccountsStatsWindow or ServiceStatsWindow.
-  """
-  stats(
-    from: Timestamp!
-
-    """
-    Granularity of buckets. Defaults to the entire range (aggregate all data into a single durationBucket) when null.
-    """
-    resolution: Resolution
-
-    """Defaults to the current time when null."""
-    to: Timestamp
-  ): StatsWindow!
+  graph(id: ID!): Graph
 
   """
   Returns details of a Studio graph variant with the provided graph ref. A graph ref has the format `graphID@variantName` (or just `graphID` for the default variant `current`). Returns null if the graph or variant doesn't exist, or if the graph isn't accessible by the current actor.
   """
   variant(ref: ID!): GraphVariantLookup
-  odysseyCertification(id: ID!): OdysseyCertification
 
   """
-  Returns the [operation collection](https://www.apollographql.com/docs/studio/explorer/operation-collections/) for the provided ID.
+  Returns the [operation collection](https://www.apollographql.com/docs/studio/explorer/operation-collections/) for the provided ID. This field accepts up to 400 requests per minute. This rate may be temporarily adjusted based on system conditions.
   """
   operationCollection(id: ID!): OperationCollectionResult!
-  operationCollectionEntries(collectionEntryIds: [ID!]!): [OperationCollectionEntry!]!
+
+  """
+  Returns a proposal by its ID. This field accepts up to 1000 requests per minute. This rate may be temporarily adjusted based on system conditions.
+  """
   proposal(id: ID!): Proposal
-  diffSchemas(baseSchema: String!, nextSchema: String!): [Change!]!
-
-  """
-  Schema transformation for the Apollo platform API. Renames types. Internal to Apollo.
-  """
-  transformSchemaForPlatformApi(baseSchema: GraphQLDocument!): GraphQLDocument
-}
-
-"""query documents to validate against"""
-input QueryDocumentInput {
-  document: String
-}
-
-type QueryPlan {
-  text: String!
-  json: String!
-  object: Object!
-}
-
-"""Columns of QueryStats."""
-enum QueryStatsColumn {
-  ACCOUNT_ID
-  CACHED_HISTOGRAM
-  CACHED_REQUESTS_COUNT
-  CACHE_TTL_HISTOGRAM
-  CLIENT_NAME
-  CLIENT_VERSION
-  FORBIDDEN_OPERATION_COUNT
-  FROM_ENGINEPROXY
-  OPERATION_SUBTYPE
-  OPERATION_TYPE
-  PERSISTED_QUERY_ID
-  QUERY_ID
-  QUERY_NAME
-  REGISTERED_OPERATION_COUNT
-  REQUESTS_WITH_ERRORS_COUNT
-  SCHEMA_HASH
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-  UNCACHED_HISTOGRAM
-  UNCACHED_REQUESTS_COUNT
-}
-
-type QueryStatsDimensions {
-  accountId: ID
-  clientName: String
-  clientVersion: String
-  fromEngineproxy: String
-  operationSubtype: String
-  operationType: String
-  persistedQueryId: String
-  queryId: ID
-  queryName: String
-  querySignature: String
-  querySignatureLength: Int
-  schemaHash: String
-  schemaTag: String
-  serviceId: ID
-}
-
-"""
-Filter for data in QueryStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input QueryStatsFilter {
-  """
-  Selects rows whose accountId dimension equals the given value if not null. To query for the null value, use {in: {accountId: [null]}} instead.
-  """
-  accountId: ID
-  and: [QueryStatsFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-
-  """
-  Selects rows whose fromEngineproxy dimension equals the given value if not null. To query for the null value, use {in: {fromEngineproxy: [null]}} instead.
-  """
-  fromEngineproxy: String
-  in: QueryStatsFilterIn
-  not: QueryStatsFilter
-
-  """
-  Selects rows whose operationSubtype dimension equals the given value if not null. To query for the null value, use {in: {operationSubtype: [null]}} instead.
-  """
-  operationSubtype: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [QueryStatsFilter!]
-
-  """
-  Selects rows whose persistedQueryId dimension equals the given value if not null. To query for the null value, use {in: {persistedQueryId: [null]}} instead.
-  """
-  persistedQueryId: String
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: ID
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead.
-  """
-  schemaHash: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-}
-
-"""
-Filter for data in QueryStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input QueryStatsFilterIn {
-  """
-  Selects rows whose accountId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  accountId: [ID]
-
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose fromEngineproxy dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  fromEngineproxy: [String]
-
-  """
-  Selects rows whose operationSubtype dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationSubtype: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose persistedQueryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  persistedQueryId: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [ID]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaHash: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-}
-
-type QueryStatsMetrics {
-  cacheTtlHistogram: DurationHistogram!
-  cachedHistogram: DurationHistogram!
-  cachedRequestsCount: Long!
-  forbiddenOperationCount: Long!
-  registeredOperationCount: Long!
-  requestsWithErrorsCount: Long!
-  totalLatencyHistogram: DurationHistogram!
-  totalRequestCount: Long!
-  uncachedHistogram: DurationHistogram!
-  uncachedRequestsCount: Long!
-}
-
-input QueryStatsOrderBySpec {
-  column: QueryStatsColumn!
-  direction: Ordering!
-}
-
-type QueryStatsRecord {
-  """Dimensions of QueryStats that can be grouped by."""
-  groupBy: QueryStatsDimensions!
-
-  """Metrics of QueryStats that can be aggregated over."""
-  metrics: QueryStatsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Query Trigger"""
-type QueryTrigger implements ChannelSubscription {
-  channels: [Channel!]!
-  comparisonOperator: ComparisonOperator!
-  enabled: Boolean!
-  excludedOperationNames: [String!]!
-  id: ID!
-  metric: QueryTriggerMetric!
-  operationNames: [String!]!
-  percentile: Float
-  scope: QueryTriggerScope!
-  serviceId: String!
-  state: QueryTriggerState!
-  threshold: Float!
-  variant: String
-  window: QueryTriggerWindow!
-}
-
-"""Query trigger"""
-input QueryTriggerInput {
-  channelIds: [String!]
-  comparisonOperator: ComparisonOperator!
-  enabled: Boolean
-  excludedOperationNames: [String!]
-  metric: QueryTriggerMetric!
-  operationNames: [String!]
-  percentile: Float
-  scope: QueryTriggerScope
-  threshold: Float!
-  variant: String
-  window: QueryTriggerWindow!
-}
-
-enum QueryTriggerMetric {
-  """
-  Number of requests within the window that resulted in an error. Ignores `percentile`.
-  """
-  ERROR_COUNT
-
-  """
-  Number of error requests divided by total number of requests. Ignores `percentile`.
-  """
-  ERROR_PERCENTAGE
-
-  """Number of requests within the window. Ignores `percentile`."""
-  REQUEST_COUNT
-
-  """Request latency in ms. Requires `percentile`."""
-  REQUEST_SERVICE_TIME
-}
-
-enum QueryTriggerScope {
-  ALL
-  ANY
-  UNRECOGNIZED
-}
-
-"""Query trigger state"""
-type QueryTriggerState {
-  evaluatedAt: Timestamp!
-  lastTriggeredAt: Timestamp
-  operations: [QueryTriggerStateOperation!]!
-  triggered: Boolean!
-}
-
-type QueryTriggerStateOperation {
-  count: Long!
-  operation: String!
-  triggered: Boolean!
-  value: Float!
-}
-
-enum QueryTriggerWindow {
-  FIFTEEN_MINUTES
-  FIVE_MINUTES
-  ONE_MINUTE
-  UNRECOGNIZED
-}
-
-"""Result of calling a test request to a custom check endpoint."""
-union QueueTestCustomChecksRequestResult = GraphVariant | PermissionError | ValidationError
-
-type QueueTestProposalLifecycleNotificationError {
-  message: String!
-}
-
-input QueueTestProposalLifecycleNotificationInput {
-  channelId: ID!
-  subscriptionId: ID!
-}
-
-union QueueTestProposalLifecycleNotificationResult = NotFoundError | PermissionError | QueueTestProposalLifecycleNotificationError | QueueTestProposalLifecycleNotificationSuccess | ValidationError
-
-type QueueTestProposalLifecycleNotificationSuccess {
-  queued: Boolean
-}
-
-type RateLimit {
-  count: Long!
-  durationMs: Long!
 }
 
 """
@@ -13440,11 +4516,6 @@ type Readme {
   id: ID!
 
   """
-  The timestamp when the README was most recently updated. `1970-01-01T00:00:00Z` for the default README
-  """
-  lastUpdatedAt: Timestamp! @deprecated(reason: "Deprecated in favour of lastUpdatedTime")
-
-  """
   The actor that most recently updated the README (usually a `User`). `null` for the default README, or if the `User` was deleted.
   """
   lastUpdatedBy: Identity
@@ -13453,127 +4524,6 @@ type Readme {
   The timestamp when the README was most recently updated. `null` for the default README
   """
   lastUpdatedTime: Timestamp
-}
-
-"""Responsibility for an errored order"""
-enum ReasonCause {
-  """
-  Could not complete an order due to invalid User input
-  
-  For example, the user provided an invalid router configuration or supergraph schema.
-  """
-  USER
-
-  """
-  Could not complete an order due to internal reason
-  
-  This could be due to intermittent issues, bug in our code, etc.
-  """
-  INTERNAL
-}
-
-type RebaseConflict {
-  location: ParsedSchemaCoordinate
-  message: String
-}
-
-type RebaseConflictData {
-  conflicts: [RebaseConflict!]!
-  count: Int!
-}
-
-union RebaseConflictResult = NotFoundError | RebaseConflictData | SchemaValidationError
-
-type RecentPage {
-  url: String!
-  timestamp: Timestamp!
-}
-
-"""Details of account data stored in Recurly"""
-type RecurlyAccountDetails {
-  accountCode: String!
-  createdAt: Timestamp!
-}
-
-"""Description for a Cloud Router region"""
-type RegionDescription {
-  """Full name of the region"""
-  name: String!
-
-  """Region identifier"""
-  code: String!
-
-  """Cloud Provider related to this region"""
-  provider: CloudProvider!
-
-  """State of the Region"""
-  state: RegionState!
-
-  """Country of the region, in ISO 3166-1 alpha-2 code"""
-  country: String!
-}
-
-"""Possible state of a region"""
-enum RegionState {
-  """
-  Active region
-  
-  Can be used for Cloud Routers
-  """
-  ACTIVE
-
-  """
-  Inactive region
-  
-  Cannot yet be used for Cloud Routers
-  """
-  INACTIVE
-
-  """Does not appear in the API"""
-  HIDDEN
-}
-
-input RegisteredClientIdentityInput {
-  identifier: String!
-  name: String!
-  version: String
-}
-
-type RegisteredOperation {
-  signature: ID!
-}
-
-input RegisteredOperationInput {
-  signature: ID!
-  document: String
-  metadata: RegisteredOperationMetadataInput
-}
-
-input RegisteredOperationMetadataInput {
-  """This will be used to link existing records in Engine to a new ID."""
-  engineSignature: String
-}
-
-type RegisterOperationsMutationResponse {
-  registrationSuccess: Boolean!
-  newOperations: [RegisteredOperation!]
-  invalidOperations: [InvalidOperation!]
-}
-
-type RegistryStatsWindow {
-  schemaCheckStats: [AccountChecksStatsRecord!]!
-  schemaPublishStats: [AccountPublishesStatsRecord!]!
-}
-
-type RegistrySubscription implements ChannelSubscription {
-  channel: Channel
-  channels: [Channel!]! @deprecated(reason: "Use channels list instead")
-  createdAt: Timestamp!
-  enabled: Boolean!
-  id: ID!
-  lastUpdatedAt: Timestamp!
-  options: SubscriptionOptions!
-  variant: String
 }
 
 """A Proposal related to a Proposal Check Task."""
@@ -13594,26 +4544,9 @@ type RelatedProposalResult {
   statusAtCheck: ProposalStatus!
 }
 
-type RelaunchComplete {
-  latestLaunch: Launch!
-  updated: Boolean!
-}
-
-type RelaunchError {
-  message: String!
-}
-
-union RelaunchResult = RelaunchComplete | RelaunchError
-
 union RemoveOperationCollectionEntryResult = OperationCollection | PermissionError
 
-union RemoveOperationCollectionFromVariantResult = GraphVariant | NotFoundError | PermissionError | ValidationError
-
-union ReorderOperationCollectionResult = OperationCollection | PermissionError
-
-union ReplaceReviewersWithDefaultReviewersResult = PermissionError | Proposal | ValidationError
-
-type ReplyChangeProposalComment implements ChangeProposalComment & ProposalComment {
+type ReplyChangeProposalComment implements ProposalComment {
   createdAt: Timestamp!
 
   """null if the user is deleted"""
@@ -13650,94 +4583,8 @@ type ReplyGeneralProposalComment implements GeneralProposalComment & ProposalCom
   updatedAt: Timestamp
 }
 
-type ReportSchemaError implements ReportSchemaResult {
-  code: ReportSchemaErrorCode!
-  inSeconds: Int!
-  message: String!
-  withCoreSchema: Boolean!
-}
-
-enum ReportSchemaErrorCode {
-  BOOT_ID_IS_NOT_VALID_UUID
-  BOOT_ID_IS_REQUIRED
-  CORE_SCHEMA_HASH_IS_NOT_SCHEMA_SHA256
-  CORE_SCHEMA_HASH_IS_REQUIRED
-  CORE_SCHEMA_HASH_IS_TOO_LONG
-  EXECUTABLE_SCHEMA_ID_IS_NOT_SCHEMA_SHA256
-  EXECUTABLE_SCHEMA_ID_IS_REQUIRED
-  EXECUTABLE_SCHEMA_ID_IS_TOO_LONG
-  GRAPH_REF_INVALID_FORMAT
-  GRAPH_REF_IS_REQUIRED
-  GRAPH_VARIANT_DOES_NOT_MATCH_REGEX
-  GRAPH_VARIANT_IS_REQUIRED
-  LIBRARY_VERSION_IS_TOO_LONG
-  PLATFORM_IS_TOO_LONG
-  RUNTIME_VERSION_IS_TOO_LONG
-  SCHEMA_IS_NOT_PARSABLE
-  SCHEMA_IS_NOT_VALID
-  SERVER_ID_IS_TOO_LONG
-  USER_VERSION_IS_TOO_LONG
-}
-
-type ReportSchemaResponse implements ReportSchemaResult {
-  inSeconds: Int!
-  withCoreSchema: Boolean!
-}
-
-interface ReportSchemaResult {
-  inSeconds: Int!
-  withCoreSchema: Boolean!
-}
-
-type ReportServerInfoError implements ReportServerInfoResult {
-  code: ReportSchemaErrorCode!
-  inSeconds: Int!
-  message: String!
-  withExecutableSchema: Boolean!
-}
-
-type ReportServerInfoResponse implements ReportServerInfoResult {
-  inSeconds: Int!
-  withExecutableSchema: Boolean!
-}
-
-interface ReportServerInfoResult {
-  inSeconds: Int!
-  withExecutableSchema: Boolean!
-}
-
-type RequestCountsPerGraphVariant {
-  cachedRequestsCount: Long!
-  graphID: String!
-  uncachedRequestsCount: Long!
-  variant: String
-}
-
 input RerunAsyncInput {
   sourceVariant: String
-}
-
-input ReRunCheckForRevisionInput {
-  revisionId: ID!
-}
-
-union ReRunCheckForRevisionResult = NotFoundError | PermissionError | Proposal | ValidationError
-
-enum Resolution {
-  R15M
-  R1D
-  R1H
-  R1M
-  R5M
-  R6H
-}
-
-enum ResponseHints {
-  NONE
-  SAMPLE_RESPONSES
-  SUBGRAPHS
-  TIMINGS
-  TRACE_TIMINGS
 }
 
 enum ReviewDecision {
@@ -13758,20 +4605,7 @@ type ReviewProposalComment implements ProposalComment {
   updatedAt: Timestamp
 }
 
-type RoleOverride {
-  graph: Service! @deprecated(reason: "RoleOverride can only be queried via a Graph, so any fields here should instead be selected via the parent object.")
-  lastUpdatedAt: Timestamp!
-  role: UserPermission!
-  user: User!
-}
-
 type Router {
-  """graphRef representing the Cloud Router"""
-  id: ID!
-
-  """Internal identifier for a Cloud Router"""
-  internalId: ID
-
   """Return the GraphVariant associated with this Router"""
   graphVariant: GraphVariant
 
@@ -13789,13 +4623,6 @@ type Router {
   status: RouterStatus!
 
   """
-  The next scheduled router status, useful for telling when a router will be transitioning in
-  the near future to another staus. If no change in status is scheduled, this field will be
-  null
-  """
-  nextStatus: RouterStatus
-
-  """
   Current version of the Cloud Router
   
   This will be null if the Cloud Router is in a deleted status.
@@ -13810,9 +4637,6 @@ type Router {
   automatically update this Cloud Router, for example due to configuration issues.
   """
   nextRouterVersion: RouterVersion
-
-  """Capabilities for this Cloud Router"""
-  capabilities: RouterCapabilities
 
   """
   URL where the Cloud Router can be found
@@ -13843,55 +4667,12 @@ type Router {
   """
   secrets: [Secret!]!
 
-  """Shard associated with this Cloud Router"""
-  shard: Shard
-
-  """Order currently modifying this Cloud Router"""
-  currentOrder: Order
-
   """
   Number of Graph Compute Units (GCUs) associated with this Cloud Router
   
   This value is not present for Cloud Routers on the `SERVERLESS` tier.
   """
   gcus: Int
-
-  """Constants for Cloud Routers"""
-  constants: CloudConstants!
-}
-
-type RouterAdminMutation {
-  """Sleep this Cloud Router"""
-  sleep: RouterSleepResult!
-
-  """Wake up this Cloud Router"""
-  wakeUp: RouterWakeUpResult!
-
-  """Override the lastTraffic for Serverless Cloud Routers"""
-  setLastTraffic(lastTraffic: NaiveDateTime!): RouterSetLastTrafficResult!
-
-  """Update the Cloud Router state so it will display a `nextStatus` value"""
-  setNextStatus(nextStatus: RouterStatus!): RouterSetNextStatusResult!
-
-  """
-  Pre-create a custom domain for this Cloud Router, but don't enable routing yet
-  """
-  preCreateCustomDomain(customDomain: String!): RouterPreCreateDomainResult!
-}
-
-"""Capabilities for this Cloud Router"""
-type RouterCapabilities {
-  """This Cloud Router supports getting and settings GCUs"""
-  gcus: Boolean!
-
-  """This Cloud Router can use private subgraphs"""
-  privateSubgraphs: Boolean!
-
-  """This Cloud Router can router traffic from custom domains"""
-  customDomains: Boolean!
-
-  """This Cloud Router supports using a custom path"""
-  customPath: Boolean!
 }
 
 """Router configuration input"""
@@ -13911,23 +4692,6 @@ input RouterConfigInput {
   This is ignored for serverless Cloud Routers
   """
   gcus: Int
-}
-
-type RouterConfigVersion {
-  """Name of the RouterConfigVersion"""
-  name: String!
-
-  """JSON schema for validating the router configuration"""
-  configSchema: String
-}
-
-"""Input to create a RouterConfigVersion"""
-input RouterConfigVersionInput {
-  """Name of the RouterConfigVersion"""
-  configVersion: String!
-
-  """Configuration schema mapping for the RouterConfigVersion"""
-  configSchema: String!
 }
 
 """
@@ -13989,46 +4753,11 @@ type RouterEndpointsSuccess {
   endpoints: RouterEndpoints!
 }
 
-type RouterEntitlement {
-  """The id of the account this license was generated for."""
-  accountId: String!
-
-  """Which audiences this license applies to."""
-  audience: [RouterEntitlementAudience!]!
-
-  """
-  Router will stop serving requests after this time if commercial features are in use.
-  """
-  haltAt: Timestamp
-
+type RouterLicense {
   """
   RFC 8037 Ed25519 JWT signed representation of sibling fields. Restricted to internal services only.
   """
   jwt: String!
-
-  """Organization this license applies to."""
-  subject: String!
-  throughputLimit: RateLimit
-
-  """
-  Router will warn users after this time if commercial features are in use.
-  """
-  warnAt: Timestamp
-}
-
-enum RouterEntitlementAudience {
-  """Routers in Apollo hosted cloud."""
-  CLOUD
-
-  """
-  Routers in offline environments with license files supplied from a URL or locally.
-  """
-  OFFLINE
-
-  """
-  Routers in self-hosted environments fetching their license from uplink.
-  """
-  SELF_HOSTED
 }
 
 """Represents the possible outcomes of a setGcus mutation"""
@@ -14040,14 +4769,8 @@ type RouterGcusSuccess {
 }
 
 type RouterMutation {
-  """Set the version used for the next update for this Cloud Router"""
-  setNextVersion(version: String!): SetNextVersionResult!
-
   """Set secrets for this Cloud Router"""
   setSecrets(input: RouterSecretsInput!): RouterSecretsResult!
-
-  """Set a custom path for this Router"""
-  setCustomPath(path: String!): RouterPathResult!
 
   """Set the number of GCUs associated with this Router"""
   setGcus(gcus: Int!): RouterGcusResult!
@@ -14057,63 +4780,6 @@ type RouterMutation {
 
   """Remove a custom domain for this Cloud Router"""
   removeCustomDomain(customDomain: String!): RouterEndpointsResult!
-
-  """
-  Enable the default endpoint
-  
-  This mutation will only work if the Router is not in a DELETED state
-  """
-  enableDefaultEndpoint: RouterEndpointsResult!
-
-  """
-  Disable the default endpoint
-  
-  This mutation will only work if the Router is not in a DELETED state and the default
-  endpoint is not the primary endpoint.
-  """
-  disableDefaultEndpoint: RouterEndpointsResult!
-
-  """
-  Set the primary endpoint to a custom endpoint
-  
-  This mutation will only work if the Router is not in a DELETED state, and the primary
-  endpoint correspond to the full endpoint name (e.g. `https://api.mycompany.com/graphql`) of
-  an existing custom endpoint.
-  """
-  setPrimaryEndpoint(endpoint: String!): RouterEndpointsResult!
-
-  """
-  Reset the primary endpoint to the default endpoint
-  
-  This mutation will only work if the Router is not in a DELETED state, and the default
-  endpoint is enabled.
-  """
-  resetPrimaryEndpoint: RouterEndpointsResult!
-
-  """Sleep this Cloud Router"""
-  sleep: RouterSleepResult! @deprecated(reason: "use Router.admin.sleep instead")
-
-  """Admin mutations for this Router"""
-  admin: RouterAdminMutation!
-}
-
-"""Represents the possible outcomes of a setCustomPath mutation"""
-union RouterPathResult = RouterPathSuccess | InvalidInputErrors | InternalServerError
-
-"""Success branch of a setCustomPath mutation"""
-type RouterPathSuccess {
-  order: Order!
-  endpoints: RouterEndpoints!
-}
-
-"""
-"Represents the possible outcomes of a ", RouterPreCreateDomain, " mutation"
-"""
-union RouterPreCreateDomainResult = RouterPreCreateDomainSuccess | InvalidInputErrors | InternalServerError
-
-"""Success branch of a preCreateCustomDomain mutation"""
-type RouterPreCreateDomainSuccess {
-  success: Boolean!
 }
 
 """User input for a RouterSecrets mutation"""
@@ -14131,37 +4797,6 @@ union RouterSecretsResult = RouterSecretsSuccess | InvalidInputErrors | Internal
 """Success branch of a RouterSecrets mutation."""
 type RouterSecretsSuccess {
   secrets: [Secret!]!
-  order: Order!
-}
-
-"""
-"Represents the possible outcomes of a ", RouterSetLastTraffic, " mutation"
-"""
-union RouterSetLastTrafficResult = RouterSetLastTrafficSuccess | InvalidInputErrors | InternalServerError
-
-"""Success branch of a setLastTraffic mutation"""
-type RouterSetLastTrafficSuccess {
-  success: Boolean!
-}
-
-"""
-"Represents the possible outcomes of a ", RouterSetNextStatus, " mutation"
-"""
-union RouterSetNextStatusResult = RouterSetNextStatusSuccess | InvalidInputErrors | InternalServerError
-
-"""Success branch of a setNextStatus mutation"""
-type RouterSetNextStatusSuccess {
-  success: Boolean!
-}
-
-"""
-"Represents the possible outcomes of a ", RouterSleep, " mutation"
-"""
-union RouterSleepResult = RouterSleepSuccess | InvalidInputErrors | InternalServerError
-
-"""Success branch of a sleep mutation"""
-type RouterSleepSuccess {
-  success: Boolean!
 }
 
 """Current status of Cloud Routers"""
@@ -14208,14 +4843,6 @@ type RouterUpsertFailure {
   message: String!
 }
 
-"""
-A generic key→count type so that router usage metrics can be added to without modifying the `trackRouterUsage` mutation
-"""
-input RouterUsageInput {
-  count: Int!
-  key: String!
-}
-
 """Router Version"""
 type RouterVersion {
   """Version identifier"""
@@ -14237,336 +4864,6 @@ type RouterVersion {
   JSON schema for validating the router configuration for this router version
   """
   configSchema: String!
-
-  """Latest supported BuildPipelineTrack for this version"""
-  latestSupportedPipelineTrack: String
-}
-
-type RouterVersionBuild {
-  jobId: String!
-  routerVersion: String
-  status: RouterVersionBuildStatus!
-}
-
-type RouterVersionBuildError {
-  jobId: String!
-  routerVersion: String
-}
-
-type RouterVersionBuildPageResults {
-  count: Int!
-  cursor: Cursor
-  results: [RouterVersionBuildResult!]!
-}
-
-union RouterVersionBuildResult = RouterVersionBuild | RouterVersionBuildError
-
-enum RouterVersionBuildsField {
-  CREATED_AT
-}
-
-input RouterVersionBuildsInput {
-  orderBy: RouterVersionBuildsOrderByInput
-  pagination: CloudRouterTestingToolPaginationInput
-}
-
-input RouterVersionBuildsOrderByInput {
-  field: RouterVersionBuildsField!
-  direction: OrderingDirection!
-}
-
-enum RouterVersionBuildStatus {
-  PENDING
-  BUILDING
-  COMPLETE
-  CANCELLED
-}
-
-"""Result of a RouterConfigVersion mutation"""
-union RouterVersionConfigResult = RouterConfigVersion | CloudInvalidInputError | InternalServerError
-
-"""Input to create a new router version"""
-input RouterVersionCreateInput {
-  """Version identifier"""
-  version: String!
-
-  """Version status"""
-  status: Status!
-
-  """Version of the configuration"""
-  configVersion: String!
-
-  """Latest supported BuildPipelineTrack for this version"""
-  latestSupportedPipelineTrack: String!
-}
-
-"""Result of a router version query"""
-union RouterVersionResult = RouterVersion | InvalidInputErrors | InternalServerError
-
-"""List of router versions"""
-type RouterVersions {
-  versions: [RouterVersion!]!
-}
-
-"""Input for filtering router versions"""
-input RouterVersionsInput {
-  """Maximum number of versions to return"""
-  limit: Int
-
-  """Name of the branch"""
-  branch: String
-
-  """Status of the version"""
-  status: Status
-}
-
-"""Result of a router versions query"""
-union RouterVersionsResult = RouterVersions | InvalidInputErrors | InternalServerError
-
-"""Input for updating a router version"""
-input RouterVersionUpdateInput {
-  """Version identifier"""
-  version: String!
-
-  """Version status"""
-  status: Status
-
-  """Version of the configuration"""
-  configVersion: String
-
-  """Latest supported BuildPipelineTrack for this version"""
-  latestSupportedPipelineTrack: String
-}
-
-"""
-"Represents the possible outcomes of a ", RouterWakeUp, " mutation"
-"""
-union RouterWakeUpResult = RouterWakeUpSuccess | InvalidInputErrors | InternalServerError
-
-"""Success branch of a wakeUp mutation"""
-type RouterWakeUpSuccess {
-  success: Boolean!
-}
-
-input RoverArgumentInput {
-  key: String!
-  value: Object
-}
-
-type RuleEnforcement {
-  """The instant this enforcement was created."""
-  createdAt: Timestamp!
-
-  """Identifying info for the creator of this enforcement."""
-  createdBy: String!
-
-  """The instant this enforcement was deleted."""
-  deletedAt: Timestamp
-
-  """The identifier for the graph this this enforcement applies to."""
-  graphId: String!
-
-  """The name of the variant that this enforcement applies to."""
-  graphVariant: String
-
-  """The ID of this enforcement."""
-  id: ID!
-
-  """
-  A list of key/value pairs representing any parameters necessary for the policy's enforcement.
-  """
-  params: [StringToString!]
-
-  """The policy that this enforcement belongs to."""
-  policy: EnforcementPolicy!
-
-  """The instant this enforcement was last updated."""
-  updatedAt: Timestamp!
-}
-
-type RuleEnforcementError {
-  message: String!
-}
-
-union RuleEnforcementResult = RuleEnforcement | RuleEnforcementError
-
-input RunLintCheckInput {
-  baseSchema: SchemaHashInput!
-  checkStep: CheckStepInput!
-  proposedSchema: SchemaHashInput!
-}
-
-"""Inputs needed to find all relevant proposals to a check workflow"""
-input RunProposalsCheckInput {
-  """
-  List of subgraph names and hashes from the state of this variant when the check was run.
-  """
-  baseSubgraphs: [SubgraphCheckInput!]!
-
-  """
-  Supergraph hash that was most recently published when the check was run
-  """
-  baseSupergraphHash: String!
-
-  """
-  List of subgraph names and hashes that are being proposed in the check task
-  """
-  proposedSubgraphs: [SubgraphCheckInput!]!
-
-  """Supergraph hash that is the output of the check's composition task"""
-  proposedSupergraphHash: String!
-
-  """
-  If this check was created by rerunning, the original check workflow task that was rerun
-  """
-  rerunOfTaskId: ID
-
-  """
-  The severity to assign the check results if matching proposals are not found
-  """
-  severityLevel: ProposalChangeMismatchSeverity!
-
-  """
-  The check workflow task id. Used by Task entities to resolve the results
-  """
-  workflowTaskId: String!
-}
-
-type SafAssessment {
-  id: ID!
-
-  """The date and time the assessment was started."""
-  startedAt: Date!
-
-  """The date and time the assessment was completed."""
-  completedAt: Date
-
-  """The graph that this assessment belongs to."""
-  graph: Service!
-
-  """The responses for this assessment."""
-  responses: [SafResponse!]!
-
-  """The plan items for this assessment."""
-  planItems: [SafPlanItem!]!
-
-  """The time that the assessment was deleted."""
-  deletedAt: Date
-}
-
-type SafAssessmentMutation {
-  id: String!
-
-  """Save a response for a question."""
-  saveResponse(
-    """The response to save."""
-    input: SafResponseInput!
-  ): SafResponse!
-
-  """Submit the assessment."""
-  submit(planItemIds: [String!]!, organizationId: String): SafAssessment!
-
-  """Delete the assessment."""
-  delete: SafAssessment!
-
-  """Mutations for a specific plan item."""
-  planItem(id: ID!): SafPlanItemMutation
-
-  """Reorder the plan items for a given assessment."""
-  reorderPlanItems(
-    """An array of plan item IDs in the desired order."""
-    ids: [ID!]!
-  ): [SafPlanItem!]!
-}
-
-type SafPlanItem {
-  id: ID!
-  bestPracticeId: String!
-  notes: String!
-  order: Int!
-  isDeprioritized: Boolean!
-}
-
-input SafPlanItemInput {
-  notes: String!
-  isDeprioritized: Boolean!
-  order: Int!
-}
-
-type SafPlanItemMutation {
-  """Update a plan item."""
-  update(input: SafPlanItemInput!): SafPlanItem!
-}
-
-type SafResponse {
-  id: ID!
-
-  """The ID of the question that this response is for."""
-  questionId: String!
-
-  """A list of responses for this question."""
-  response: [String!]!
-
-  """Additional context or feedback about the question."""
-  comment: String!
-
-  """The assessment that this response belongs to."""
-  assessment: SafAssessment
-}
-
-input SafResponseInput {
-  questionId: String!
-  response: [String!]!
-  comment: String!
-}
-
-type SamlCertInfo {
-  id: ID!
-  notAfter: Timestamp!
-  notBefore: Timestamp!
-  pem: String!
-  subjectDN: String!
-}
-
-input SamlConfigurationInput {
-  encryptionCerts: [String!]
-  entityId: String!
-  ssoUrl: String!
-  verificationCerts: [String!]!
-  wantsSignedRequests: Boolean
-}
-
-type SamlConnection implements SsoConnection {
-  domains: [String!]!
-  id: ID!
-  idpId: ID!
-  metadata: SamlIdpMetadata!
-  scim: SsoScimProvisioningDetails
-  state: SsoConnectionState! @deprecated(reason: "Use stateV2 instead")
-  stateV2: SsoConnectionStateV2!
-}
-
-type SamlConnectionMutation {
-  addEncryptionCert(pem: String!): SamlConnection
-  addVerificationCert(pem: String!): SamlConnection
-  updateIdpId(idpId: String!): SamlConnection
-}
-
-type SamlIdpMetadata {
-  encryptionCerts: [SamlCertInfo!]!
-  entityId: String!
-  ssoUrl: String!
-  verificationCerts: [SamlCertInfo!]!
-  wantsSignedRequests: Boolean!
-}
-
-type ScheduledSummary implements ChannelSubscription {
-  channel: Channel @deprecated(reason: "Use channels list instead")
-  channels: [Channel!]!
-  enabled: Boolean!
-  id: ID!
-  timezone: String!
-  variant: String!
 }
 
 """A GraphQL schema document and associated metadata."""
@@ -14576,31 +4873,8 @@ type Schema {
   """
   hash: ID!
 
-  """The timestamp of initial ingestion of a schema to a graph."""
-  createdAt: Timestamp!
-  introspection: IntrospectionSchema!
-  gitContext: GitContext
-
-  """
-  The number of fields; this includes user defined fields only, excluding built-in types and fields
-  """
-  fieldCount: Int!
-
-  """
-  The number of types; this includes user defined types only, excluding built-in types
-  """
-  typeCount: Int!
-
-  """
-  The list of schema coordinates ('TypeName.fieldName') in the schema
-  that can be measured by usage reporting.
-  Currently only supports object types and interface types.
-  """
-  observableCoordinates: [SchemaCoordinate!]
-
   """The GraphQL schema document."""
   document: GraphQLDocument!
-  createTemporaryURL(expiresInSeconds: Int! = 86400): TemporaryURL
 }
 
 """
@@ -14617,30 +4891,10 @@ type SchemaCompositionError {
   code: String
 }
 
-type SchemaCoordinate {
-  id: ID!
-
-  """The printed coordinate value, e.g. 'ParentType.fieldName'"""
-  coordinate: String!
-
-  """Whether the coordinate being referred to is marked as deprecated"""
-  isDeprecated: Boolean!
-}
-
-input SchemaCoordinateFilterInput {
-  """
-  If true, only include deprecated coordinates.
-  If false, filter out deprecated coordinates.
-  """
-  deprecated: Boolean
-}
-
 """
 The result of computing the difference between two schemas, usually as part of schema checks.
 """
 type SchemaDiff {
-  type: ChangeType! @deprecated(reason: "use severity instead")
-
   """
   Indicates the overall safety of the changes included in the diff, based on operation history (e.g., `FAILURE` or `NOTICE`).
   """
@@ -14655,9 +4909,6 @@ type SchemaDiff {
   """Operations affected by all changes in the diff."""
   affectedQueries: [AffectedQuery!]
 
-  """Clients affected by all changes in the diff."""
-  affectedClients: [AffectedClient!] @deprecated(reason: "Unsupported.")
-
   """The number of GraphQL operations that were validated during the check."""
   numberOfCheckedOperations: Int
 
@@ -14665,134 +4916,16 @@ type SchemaDiff {
   The number of GraphQL operations affected by the diff's changes that are neither marked as safe nor ignored.
   """
   numberOfAffectedOperations: Int!
-
-  """Configuration of validation"""
-  validationConfig: SchemaDiffValidationConfig
-
-  """The tag against which this diff was created"""
-  tag: String
-}
-
-type SchemaDiffValidationConfig {
-  """
-  delta in seconds from current time that determines the start of the window
-  for reported metrics included in a schema diff. A day window from the present
-  day would have a `from` value of -86400. In rare cases, this could be an ISO
-  timestamp if the user passed one in on diff creation
-  """
-  from: Timestamp
-
-  """
-  delta in seconds from current time that determines the end of the
-  window for reported metrics included in a schema diff. A day window
-  from the present day would have a `to` value of -0. In rare
-  cases, this could be an ISO timestamp if the user passed one in on diff
-  creation
-  """
-  to: Timestamp
-
-  """
-  Minimum number of requests within the window for a query to be considered.
-  """
-  queryCountThreshold: Int
-
-  """
-  Number of requests within the window for a query to be considered, relative to
-  total request count. Expected values are between 0 and 0.05 (minimum 5% of
-  total request volume)
-  """
-  queryCountThresholdPercentage: Float
-
-  """Clients to ignore during validation."""
-  excludedClients: [ClientInfoFilterOutput!]
-
-  """Operation names to ignore during validation."""
-  excludedOperationNames: [OperationNameFilter]
-
-  """Operation IDs to ignore during validation."""
-  ignoredOperations: [ID!]
-
-  """Variants to include during validation."""
-  includedVariants: [String!]
-}
-
-input SchemaHashInput {
-  """If provided fetches build messages that are added to linter results."""
-  buildID: ID
-
-  """SHA256 of the schema sdl."""
-  hash: String!
-  subgraphs: [SubgraphHashInput!]
-}
-
-type SchemaPublishSubscription implements ChannelSubscription {
-  channels: [Channel!]!
-  createdAt: Timestamp!
-  enabled: Boolean!
-  id: ID!
-  lastUpdatedAt: Timestamp!
-  variant: String
-}
-
-input SchemaReport {
-  """
-  A randomly generated UUID, immutable for the lifetime of the edge server runtime.
-  """
-  bootId: String!
-
-  """
-  The hex SHA256 hash of the schema being reported. Note that for a GraphQL server with a core schema, this should be the core schema, not the API schema.
-  """
-  coreSchemaHash: String!
-
-  """The graph ref (eg, 'id@variant')"""
-  graphRef: String!
-
-  """
-  The version of the edge server reporting agent, e.g. apollo-server-2.8, graphql-java-3.1, etc. length must be <= 256 characters.
-  """
-  libraryVersion: String
-
-  """
-  The infra environment in which this edge server is running, e.g. localhost, Kubernetes, AWS Lambda, Google CloudRun, AWS ECS, etc. length must be <= 256 characters.
-  """
-  platform: String
-
-  """
-  The runtime in which the edge server is running, e.g. node 12.03, zulu8.46.0.19-ca-jdk8.0.252-macosx_x64, etc. length must be <= 256 characters.
-  """
-  runtimeVersion: String
-
-  """
-  If available, an identifier for the edge server instance, such that when restarting this instance it will have the same serverId, with a different bootId. For example, in Kubernetes this might be the pod name. Length must be <= 256 characters.
-  """
-  serverId: String
-
-  """
-  An identifier used to distinguish the version (from the user's perspective) of the edge server's code itself. For instance, the git sha of the server's repository or the docker sha of the associated image this server runs with. Length must be <= 256 characters.
-  """
-  userVersion: String
 }
 
 """
 Contains details for an individual publication of an individual graph variant.
 """
-type SchemaTag {
-  """The identifier for this specific publication."""
-  id: ID!
-
-  """
-  The launch for this publication. This value is non-null for contract variants, and sometimes null
-  for composition variants (specifically for older publications). This value is null for other
-  variants.
-  """
-  launch: Launch
-
+type SchemaPublication {
   """
   The variant that was published to."
   """
   variant: GraphVariant!
-  tag: String! @deprecated(reason: "Please use variant { name } instead")
 
   """The schema that was published to the variant."""
   schema: Schema!
@@ -14801,74 +4934,14 @@ type SchemaTag {
   The result of federated composition executed for this publication. This result includes either a supergraph schema or error details, depending on whether composition succeeded. This value is null when the publication is for a non-federated graph.
   """
   compositionResult: CompositionResult
-  createdAt: Timestamp!
 
   """The timestamp when the variant was published to."""
   publishedAt: Timestamp!
 
   """
-  The Identity that published this schema and their client info, or null if this isn't
-  a publish. Sub-fields may be null if they weren't recorded.
-  """
-  publishedBy: IdentityAndClientInfo
-
-  """
-  List of previously uploaded SchemaTags under the same tag name, starting with
-  the selected published schema record. Sorted in reverse chronological order
-  by creation date (newest publish first).
-  
-  Note: This does not include the history of checked schemas
-  """
-  history(limit: Int! = 3, offset: Int = 0, includeUnchanged: Boolean! = true, orderBy: SchemaTagHistoryOrder = CREATED_DESC): [SchemaTag!]!
-
-  """
-  Number of tagged schemas created under the same tag name.
-  Also represents the maximum size of the history's limit argument.
-  """
-  historyLength(includeUnchanged: Boolean! = true): Int!
-
-  """
-  Number of schemas tagged prior to this one under the same tag name, its position
-  in the tag history.
-  """
-  historyOrder: Int!
-
-  """
   A schema diff comparing against the schema from the most recent previous successful publication.
   """
   diffToPrevious: SchemaDiff
-  gitContext: GitContext
-  slackNotificationBody(graphDisplayName: String!): String
-  webhookNotificationBody: String!
-}
-
-enum SchemaTagHistoryOrder {
-  CREATED_DESC
-  CREATED_ASC
-}
-
-"""An error that occurs when an invalid schema is passed in as user input"""
-type SchemaValidationError implements Error {
-  issues: [SchemaValidationIssue!]!
-
-  """The error's details."""
-  message: String!
-}
-
-"""An error that occurs when an invalid schema is passed in as user input"""
-type SchemaValidationIssue {
-  message: String!
-}
-
-"""
-How many seats of the given types does an organization have (regardless of plan type)?
-"""
-type Seats {
-  """How many members that are free in this organization."""
-  free: Int!
-
-  """How many members that are not free in this organization."""
-  fullPrice: Int!
 }
 
 """Cloud Router secret"""
@@ -14921,22 +4994,19 @@ A graph in Apollo Studio represents a graph in your organization.
 Each graph has one or more variants, which correspond to the different environments where that graph runs (such as staging and production).
 Each variant has its own GraphQL schema, which means schemas can differ between environments.
 """
-type Service implements Identity {
+type Graph implements Identity {
   """The organization that this graph belongs to."""
-  account: Account
+  account: Organization
 
   """Provides a view of the graph as an `Actor` type."""
   asActor: Actor!
-
-  """Custom check configuration for this graph."""
-  customCheckConfiguration: CustomCheckConfiguration
 
   """The graph's globally unique identifier."""
   id: ID!
   name: String!
 
   """Describes the permissions that the active user has for this graph."""
-  roles: ServiceRoles
+  roles: GraphRoles
 
   """A list of the graph API keys that are active for this graph."""
   apiKeys: [GraphApiKey!]
@@ -14944,116 +5014,20 @@ type Service implements Identity {
   """Permissions of the current user in this graph."""
   myRole: UserPermission
 
-  """
-  The list of members that can access this graph, accounting for graph role overrides
-  """
-  roleOverrides: [RoleOverride!]
-
   """A list of the variants for this graph."""
   variants: [GraphVariant!]!
-  ruleEnforcement(id: ID!): RuleEnforcement
-  accountId: ID
-
-  """
-  The `GraphVariant` types of all proposal variants. This is a potentially expensive field to query.
-  """
-  allProposalVariants: [GraphVariant!]!
-
-  """
-  Get an URL to which an avatar image can be uploaded. Client uploads by sending a PUT request
-  with the image data to MediaUploadInfo.url. Client SHOULD set the "Content-Type" header to the
-  browser-inferred MIME type, and SHOULD set the "x-apollo-content-filename" header to the
-  filename, if such information is available. Client MUST set the "x-apollo-csrf-token" header to
-  MediaUploadInfo.csrfToken.
-  """
-  avatarUpload: AvatarUploadResult
-
-  """
-  Get an image URL for the service's avatar. Note that CORS is not enabled for these URLs. The size
-  argument is used for bandwidth reduction, and should be the size of the image as displayed in the
-  application. Apollo's media server will downscale larger images to at least the requested size,
-  but this will not happen for third-party media servers.
-  """
-  avatarUrl(size: Int! = 40): String
-
-  """Get available notification endpoints"""
-  channels(channelIds: [ID!]): [Channel!]
 
   """Get a check workflow for this graph by its ID"""
   checkWorkflow(id: ID!): CheckWorkflow
-
-  """Get a check workflow task for this graph by its ID"""
-  checkWorkflowTask(id: ID!): CheckWorkflowTask
-
-  """Get a composition build check result for this graph by its ID"""
-  compositionBuildCheckResult(id: ID!): CompositionBuildCheckResult
-  createdAt: Timestamp!
-  createdBy: Identity
-  datadogMetricsConfig: DatadogMetricsConfig
-
-  """The time the default build pipeline track version was updated."""
-  defaultBuildPipelineTrackUpdatedAt: Timestamp
-  deletedAt: Timestamp
-  description: String
-  devGraphOwner: User @deprecated(reason: "No longer supported")
-
-  """The capabilities that are supported for this graph"""
-  graphCapabilities: GraphCapabilities!
-  graphType: GraphType!
 
   """
   When this is true, this graph will be hidden from non-admin members of the org who haven't been explicitly assigned a
   role on this graph.
   """
   hiddenFromUninvitedNonAdminAccountMembers: Boolean!
-  lastReportedAt(graphVariant: String): Timestamp
-
-  """Current identity, null if not authenticated."""
-  me: Identity
-  onboardingArchitecture: OnboardingArchitecture
-
-  """Get request counts by variant for operation checks"""
-  operationCheckRequestsByVariant(from: Timestamp!): [RequestCountsPerGraphVariant!]!
-
-  """
-  Get query triggers for a given variant. If variant is null all the triggers for this service will be gotten.
-  """
-  queryTriggers(graphVariant: String, operationNames: [String!]): [QueryTrigger!]
-  readme: Readme
-
-  """
-  Whether registry subscriptions (with any options) are enabled. If variant is not passed, returns true if configuration is present for any variant
-  """
-  registrySubscriptionsEnabled(graphVariant: String): Boolean! @deprecated(reason: "This field will be removed")
-  reportingEnabled: Boolean!
-  scheduledSummaries: [ScheduledSummary!]!
-  stats(
-    from: Timestamp!
-
-    """
-    Granularity of buckets. Defaults to the entire range (aggregate all data into a single durationBucket) when null.
-    """
-    resolution: Resolution
-
-    """Defaults to the current time when null."""
-    to: Timestamp
-  ): ServiceStatsWindow! @deprecated(reason: "use Service.statsWindow instead")
-  statsWindow(
-    from: Timestamp!
-
-    """
-    Granularity of buckets. Defaults to the entire range (aggregate all data into a single durationBucket) when null.
-    """
-    resolution: Resolution
-
-    """Defaults to the current time when null."""
-    to: Timestamp
-  ): ServiceStatsWindow
 
   """The graph's name."""
   title: String!
-  trace(id: ID!): Trace
-  traceStorageEnabled: Boolean!
 
   """
   Provides details of the graph variant with the provided `name`, if a variant
@@ -15063,96 +5037,39 @@ type Service implements Identity {
   """
   variant(name: String!): GraphVariant
 
-  """List of ignored rule violations for the linter"""
-  ignoredLinterViolations: [IgnoredRule!]!
-
-  """Linter configuration for this graph."""
-  linterConfiguration: GraphLinterConfiguration!
-
   """The Persisted Query List associated with this graph with the given ID."""
   persistedQueryList(id: ID!): PersistedQueryList
-  persistedQueryLists: [PersistedQueryList!]
 
   """Get check configuration for this graph."""
   checkConfiguration: CheckConfiguration
+
+  """
+  Returns the default reviewers for this graph. This field accepts up to 1000 requests per minute. This rate may be temporarily adjusted based on system conditions.
+  """
   defaultProposalReviewers: [Identity]!
+
+  """
+  Diffs the sdls at the oldSdlHash and newSdlHash, returning a FlatDiffResult. This field accepts up to 1000 requests per minute. This rate may be temporarily adjusted based on system conditions.
+  """
   flatDiff(newSdlHash: SHA256, oldSdlHash: SHA256): FlatDiffResult!
-  minProposalApprovers: Int!
-  minProposalRoles: ProposalRoles!
-
-  """A template that is the base description for new schema proposals"""
-  proposalDescriptionTemplate: String
-
-  """The current active user's Proposal notification status on this graph."""
-  proposalNotificationStatus: NotificationStatus!
 
   """
   A list of the proposals for this graph sorted by created at date.
-  limit defaults to 25 and has an allowed max of 50, offset defaults to 0
+  limit defaults to 25 and has an allowed max of 50, offset defaults to 0.
+  This field accepts up to 1000 requests per minute. This rate may be temporarily adjusted based on system conditions.
   """
   proposals(filterBy: ProposalsFilterInput, limit: Int, offset: Int): ProposalsResult!
-
-  """
-  If the graph setting for the proposals implementation variant has been set, this will be non null.
-  """
-  proposalsImplementationVariant: GraphVariant
-
-  """Must one of the default reviewers approve proposals"""
-  proposalsMustBeApprovedByADefaultReviewer: Boolean!
-
-  """
-  True if each approving reviewer's review will get dismissed & the proposal status will change from approved to open on new revisions.
-  """
-  proposalsMustBeReApprovedOnChange: Boolean!
-  operation(id: ID!): Operation
-  defaultBuildPipelineTrack: String
 
   """Get a GraphQL document by hash"""
   doc(hash: SHA256): GraphQLDoc
 
   """
-  Get GraphQL documents by hash, max up to 100 can be requested per query
+  Get GraphQL documents by hash, max up to 100 can be requested per query. This field accepts up to 120 requests per minute. This rate may be temporarily adjusted based on system conditions.
   """
   docs(hashes: [SHA256!]!): [GraphQLDoc]
 
   """Get a GraphQL document by hash"""
   document(hash: SHA256): GraphQLDocument @deprecated(reason: "Use doc instead")
-
-  """Get a schema by hash or current tag"""
-  schema(hash: ID, tag: String): Schema
-
-  """
-  Get schema tags, with optional filtering to a set of tags. Always sorted by creation
-  date in reverse chronological order.
-  """
-  schemaTags(tags: [String!]): [SchemaTag!]
-
-  """
-  The current publish associated to a given variant (with 'tag' as the variant name).
-  """
-  schemaTag(tag: String!): SchemaTag
-  schemaTagById(id: ID!): SchemaTag
-
-  """
-  List of subgraphs that comprise a graph. A non-federated graph should have a single implementing service.
-  Set includeDeleted to see deleted subgraphs.
-  """
-  implementingServices(graphVariant: String!, includeDeleted: Boolean): GraphImplementors
-
-  """
-  The composition result that was most recently published to a graph variant.
-  """
-  mostRecentCompositionPublish(graphVariant: String!): CompositionPublishResult
-
-  """
-  Given a graphCompositionID, return the results of composition. This can represent either a validation or a publish.
-  """
-  compositionResultById(id: ID!): CompositionResult
-
-  """
-  Gets the operations and their approved changes for this graph, checkID, and operationID.
-  """
-  operationsAcceptedChanges(checkID: ID!, operationID: String!): [OperationAcceptedChange!]!
 
   """
   Count checkWorkflows for the given filter. Used for paginating with checkWorkflows.
@@ -15163,1342 +5080,18 @@ type Service implements Identity {
   Get check workflows for this graph ordered by creation time, most recent first.
   """
   checkWorkflows(limit: Int! = 100, offset: Int! = 0, filter: CheckFilterInput): [CheckWorkflow!]!
-
-  """Get an operations check result for a specific check ID"""
-  operationsCheck(checkID: ID!): OperationsCheckResult
-
-  """Generate a test schema publish notification body"""
-  testSchemaPublishBody(variant: String!): String!
-
-  """
-  List of options available for filtering checks for this graph by created by field.
-  If a filter is passed, constrains results to match the filter.
-  For non cli triggered checks, this is the Studio User / author.
-  """
-  checksCreatedByOptions(filter: CheckFilterInput): [Identity!]!
-
-  """
-  List of options available for filtering checks for this graph by git committer.
-  If a filter is passed, constrains results to match the filter.
-  For cli triggered checks, this is the author.
-  """
-  checksCommitterOptions(filter: CheckFilterInput): [String!]!
-
-  """
-  List of options available for filtering checks for this graph by git committer.
-  If a filter is passed, constrains results to match the filter.
-  For cli triggered checks, this is the author.
-  """
-  checksAuthorOptions(filter: CheckFilterInput): [String!]! @deprecated(reason: "Use checksCommitterOptions instead")
-
-  """
-  List of options available for filtering checks for this graph by branch.
-  If a filter is passed, constrains results to match the filter.
-  """
-  checksBranchOptions(filter: CheckFilterInput): [String!]!
-
-  """
-  List of options available for filtering checks for this graph by subgraph name.
-  If a filter is passed, constrains results to match the filter.
-  """
-  checksSubgraphOptions(filter: CheckFilterInput): [String!]!
-
-  """Registry specific stats for this graph."""
-  registryStatsWindow(from: Timestamp!, resolution: Resolution, to: Timestamp): RegistryStatsWindow
-
-  """All assessments for this graph."""
-  safAssessments(includeDeleted: Boolean! = false): [SafAssessment!]!
-
-  """Get a specific assessment for this graph by its ID."""
-  safAssessment(id: ID!, includeDeleted: Boolean! = false): SafAssessment
-}
-
-"""Columns of ServiceBillingUsageStats."""
-enum ServiceBillingUsageStatsColumn {
-  AGENT_ID
-  AGENT_VERSION
-  GRAPH_DEPLOYMENT_TYPE
-  OPERATION_COUNT
-  OPERATION_COUNT_PROVIDED_EXPLICITLY
-  OPERATION_SUBTYPE
-  OPERATION_TYPE
-  ROUTER_FEATURES_ENABLED
-  SCHEMA_TAG
-  TIMESTAMP
-}
-
-type ServiceBillingUsageStatsDimensions {
-  agentId: String
-  agentVersion: String
-  graphDeploymentType: String
-  operationCountProvidedExplicitly: String
-  operationSubtype: String
-  operationType: String
-  routerFeaturesEnabled: String
-  schemaTag: String
-}
-
-"""
-Filter for data in ServiceBillingUsageStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input ServiceBillingUsageStatsFilter {
-  """
-  Selects rows whose agentId dimension equals the given value if not null. To query for the null value, use {in: {agentId: [null]}} instead.
-  """
-  agentId: String
-
-  """
-  Selects rows whose agentVersion dimension equals the given value if not null. To query for the null value, use {in: {agentVersion: [null]}} instead.
-  """
-  agentVersion: String
-  and: [ServiceBillingUsageStatsFilter!]
-
-  """
-  Selects rows whose graphDeploymentType dimension equals the given value if not null. To query for the null value, use {in: {graphDeploymentType: [null]}} instead.
-  """
-  graphDeploymentType: String
-  in: ServiceBillingUsageStatsFilterIn
-  not: ServiceBillingUsageStatsFilter
-
-  """
-  Selects rows whose operationCountProvidedExplicitly dimension equals the given value if not null. To query for the null value, use {in: {operationCountProvidedExplicitly: [null]}} instead.
-  """
-  operationCountProvidedExplicitly: String
-
-  """
-  Selects rows whose operationSubtype dimension equals the given value if not null. To query for the null value, use {in: {operationSubtype: [null]}} instead.
-  """
-  operationSubtype: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [ServiceBillingUsageStatsFilter!]
-
-  """
-  Selects rows whose routerFeaturesEnabled dimension equals the given value if not null. To query for the null value, use {in: {routerFeaturesEnabled: [null]}} instead.
-  """
-  routerFeaturesEnabled: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-}
-
-"""
-Filter for data in ServiceBillingUsageStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input ServiceBillingUsageStatsFilterIn {
-  """
-  Selects rows whose agentId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  agentId: [String]
-
-  """
-  Selects rows whose agentVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  agentVersion: [String]
-
-  """
-  Selects rows whose graphDeploymentType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  graphDeploymentType: [String]
-
-  """
-  Selects rows whose operationCountProvidedExplicitly dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationCountProvidedExplicitly: [String]
-
-  """
-  Selects rows whose operationSubtype dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationSubtype: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose routerFeaturesEnabled dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  routerFeaturesEnabled: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-}
-
-type ServiceBillingUsageStatsMetrics {
-  operationCount: Long!
-}
-
-input ServiceBillingUsageStatsOrderBySpec {
-  column: ServiceBillingUsageStatsColumn!
-  direction: Ordering!
-}
-
-type ServiceBillingUsageStatsRecord {
-  """Dimensions of ServiceBillingUsageStats that can be grouped by."""
-  groupBy: ServiceBillingUsageStatsDimensions!
-
-  """Metrics of ServiceBillingUsageStats that can be aggregated over."""
-  metrics: ServiceBillingUsageStatsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of ServiceCardinalityStats."""
-enum ServiceCardinalityStatsColumn {
-  CLIENT_NAME_CARDINALITY
-  CLIENT_VERSION_CARDINALITY
-  OPERATION_SHAPE_CARDINALITY
-  SCHEMA_COORDINATE_CARDINALITY
-  SCHEMA_TAG
-  TIMESTAMP
-}
-
-type ServiceCardinalityStatsDimensions {
-  schemaTag: String
-}
-
-"""
-Filter for data in ServiceCardinalityStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input ServiceCardinalityStatsFilter {
-  and: [ServiceCardinalityStatsFilter!]
-  in: ServiceCardinalityStatsFilterIn
-  not: ServiceCardinalityStatsFilter
-  or: [ServiceCardinalityStatsFilter!]
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-}
-
-"""
-Filter for data in ServiceCardinalityStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input ServiceCardinalityStatsFilterIn {
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-}
-
-type ServiceCardinalityStatsMetrics {
-  clientNameCardinality: Float!
-  clientVersionCardinality: Float!
-  operationShapeCardinality: Float!
-  schemaCoordinateCardinality: Float!
-}
-
-input ServiceCardinalityStatsOrderBySpec {
-  column: ServiceCardinalityStatsColumn!
-  direction: Ordering!
-}
-
-type ServiceCardinalityStatsRecord {
-  """Dimensions of ServiceCardinalityStats that can be grouped by."""
-  groupBy: ServiceCardinalityStatsDimensions!
-
-  """Metrics of ServiceCardinalityStats that can be aggregated over."""
-  metrics: ServiceCardinalityStatsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of ServiceCoordinateUsage."""
-enum ServiceCoordinateUsageColumn {
-  CLIENT_NAME
-  CLIENT_VERSION
-  ESTIMATED_EXECUTION_COUNT
-  EXECUTION_COUNT
-  KIND
-  NAMED_ATTRIBUTE
-  NAMED_TYPE
-  OPERATION_SUBTYPE
-  OPERATION_TYPE
-  QUERY_ID
-  QUERY_NAME
-  REFERENCING_OPERATION_COUNT
-  REQUEST_COUNT_NULL
-  REQUEST_COUNT_UNDEFINED
-  SCHEMA_TAG
-  TIMESTAMP
-}
-
-type ServiceCoordinateUsageDimensions {
-  clientName: String
-  clientVersion: String
-  kind: String
-  namedAttribute: String
-  namedType: String
-  operationSubtype: String
-  operationType: String
-  queryId: String
-  queryName: String
-  schemaTag: String
-}
-
-"""
-Filter for data in ServiceCoordinateUsage. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input ServiceCoordinateUsageFilter {
-  and: [ServiceCoordinateUsageFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-  in: ServiceCoordinateUsageFilterIn
-
-  """
-  Selects rows whose kind dimension equals the given value if not null. To query for the null value, use {in: {kind: [null]}} instead.
-  """
-  kind: String
-
-  """
-  Selects rows whose namedAttribute dimension equals the given value if not null. To query for the null value, use {in: {namedAttribute: [null]}} instead.
-  """
-  namedAttribute: String
-
-  """
-  Selects rows whose namedType dimension equals the given value if not null. To query for the null value, use {in: {namedType: [null]}} instead.
-  """
-  namedType: String
-  not: ServiceCoordinateUsageFilter
-
-  """
-  Selects rows whose operationSubtype dimension equals the given value if not null. To query for the null value, use {in: {operationSubtype: [null]}} instead.
-  """
-  operationSubtype: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [ServiceCoordinateUsageFilter!]
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: String
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-}
-
-"""
-Filter for data in ServiceCoordinateUsage. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input ServiceCoordinateUsageFilterIn {
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose kind dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  kind: [String]
-
-  """
-  Selects rows whose namedAttribute dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  namedAttribute: [String]
-
-  """
-  Selects rows whose namedType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  namedType: [String]
-
-  """
-  Selects rows whose operationSubtype dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationSubtype: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [String]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-}
-
-type ServiceCoordinateUsageMetrics {
-  estimatedExecutionCount: Long!
-  executionCount: Long!
-  referencingOperationCount: Long!
-  requestCountNull: Long!
-  requestCountUndefined: Long!
-}
-
-input ServiceCoordinateUsageOrderBySpec {
-  column: ServiceCoordinateUsageColumn!
-  direction: Ordering!
-}
-
-type ServiceCoordinateUsageRecord {
-  """Dimensions of ServiceCoordinateUsage that can be grouped by."""
-  groupBy: ServiceCoordinateUsageDimensions!
-
-  """Metrics of ServiceCoordinateUsage that can be aggregated over."""
-  metrics: ServiceCoordinateUsageMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of ServiceEdgeServerInfos."""
-enum ServiceEdgeServerInfosColumn {
-  BOOT_ID
-  EXECUTABLE_SCHEMA_ID
-  LIBRARY_VERSION
-  PLATFORM
-  RUNTIME_VERSION
-  SCHEMA_TAG
-  SERVER_ID
-  TIMESTAMP
-  USER_VERSION
-}
-
-type ServiceEdgeServerInfosDimensions {
-  bootId: ID
-  executableSchemaId: ID
-  libraryVersion: String
-  platform: String
-  runtimeVersion: String
-  schemaTag: String
-  serverId: ID
-  userVersion: String
-}
-
-"""
-Filter for data in ServiceEdgeServerInfos. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input ServiceEdgeServerInfosFilter {
-  and: [ServiceEdgeServerInfosFilter!]
-
-  """
-  Selects rows whose bootId dimension equals the given value if not null. To query for the null value, use {in: {bootId: [null]}} instead.
-  """
-  bootId: ID
-
-  """
-  Selects rows whose executableSchemaId dimension equals the given value if not null. To query for the null value, use {in: {executableSchemaId: [null]}} instead.
-  """
-  executableSchemaId: ID
-  in: ServiceEdgeServerInfosFilterIn
-
-  """
-  Selects rows whose libraryVersion dimension equals the given value if not null. To query for the null value, use {in: {libraryVersion: [null]}} instead.
-  """
-  libraryVersion: String
-  not: ServiceEdgeServerInfosFilter
-  or: [ServiceEdgeServerInfosFilter!]
-
-  """
-  Selects rows whose platform dimension equals the given value if not null. To query for the null value, use {in: {platform: [null]}} instead.
-  """
-  platform: String
-
-  """
-  Selects rows whose runtimeVersion dimension equals the given value if not null. To query for the null value, use {in: {runtimeVersion: [null]}} instead.
-  """
-  runtimeVersion: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serverId dimension equals the given value if not null. To query for the null value, use {in: {serverId: [null]}} instead.
-  """
-  serverId: ID
-
-  """
-  Selects rows whose userVersion dimension equals the given value if not null. To query for the null value, use {in: {userVersion: [null]}} instead.
-  """
-  userVersion: String
-}
-
-"""
-Filter for data in ServiceEdgeServerInfos. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input ServiceEdgeServerInfosFilterIn {
-  """
-  Selects rows whose bootId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  bootId: [ID]
-
-  """
-  Selects rows whose executableSchemaId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  executableSchemaId: [ID]
-
-  """
-  Selects rows whose libraryVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  libraryVersion: [String]
-
-  """
-  Selects rows whose platform dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  platform: [String]
-
-  """
-  Selects rows whose runtimeVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  runtimeVersion: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serverId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serverId: [ID]
-
-  """
-  Selects rows whose userVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  userVersion: [String]
-}
-
-input ServiceEdgeServerInfosOrderBySpec {
-  column: ServiceEdgeServerInfosColumn!
-  direction: Ordering!
-}
-
-type ServiceEdgeServerInfosRecord {
-  """Dimensions of ServiceEdgeServerInfos that can be grouped by."""
-  groupBy: ServiceEdgeServerInfosDimensions!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of ServiceErrorStats."""
-enum ServiceErrorStatsColumn {
-  CLIENT_NAME
-  CLIENT_VERSION
-  ERRORS_COUNT
-  PATH
-  QUERY_ID
-  QUERY_NAME
-  REQUESTS_WITH_ERRORS_COUNT
-  SCHEMA_HASH
-  SCHEMA_TAG
-  TIMESTAMP
-}
-
-type ServiceErrorStatsDimensions {
-  clientName: String
-  clientVersion: String
-  path: String
-  queryId: ID
-  queryName: String
-  schemaHash: String
-  schemaTag: String
-}
-
-"""
-Filter for data in ServiceErrorStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input ServiceErrorStatsFilter {
-  and: [ServiceErrorStatsFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-  in: ServiceErrorStatsFilterIn
-  not: ServiceErrorStatsFilter
-  or: [ServiceErrorStatsFilter!]
-
-  """
-  Selects rows whose path dimension equals the given value if not null. To query for the null value, use {in: {path: [null]}} instead.
-  """
-  path: String
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: ID
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead.
-  """
-  schemaHash: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-}
-
-"""
-Filter for data in ServiceErrorStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input ServiceErrorStatsFilterIn {
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  path: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [ID]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaHash: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-}
-
-type ServiceErrorStatsMetrics {
-  errorsCount: Long!
-  requestsWithErrorsCount: Long!
-}
-
-input ServiceErrorStatsOrderBySpec {
-  column: ServiceErrorStatsColumn!
-  direction: Ordering!
-}
-
-type ServiceErrorStatsRecord {
-  """Dimensions of ServiceErrorStats that can be grouped by."""
-  groupBy: ServiceErrorStatsDimensions!
-
-  """Metrics of ServiceErrorStats that can be aggregated over."""
-  metrics: ServiceErrorStatsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of ServiceFederatedErrorStats."""
-enum ServiceFederatedErrorStatsColumn {
-  AGENT_VERSION
-  CLIENT_NAME
-  CLIENT_VERSION
-  ERROR_CODE
-  ERROR_COUNT
-  ERROR_PATH
-  ERROR_SERVICE
-  OPERATION_ID
-  OPERATION_NAME
-  OPERATION_TYPE
-  SCHEMA_TAG
-  SEVERITY
-  TIMESTAMP
-}
-
-type ServiceFederatedErrorStatsDimensions {
-  agentVersion: String
-  clientName: String
-  clientVersion: String
-  errorCode: String
-  errorPath: String
-  errorService: String
-  operationId: String
-  operationName: String
-  operationType: String
-  schemaTag: String
-  severity: String
-}
-
-"""
-Filter for data in ServiceFederatedErrorStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input ServiceFederatedErrorStatsFilter {
-  """
-  Selects rows whose agentVersion dimension equals the given value if not null. To query for the null value, use {in: {agentVersion: [null]}} instead.
-  """
-  agentVersion: String
-  and: [ServiceFederatedErrorStatsFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-
-  """
-  Selects rows whose errorCode dimension equals the given value if not null. To query for the null value, use {in: {errorCode: [null]}} instead.
-  """
-  errorCode: String
-
-  """
-  Selects rows whose errorPath dimension equals the given value if not null. To query for the null value, use {in: {errorPath: [null]}} instead.
-  """
-  errorPath: String
-
-  """
-  Selects rows whose errorService dimension equals the given value if not null. To query for the null value, use {in: {errorService: [null]}} instead.
-  """
-  errorService: String
-  in: ServiceFederatedErrorStatsFilterIn
-  not: ServiceFederatedErrorStatsFilter
-
-  """
-  Selects rows whose operationId dimension equals the given value if not null. To query for the null value, use {in: {operationId: [null]}} instead.
-  """
-  operationId: String
-
-  """
-  Selects rows whose operationName dimension equals the given value if not null. To query for the null value, use {in: {operationName: [null]}} instead.
-  """
-  operationName: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [ServiceFederatedErrorStatsFilter!]
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose severity dimension equals the given value if not null. To query for the null value, use {in: {severity: [null]}} instead.
-  """
-  severity: String
-}
-
-"""
-Filter for data in ServiceFederatedErrorStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input ServiceFederatedErrorStatsFilterIn {
-  """
-  Selects rows whose agentVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  agentVersion: [String]
-
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose errorCode dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  errorCode: [String]
-
-  """
-  Selects rows whose errorPath dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  errorPath: [String]
-
-  """
-  Selects rows whose errorService dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  errorService: [String]
-
-  """
-  Selects rows whose operationId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationId: [String]
-
-  """
-  Selects rows whose operationName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationName: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose severity dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  severity: [String]
-}
-
-type ServiceFederatedErrorStatsMetrics {
-  errorCount: Long!
-}
-
-input ServiceFederatedErrorStatsOrderBySpec {
-  column: ServiceFederatedErrorStatsColumn!
-  direction: Ordering!
-}
-
-type ServiceFederatedErrorStatsRecord {
-  """Dimensions of ServiceFederatedErrorStats that can be grouped by."""
-  groupBy: ServiceFederatedErrorStatsDimensions!
-
-  """Metrics of ServiceFederatedErrorStats that can be aggregated over."""
-  metrics: ServiceFederatedErrorStatsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of ServiceFieldExecutions."""
-enum ServiceFieldExecutionsColumn {
-  ERRORS_COUNT
-  ESTIMATED_EXECUTION_COUNT
-  FIELD_NAME
-  OBSERVED_EXECUTION_COUNT
-  PARENT_TYPE
-  REFERENCING_OPERATION_COUNT
-  REQUESTS_WITH_ERRORS_COUNT
-  SCHEMA_TAG
-  TIMESTAMP
-}
-
-type ServiceFieldExecutionsDimensions {
-  fieldName: String
-  parentType: String
-  schemaTag: String
-}
-
-"""
-Filter for data in ServiceFieldExecutions. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input ServiceFieldExecutionsFilter {
-  and: [ServiceFieldExecutionsFilter!]
-
-  """
-  Selects rows whose fieldName dimension equals the given value if not null. To query for the null value, use {in: {fieldName: [null]}} instead.
-  """
-  fieldName: String
-  in: ServiceFieldExecutionsFilterIn
-  not: ServiceFieldExecutionsFilter
-  or: [ServiceFieldExecutionsFilter!]
-
-  """
-  Selects rows whose parentType dimension equals the given value if not null. To query for the null value, use {in: {parentType: [null]}} instead.
-  """
-  parentType: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-}
-
-"""
-Filter for data in ServiceFieldExecutions. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input ServiceFieldExecutionsFilterIn {
-  """
-  Selects rows whose fieldName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  fieldName: [String]
-
-  """
-  Selects rows whose parentType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  parentType: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-}
-
-type ServiceFieldExecutionsMetrics {
-  errorsCount: Long!
-  estimatedExecutionCount: Long!
-  observedExecutionCount: Long!
-  referencingOperationCount: Long!
-  requestsWithErrorsCount: Long!
-}
-
-input ServiceFieldExecutionsOrderBySpec {
-  column: ServiceFieldExecutionsColumn!
-  direction: Ordering!
-}
-
-type ServiceFieldExecutionsRecord {
-  """Dimensions of ServiceFieldExecutions that can be grouped by."""
-  groupBy: ServiceFieldExecutionsDimensions!
-
-  """Metrics of ServiceFieldExecutions that can be aggregated over."""
-  metrics: ServiceFieldExecutionsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of ServiceFieldLatencies."""
-enum ServiceFieldLatenciesColumn {
-  FIELD_HISTOGRAM
-  FIELD_NAME
-  PARENT_TYPE
-  SCHEMA_HASH
-  SCHEMA_TAG
-  TIMESTAMP
-}
-
-type ServiceFieldLatenciesDimensions {
-  field: String
-  fieldName: String
-  parentType: String
-  schemaHash: String
-  schemaTag: String
-}
-
-"""
-Filter for data in ServiceFieldLatencies. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input ServiceFieldLatenciesFilter {
-  and: [ServiceFieldLatenciesFilter!]
-
-  """
-  Selects rows whose fieldName dimension equals the given value if not null. To query for the null value, use {in: {fieldName: [null]}} instead.
-  """
-  fieldName: String
-  in: ServiceFieldLatenciesFilterIn
-  not: ServiceFieldLatenciesFilter
-  or: [ServiceFieldLatenciesFilter!]
-
-  """
-  Selects rows whose parentType dimension equals the given value if not null. To query for the null value, use {in: {parentType: [null]}} instead.
-  """
-  parentType: String
-
-  """
-  Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead.
-  """
-  schemaHash: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-}
-
-"""
-Filter for data in ServiceFieldLatencies. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input ServiceFieldLatenciesFilterIn {
-  """
-  Selects rows whose fieldName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  fieldName: [String]
-
-  """
-  Selects rows whose parentType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  parentType: [String]
-
-  """
-  Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaHash: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-}
-
-type ServiceFieldLatenciesMetrics {
-  fieldHistogram: DurationHistogram!
-}
-
-input ServiceFieldLatenciesOrderBySpec {
-  column: ServiceFieldLatenciesColumn!
-  direction: Ordering!
-}
-
-type ServiceFieldLatenciesRecord {
-  """Dimensions of ServiceFieldLatencies that can be grouped by."""
-  groupBy: ServiceFieldLatenciesDimensions!
-
-  """Metrics of ServiceFieldLatencies that can be aggregated over."""
-  metrics: ServiceFieldLatenciesMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of ServiceFieldUsage."""
-enum ServiceFieldUsageColumn {
-  CLIENT_NAME
-  CLIENT_VERSION
-  ESTIMATED_EXECUTION_COUNT
-  EXECUTION_COUNT
-  FIELD_NAME
-  OPERATION_SUBTYPE
-  OPERATION_TYPE
-  PARENT_TYPE
-  QUERY_ID
-  QUERY_NAME
-  REFERENCING_OPERATION_COUNT
-  SCHEMA_HASH
-  SCHEMA_TAG
-  TIMESTAMP
-}
-
-type ServiceFieldUsageDimensions {
-  clientName: String
-  clientVersion: String
-  fieldName: String
-  operationSubtype: String
-  operationType: String
-  parentType: String
-  queryId: ID
-  queryName: String
-  schemaHash: String
-  schemaTag: String
-}
-
-"""
-Filter for data in ServiceFieldUsage. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input ServiceFieldUsageFilter {
-  and: [ServiceFieldUsageFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-
-  """
-  Selects rows whose fieldName dimension equals the given value if not null. To query for the null value, use {in: {fieldName: [null]}} instead.
-  """
-  fieldName: String
-  in: ServiceFieldUsageFilterIn
-  not: ServiceFieldUsageFilter
-
-  """
-  Selects rows whose operationSubtype dimension equals the given value if not null. To query for the null value, use {in: {operationSubtype: [null]}} instead.
-  """
-  operationSubtype: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [ServiceFieldUsageFilter!]
-
-  """
-  Selects rows whose parentType dimension equals the given value if not null. To query for the null value, use {in: {parentType: [null]}} instead.
-  """
-  parentType: String
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: ID
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead.
-  """
-  schemaHash: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-}
-
-"""
-Filter for data in ServiceFieldUsage. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input ServiceFieldUsageFilterIn {
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose fieldName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  fieldName: [String]
-
-  """
-  Selects rows whose operationSubtype dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationSubtype: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose parentType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  parentType: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [ID]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaHash: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-}
-
-type ServiceFieldUsageMetrics {
-  estimatedExecutionCount: Long!
-  executionCount: Long!
-  referencingOperationCount: Long!
-}
-
-input ServiceFieldUsageOrderBySpec {
-  column: ServiceFieldUsageColumn!
-  direction: Ordering!
-}
-
-type ServiceFieldUsageRecord {
-  """Dimensions of ServiceFieldUsage that can be grouped by."""
-  groupBy: ServiceFieldUsageDimensions!
-
-  """Metrics of ServiceFieldUsage that can be aggregated over."""
-  metrics: ServiceFieldUsageMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of ServiceGraphosCloudMetrics."""
-enum ServiceGraphosCloudMetricsColumn {
-  AGENT_VERSION
-  CLOUD_PROVIDER
-  RESPONSE_SIZE
-  RESPONSE_SIZE_THROTTLED
-  ROUTER_ID
-  ROUTER_OPERATIONS
-  ROUTER_OPERATIONS_THROTTLED
-  SCHEMA_TAG
-  SUBGRAPH_FETCHES
-  SUBGRAPH_FETCHES_THROTTLED
-  TIER
-  TIMESTAMP
-}
-
-type ServiceGraphosCloudMetricsDimensions {
-  agentVersion: String
-  cloudProvider: String
-  routerId: String
-  schemaTag: String
-  tier: String
-}
-
-"""
-Filter for data in ServiceGraphosCloudMetrics. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input ServiceGraphosCloudMetricsFilter {
-  """
-  Selects rows whose agentVersion dimension equals the given value if not null. To query for the null value, use {in: {agentVersion: [null]}} instead.
-  """
-  agentVersion: String
-  and: [ServiceGraphosCloudMetricsFilter!]
-
-  """
-  Selects rows whose cloudProvider dimension equals the given value if not null. To query for the null value, use {in: {cloudProvider: [null]}} instead.
-  """
-  cloudProvider: String
-  in: ServiceGraphosCloudMetricsFilterIn
-  not: ServiceGraphosCloudMetricsFilter
-  or: [ServiceGraphosCloudMetricsFilter!]
-
-  """
-  Selects rows whose routerId dimension equals the given value if not null. To query for the null value, use {in: {routerId: [null]}} instead.
-  """
-  routerId: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose tier dimension equals the given value if not null. To query for the null value, use {in: {tier: [null]}} instead.
-  """
-  tier: String
-}
-
-"""
-Filter for data in ServiceGraphosCloudMetrics. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input ServiceGraphosCloudMetricsFilterIn {
-  """
-  Selects rows whose agentVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  agentVersion: [String]
-
-  """
-  Selects rows whose cloudProvider dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  cloudProvider: [String]
-
-  """
-  Selects rows whose routerId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  routerId: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose tier dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  tier: [String]
-}
-
-type ServiceGraphosCloudMetricsMetrics {
-  responseSize: Long!
-  responseSizeThrottled: Long!
-  routerOperations: Long!
-  routerOperationsThrottled: Long!
-  subgraphFetches: Long!
-  subgraphFetchesThrottled: Long!
-}
-
-input ServiceGraphosCloudMetricsOrderBySpec {
-  column: ServiceGraphosCloudMetricsColumn!
-  direction: Ordering!
-}
-
-type ServiceGraphosCloudMetricsRecord {
-  """Dimensions of ServiceGraphosCloudMetrics that can be grouped by."""
-  groupBy: ServiceGraphosCloudMetricsDimensions!
-
-  """Metrics of ServiceGraphosCloudMetrics that can be aggregated over."""
-  metrics: ServiceGraphosCloudMetricsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
 }
 
 """
 Provides access to mutation fields for managing Studio graphs and subgraphs.
 """
-type ServiceMutation {
-  service: Service!
+type GraphMutation {
   setCustomCheckConfiguration(input: SetCustomCheckConfigurationInput!): CustomCheckConfigurationResult!
 
   """
   Generates a new graph API key for this graph with the specified permission level.
   """
   newKey(keyName: String, role: UserPermission! = GRAPH_ADMIN): GraphApiKey!
-
-  """Adds an override to the given users permission for this graph"""
-  overrideUserPermission(permission: UserPermission, userID: ID!): Service
 
   """Deletes the existing graph API key with the provided ID, if any."""
   removeKey(
@@ -16510,111 +5103,17 @@ type ServiceMutation {
   Sets a new name for the graph API key with the provided ID, if any. This does not invalidate the key or change its value.
   """
   renameKey(id: ID!, newKeyName: String): GraphApiKey
-  createRuleEnforcement(input: CreateRuleEnforcementInput!): RuleEnforcementResult!
-  deleteRuleEnforcement(id: ID!): Boolean!
-  updateRuleEnforcement(id: ID!, input: UpdateRuleEnforcementInput!): RuleEnforcementResult!
-
-  """Make changes to a check workflow."""
-  checkWorkflow(id: ID!): CheckWorkflowMutation
-  createCompositionStatusSubscription(
-    """ID of Slack channel for registry notification."""
-    channelID: ID!
-
-    """Variant to notify on."""
-    variant: String!
-  ): SchemaPublishSubscription!
-
-  """
-  Creates a proposal variant from a source variant and a name, description. Do not call this from any clients, this resolver is exclusively for inter-service proposal -> kotlin registry communication.
-  """
-  createProposalVariant(
-    """
-    Name of the base variant, used to port over all subgraphs or monograph sdl to the new proposal as a base revision.
-    """
-    sourceVariantName: ID!
-
-    """
-    Actor of the og user calling this. We call this from the proposals subgraph, we need to pass through the actor.
-    """
-    triggeredBy: ActorInput
-  ): ProposalVariantCreationResult!
-  createSchemaPublishSubscription(
-    """ID of Slack channel for registry notification."""
-    channelID: ID!
-
-    """Variant to notify on."""
-    variant: String!
-  ): SchemaPublishSubscription!
-
-  """Update the default build pipeline track for this graph."""
-  defaultBuildPipelineTrack(buildPipelineTrack: BuildPipelineTrack!): BuildPipelineTrack
 
   """
   Soft delete a graph. Data associated with the graph is not permanently deleted; Apollo support can undo.
   """
   delete: Void
 
-  """
-  Delete the service's avatar. Requires Service.roles.canUpdateAvatar to be true.
-  """
-  deleteAvatar: AvatarDeleteError
-
-  """Delete an existing channel"""
-  deleteChannel(id: ID!): Boolean!
-
-  """Delete an existing query trigger"""
-  deleteQueryTrigger(id: ID!): Boolean!
-
-  """
-  Deletes this service's current subscriptions specific to the ID, returns true if it existed
-  """
-  deleteRegistrySubscription(id: ID!): Boolean!
-
-  """
-  Deletes this service's current registry subscription(s) specific to its graph variant,
-  returns a list of subscription IDs that were deleted.
-  """
-  deleteRegistrySubscriptions(variant: String!): [ID!]!
-  deleteScheduledSummary(id: ID!): Boolean!
-
-  """
-  Given a UTC timestamp, delete all traces associated with this Service, on that corresponding day. If a timestamp to is provided, deletes all days inclusive.
-  """
-  deleteTraces(from: Timestamp!, to: Timestamp): Void
-  disableDatadogForwardingLegacyMetricNames: Service
-
-  """
-  Hard delete a graph and all data associated with it. Its ID cannot be reused.
-  """
-  hardDelete: Void
-  id: ID! @deprecated(reason: "Use service.id")
-  reportServerInfo(
-    """
-    Only sent if previously requested i.e. received ReportServerInfoResult with withExecutableSchema = true. An executable schema is a schema document that describes the full GraphQL schema that an external client could execute queries against. This must be a valid GraphQL schema document, as per the GraphQL specification: https://spec.graphql.org/
-    """
-    executableSchema: String
-
-    """
-    Information about the edge server, see descriptions for individual fields.
-    """
-    info: EdgeServerInfo!
-  ): ReportServerInfoResult @deprecated(reason: "use Mutation.reportSchema instead")
-
-  """Test Slack notification channel"""
-  testSlackChannel(id: ID!, notification: SlackNotificationInput!): Void
-  testSubscriptionForChannel(channelID: ID!, subscriptionID: ID!): String!
-  transfer(to: String!): Service
-
   """Undelete a soft deleted graph."""
-  undelete: Service
-  updateDatadogMetricsConfig(apiKey: String, apiRegion: DatadogApiRegion, enabled: Boolean): DatadogMetricsConfig
-  updateDescription(description: String!): Service
+  undelete: Graph
 
   """Update hiddenFromUninvitedNonAdminAccountMembers"""
-  updateHiddenFromUninvitedNonAdminAccountMembers(hiddenFromUninvitedNonAdminAccountMembers: Boolean!): Service
-  updateReadme(readme: String!): Service
-  updateTitle(title: String!): Service
-  upsertChannel(id: ID, pagerDutyChannel: PagerDutyChannelInput, slackChannel: SlackChannelInput, webhookChannel: WebhookChannelInput): Channel
+  updateHiddenFromUninvitedNonAdminAccountMembers(hiddenFromUninvitedNonAdminAccountMembers: Boolean!): Graph
 
   """
   Creates a contract schema from a source variant and a set of filter configurations
@@ -16641,39 +5140,6 @@ type ServiceMutation {
     sourceVariant: String
   ): ContractVariantUpsertResult!
 
-  """Create/update PagerDuty notification channel"""
-  upsertPagerDutyChannel(channel: PagerDutyChannelInput!, id: ID): PagerDutyChannel
-  upsertQueryTrigger(id: ID, trigger: QueryTriggerInput!): QueryTrigger
-
-  """Create or update a subscription for a service."""
-  upsertRegistrySubscription(
-    """ID of Slack channel for registry notification."""
-    channelID: ID
-
-    """ID of registry subscription"""
-    id: ID
-
-    """Set of options/customization for notification."""
-    options: SubscriptionOptionsInput
-
-    """Variant to notify on."""
-    variant: String
-  ): RegistrySubscription!
-  upsertScheduledSummary(
-    channelID: ID
-    enabled: Boolean
-    id: ID
-
-    """Deprecated, use the 'variant' argument instead"""
-    tag: String
-    timezone: String
-    variant: String
-  ): ScheduledSummary
-
-  """Create/update Slack notification channel"""
-  upsertSlackChannel(channel: SlackChannelInput!, id: ID): SlackChannel
-  upsertWebhookChannel(id: ID, name: String, secretToken: String, url: String!): WebhookChannel
-
   """Make changes to a graph variant."""
   variant(name: String!): GraphVariantMutation
 
@@ -16688,12 +5154,6 @@ type ServiceMutation {
     sdl: String!
   ): LintResult!
 
-  """Update rule violations to ignore for this graph."""
-  updateIgnoredRuleViolations(changes: LinterIgnoredRuleChangesInput!): [IgnoredRule!]!
-
-  """Update the linter configuration for this graph."""
-  updateLinterConfiguration(changes: GraphLinterConfigurationChangesInput!): GraphLinterConfiguration!
-
   """Create a new Persisted Query List."""
   createPersistedQueryList(description: String, name: String!): CreatePersistedQueryListResultOrError!
 
@@ -16703,84 +5163,14 @@ type ServiceMutation {
   persistedQueryList(id: ID!): PersistedQueryListMutation!
 
   """
-  Creates a proposal variant from a source variant and a name, description. See the documentation for proposal creation at https://www.apollographql.com/docs/graphos/delivery/schema-proposals/creation
+  Creates a proposal variant from a source variant and a name, description. See the documentation for proposal creation at https://www.apollographql.com/docs/graphos/delivery/schema-proposals/creation This field accepts up to 500 requests per minute. This rate may be temporarily adjusted based on system conditions.
   """
   createProposal(input: CreateProposalInput!): CreateProposalResult!
 
   """
-  Subscribes a webhook channel to Proposal lifecycle events on this graph.
-  """
-  createProposalLifecycleSubscription(input: CreateProposalLifecycleSubscriptionInput!): CreateProposalLifecycleSubscriptionResult!
-
-  """Deletes this service's current subscriptions specific by ID."""
-  deleteProposalLifecycleSubscription(input: DeleteProposalLifecycleSubscriptionInput!): DeleteProposalLifecycleSubscriptionResult!
-
-  """
-  Mutation to set whether a proposals check task's results should be overridden or not
-  """
-  overrideProposalsCheckTask(shouldOverride: Boolean!, taskId: ID!): Boolean
-  proposalsMustBeApprovedByADefaultReviewer(mustBeApproved: Boolean!): ProposalsMustBeApprovedByADefaultReviewerResult
-
-  """
-  Test a subscription by queueing a test notification for the one subscribed event.
-  """
-  queueTestProposalLifecycleNotification(input: QueueTestProposalLifecycleNotificationInput!): QueueTestProposalLifecycleNotificationResult!
-  setMinProposalApprovers(input: SetMinProposalApproversInput!): SetMinApproversResult!
-
-  """The minimum role for create & edit is graph admin"""
-  setMinProposalRoles(input: SetProposalRolesInput!): SetProposalRolesResult!
-  setProposalDefaultReviewers(input: SetProposalDefaultReviewersInput!): SetProposalDefaultReviewersResult!
-
-  """
-  Updates the template for schema proposal descriptions. Deletes the template if the input string is null or empty
-  """
-  setProposalDescriptionTemplate(input: SetProposalDescriptionTemplateInput!): SetProposalDescriptionTemplateResult
-
-  """
-  Set the variant for this graph that all proposals depend on for 'IMPLEMENTED' status. TODO maya switch this to canManageProposalSettings. If variantName is passed as null, implementation variant is deleted.
-  """
-  setProposalImplementationVariant(variantName: String): SetProposalImplementationVariantResult!
-
-  """
-  Sets the current active user's Proposals notification status on this graph.
-  """
-  setProposalNotificationStatus(input: SetProposalNotificationStatusInput!): SetProposalNotificationStatusResult!
-  setProposalsMustBeReApprovedOnChange(approvalRequiredOnChange: Boolean!): SetProposalsMustBeReApprovedOnChangeResult
-
-  """
-  Updates the specified proposal lifecycle subscription's subscribed events.
-  """
-  updateProposalLifecycleSubscription(input: UpdateProposalLifecycleSubscriptionInput!): UpdateProposalLifecycleSubscriptionResult!
-  validateOperations(operations: [OperationDocumentInput!]!, tag: String = "current", gitContext: GitContextInput): ValidateOperationsResult!
-  registerOperationsWithResponse(
-    clientIdentity: RegisteredClientIdentityInput
-    gitContext: GitContextInput
-    operations: [RegisteredOperationInput!]!
-    manifestVersion: Int
-
-    """
-    Specifies which variant of a graph these operations belong to.
-    Formerly known as "tag"
-    Defaults to "current"
-    """
-    graphVariant: String! = "current"
-  ): RegisterOperationsMutationResponse
-
-  """
   Publish a schema to this variant, either via a document or an introspection query result.
   """
-  uploadSchema(schema: IntrospectionSchemaInput, schemaDocument: String, tag: String!, historicParameters: HistoricQueryParameters, overrideComposedSchema: Boolean! = false, errorOnBadRequest: Boolean! = true, gitContext: GitContextInput): UploadSchemaMutationResponse
-
-  """
-  Store a given schema document. This schema will be attached to the graph but
-  not be associated with any variant. On success, returns the schema hash.
-  """
-  storeSchemaDocument(schemaDocument: String!): StoreSchemaResponseOrError!
-
-  """
-  Promote the schema with the given SHA-256 hash to active for the given variant/tag.
-  """
-  promoteSchema(sha256: SHA256!, graphVariant: String!, historicParameters: HistoricQueryParameters, overrideComposedSchema: Boolean! = false): PromoteSchemaResponseOrError!
+  uploadSchema(schema: IntrospectionSchemaInput, schemaDocument: String, tag: String!, historicParameters: HistoricQueryParameters, overrideComposedSchema: Boolean! = false, errorOnBadRequest: Boolean! = true, gitContext: GitContextInput): SchemaPublicationResult
 
   """
   Checks a proposed schema against the schema that has been published to
@@ -16814,36 +5204,16 @@ type ServiceMutation {
     frontend: String
   ): CheckSchemaResult!
 
-  """Delete a variant by name."""
-  deleteSchemaTag(tag: String!): DeleteSchemaTagResult!
-  setDefaultBuildPipelineTrack(version: String!): String
-
   """
   Publish to a subgraph. If composition is successful, this will update running routers.
   """
-  upsertImplementingServiceAndTriggerComposition(graphVariant: String!, name: String!, url: String, revision: String!, activePartialSchema: PartialSchemaInput!, gitContext: GitContextInput): CompositionAndUpsertResult
-
-  """
-  Publish to a subgraph. If composition is successful, this will update running routers.
-  """
-  publishSubgraph(graphVariant: String!, name: String!, url: String, revision: String!, activePartialSchema: PartialSchemaInput!, gitContext: GitContextInput, downstreamLaunchInitiation: DownstreamLaunchInitiation = ASYNC): CompositionAndUpsertResult
+  publishSubgraph(graphVariant: String!, name: String!, url: String, revision: String!, activePartialSchema: PartialSchemaInput!, gitContext: GitContextInput, downstreamLaunchInitiation: DownstreamLaunchInitiation = ASYNC): SubgraphPublicationResult
 
   """
   Publishes multiple subgraphs. If composition is successful, this will update running routers.
+  This field accepts up to 120 requests per minute. This rate may be temporarily adjusted based on system conditions.
   """
-  publishSubgraphs(graphVariant: String!, revision: String!, subgraphInputs: [PublishSubgraphsSubgraphInput!]!, gitContext: GitContextInput, downstreamLaunchInitiation: DownstreamLaunchInitiation = ASYNC): CompositionAndUpsertResult
-
-  """Publishes multiple subgraphs, running the build async."""
-  publishSubgraphsAsyncBuild(graphVariant: String!, revision: String!, subgraphInputs: [PublishSubgraphsSubgraphInput!]!, gitContext: GitContextInput): PublishSubgraphsAsyncBuildResult
-
-  """
-  This mutation will not result in any changes to the implementing service
-  Run composition with the Implementing Service's partial schema replaced with the one provided
-  in the mutation's input. Store the composed schema, return the hash of the composed schema,
-  and any warnings and errors pertaining to composition.
-  This mutation will not run validation against operations.
-  """
-  validatePartialSchemaOfImplementingServiceAgainstGraph(graphVariant: String!, implementingServiceName: String!, partialSchema: PartialSchemaInput!): CompositionValidationResult! @deprecated(reason: "Use GraphVariant.submitSubgraphCheckAsync instead")
+  publishSubgraphs(graphVariant: String!, revision: String!, subgraphInputs: [PublishSubgraphsSubgraphInput!]!, gitContext: GitContextInput, downstreamLaunchInitiation: DownstreamLaunchInitiation = ASYNC): SubgraphPublicationResult
 
   """
   Removes a subgraph. If composition is successful, this will update running routers.
@@ -16856,7 +5226,7 @@ type ServiceMutation {
     Do not remove the service, but recompose without it and report any errors.
     """
     dryRun: Boolean! = false
-  ): CompositionAndRemoveResult!
+  ): SubgraphRemovalResult!
 
   """
   Checks a proposed subgraph schema change against a published subgraph.
@@ -16891,9 +5261,6 @@ type ServiceMutation {
     If this check is triggered for an sdl fetched using introspection, this is the endpoint where that schema was being served.
     """
     introspectionEndpoint: String
-
-    """The user that triggered this check."""
-    triggeredBy: ActorInput
   ): CheckPartialSchemaResult! @deprecated(reason: "Use GraphVariant.submitSubgraphCheckAsync instead.\nThis mutation polls to wait for the check to finish,\nwhile subgraphSubgraphCheckAsync triggers returns\nwithout waiting for the check to finish.")
 
   """Update schema check configuration for a graph."""
@@ -16941,367 +5308,12 @@ type ServiceMutation {
     downgradeDefaultValueChange: Boolean
     enableCustomChecks: Boolean
   ): CheckConfiguration!
-
-  """
-  Mark the changeset that affects an operation in a given check instance as safe.
-  Note that only operations marked as behavior changes are allowed to be marked as safe.
-  """
-  markChangesForOperationAsSafe(
-    """ID of the schema check."""
-    checkID: ID!
-
-    """ID of the operation to accept changes for."""
-    operationID: ID!
-  ): MarkChangesForOperationAsSafeResult!
-
-  """Unmark changes for an operation as safe."""
-  unmarkChangesForOperationAsSafe(
-    """ID of the schema check."""
-    checkID: ID!
-
-    """ID of the operation to unmark changes for."""
-    operationID: ID!
-  ): MarkChangesForOperationAsSafeResult!
-
-  """
-  Ignore an operation in future checks;
-  changes affecting it will be tracked,
-  but won't affect the outcome of the check.
-  Returns true if the operation is newly ignored,
-  false if it already was.
-  """
-  ignoreOperationsInChecks(ids: [ID!]!): IgnoreOperationsInChecksResult
-
-  """
-  Revert the effects of ignoreOperation.
-  Returns true if the operation is no longer ignored,
-  false if it wasn't.
-  """
-  unignoreOperationsInChecks(ids: [ID!]!): UnignoreOperationsInChecksResult
-
-  """Create a new assessment for this graph."""
-  createSafAssessment: SafAssessment!
-
-  """Mutations for a specific assessment."""
-  safAssessment(id: ID!, includeDeleted: Boolean! = false): SafAssessmentMutation
-}
-
-"""Columns of ServiceOperationCheckStats."""
-enum ServiceOperationCheckStatsColumn {
-  CACHED_REQUESTS_COUNT
-  CLIENT_NAME
-  CLIENT_VERSION
-  OPERATION_SUBTYPE
-  OPERATION_TYPE
-  QUERY_ID
-  QUERY_NAME
-  SCHEMA_TAG
-  TIMESTAMP
-  UNCACHED_REQUESTS_COUNT
-}
-
-type ServiceOperationCheckStatsDimensions {
-  clientName: String
-  clientVersion: String
-  operationSubtype: String
-  operationType: String
-  queryId: ID
-  queryName: String
-  schemaTag: String
-}
-
-"""
-Filter for data in ServiceOperationCheckStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input ServiceOperationCheckStatsFilter {
-  and: [ServiceOperationCheckStatsFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-  in: ServiceOperationCheckStatsFilterIn
-  not: ServiceOperationCheckStatsFilter
-
-  """
-  Selects rows whose operationSubtype dimension equals the given value if not null. To query for the null value, use {in: {operationSubtype: [null]}} instead.
-  """
-  operationSubtype: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [ServiceOperationCheckStatsFilter!]
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: ID
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-}
-
-"""
-Filter for data in ServiceOperationCheckStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input ServiceOperationCheckStatsFilterIn {
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose operationSubtype dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationSubtype: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [ID]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-}
-
-type ServiceOperationCheckStatsMetrics {
-  cachedRequestsCount: Long!
-  uncachedRequestsCount: Long!
-}
-
-input ServiceOperationCheckStatsOrderBySpec {
-  column: ServiceOperationCheckStatsColumn!
-  direction: Ordering!
-}
-
-type ServiceOperationCheckStatsRecord {
-  """Dimensions of ServiceOperationCheckStats that can be grouped by."""
-  groupBy: ServiceOperationCheckStatsDimensions!
-
-  """Metrics of ServiceOperationCheckStats that can be aggregated over."""
-  metrics: ServiceOperationCheckStatsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of ServiceQueryStats."""
-enum ServiceQueryStatsColumn {
-  CACHED_HISTOGRAM
-  CACHED_REQUESTS_COUNT
-  CACHE_TTL_HISTOGRAM
-  CLIENT_NAME
-  CLIENT_VERSION
-  FORBIDDEN_OPERATION_COUNT
-  FROM_ENGINEPROXY
-  OPERATION_SUBTYPE
-  OPERATION_TYPE
-  PERSISTED_QUERY_ID
-  QUERY_ID
-  QUERY_NAME
-  REGISTERED_OPERATION_COUNT
-  REQUESTS_WITH_ERRORS_COUNT
-  SCHEMA_HASH
-  SCHEMA_TAG
-  TIMESTAMP
-  UNCACHED_HISTOGRAM
-  UNCACHED_REQUESTS_COUNT
-}
-
-type ServiceQueryStatsDimensions {
-  clientName: String
-  clientVersion: String
-  fromEngineproxy: String
-  operationSubtype: String
-  operationType: String
-  persistedQueryId: String
-  queryId: ID
-  queryName: String
-  querySignature: String
-  querySignatureLength: Int
-  schemaHash: String
-  schemaTag: String
-}
-
-"""
-Filter for data in ServiceQueryStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input ServiceQueryStatsFilter {
-  and: [ServiceQueryStatsFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-
-  """
-  Selects rows whose fromEngineproxy dimension equals the given value if not null. To query for the null value, use {in: {fromEngineproxy: [null]}} instead.
-  """
-  fromEngineproxy: String
-  in: ServiceQueryStatsFilterIn
-  not: ServiceQueryStatsFilter
-
-  """
-  Selects rows whose operationSubtype dimension equals the given value if not null. To query for the null value, use {in: {operationSubtype: [null]}} instead.
-  """
-  operationSubtype: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [ServiceQueryStatsFilter!]
-
-  """
-  Selects rows whose persistedQueryId dimension equals the given value if not null. To query for the null value, use {in: {persistedQueryId: [null]}} instead.
-  """
-  persistedQueryId: String
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: ID
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead.
-  """
-  schemaHash: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-}
-
-"""
-Filter for data in ServiceQueryStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input ServiceQueryStatsFilterIn {
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose fromEngineproxy dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  fromEngineproxy: [String]
-
-  """
-  Selects rows whose operationSubtype dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationSubtype: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose persistedQueryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  persistedQueryId: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [ID]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaHash: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-}
-
-type ServiceQueryStatsMetrics {
-  cacheTtlHistogram: DurationHistogram!
-  cachedHistogram: DurationHistogram!
-  cachedRequestsCount: Long!
-  forbiddenOperationCount: Long!
-  registeredOperationCount: Long!
-  requestsWithErrorsCount: Long!
-  totalLatencyHistogram: DurationHistogram!
-  totalRequestCount: Long!
-  uncachedHistogram: DurationHistogram!
-  uncachedRequestsCount: Long!
-}
-
-input ServiceQueryStatsOrderBySpec {
-  column: ServiceQueryStatsColumn!
-  direction: Ordering!
-}
-
-type ServiceQueryStatsRecord {
-  """Dimensions of ServiceQueryStats that can be grouped by."""
-  groupBy: ServiceQueryStatsDimensions!
-
-  """Metrics of ServiceQueryStats that can be aggregated over."""
-  metrics: ServiceQueryStatsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
 }
 
 """
 Individual permissions for the current user when interacting with a particular Studio graph.
 """
-type ServiceRoles {
+type GraphRoles {
   """
   Whether the currently authenticated user is permitted to perform schema checks (i.e., run `rover (sub)graph check`).
   """
@@ -17316,9 +5328,7 @@ type ServiceRoles {
   Whether the currently authenticated user is permitted to make updates to the check configuration for this graph.
   """
   canWriteCheckConfiguration: Boolean!
-  service: Service!
-  canQueryRoleOverrides: Boolean!
-  canQueryTokens: Boolean!
+  service: Graph!
 
   """
   Whether the currently authenticated user is permitted to create new graph variants.
@@ -17374,36 +5384,22 @@ type ServiceRoles {
   Whether the currently authenticated user is permitted to view details about the build configuration (e.g. build pipeline version).
   """
   canQueryBuildConfig: Boolean!
-  canQueryDeletedImplementingServices: Boolean!
 
   """
   Whether the currently authenticated user is permitted to view which subgraphs the graph is composed of.
   """
   canQueryImplementingServices: Boolean!
-  canQueryIntegrations: Boolean!
-  canQueryPrivateInfo: Boolean!
   canQueryProposals: Boolean!
-  canQueryPublicInfo: Boolean!
-  canQueryReadmeAuthor: Boolean!
 
   """
   Whether the currently authenticated user is permitted to download schemas owned by this graph.
   """
   canQuerySchemas: Boolean!
-  canQueryStats: Boolean!
-  canQueryTraces: Boolean!
 
   """
   Whether the currently authenticated user is permitted to register operations (i.e. `apollo client:push`) for this graph.
   """
   canRegisterOperations: Boolean!
-  canStoreSchemasWithoutVariant: Boolean!
-  canUndelete: Boolean!
-  canUpdateAvatar: Boolean!
-  canUpdateDescription: Boolean!
-  canUpdateTitle: Boolean!
-  canManagePersistedQueryLists: Boolean!
-  canQueryPersistedQueryLists: Boolean!
   canCreateProposal: Boolean!
 
   """
@@ -17412,719 +5408,13 @@ type ServiceRoles {
   canEditProposal: Boolean!
 }
 
-"""A time window with a specified granularity over a given service."""
-type ServiceStatsWindow {
-  billingUsageStats(
-    """Filter to select what rows to return."""
-    filter: ServiceBillingUsageStatsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order ServiceBillingUsageStats by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [ServiceBillingUsageStatsOrderBySpec!]
-  ): [ServiceBillingUsageStatsRecord!]!
-  cardinalityStats(
-    """Filter to select what rows to return."""
-    filter: ServiceCardinalityStatsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order ServiceCardinalityStats by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [ServiceCardinalityStatsOrderBySpec!]
-  ): [ServiceCardinalityStatsRecord!]!
-  coordinateUsage(
-    """Filter to select what rows to return."""
-    filter: ServiceCoordinateUsageFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order ServiceCoordinateUsage by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [ServiceCoordinateUsageOrderBySpec!]
-  ): [ServiceCoordinateUsageRecord!]!
-  edgeServerInfos(
-    """Filter to select what rows to return."""
-    filter: ServiceEdgeServerInfosFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order ServiceEdgeServerInfos by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [ServiceEdgeServerInfosOrderBySpec!]
-  ): [ServiceEdgeServerInfosRecord!]!
-  errorStats(
-    """Filter to select what rows to return."""
-    filter: ServiceErrorStatsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order ServiceErrorStats by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [ServiceErrorStatsOrderBySpec!]
-  ): [ServiceErrorStatsRecord!]!
-  federatedErrorStats(
-    """Filter to select what rows to return."""
-    filter: ServiceFederatedErrorStatsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order ServiceFederatedErrorStats by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [ServiceFederatedErrorStatsOrderBySpec!]
-  ): [ServiceFederatedErrorStatsRecord!]!
-  fieldExecutions(
-    """Filter to select what rows to return."""
-    filter: ServiceFieldExecutionsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order ServiceFieldExecutions by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [ServiceFieldExecutionsOrderBySpec!]
-  ): [ServiceFieldExecutionsRecord!]!
-  fieldLatencies(
-    """Filter to select what rows to return."""
-    filter: ServiceFieldLatenciesFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order ServiceFieldLatencies by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [ServiceFieldLatenciesOrderBySpec!]
-  ): [ServiceFieldLatenciesRecord!]!
-  fieldStats(
-    """Filter to select what rows to return."""
-    filter: ServiceFieldLatenciesFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order ServiceFieldLatencies by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [ServiceFieldLatenciesOrderBySpec!]
-  ): [ServiceFieldLatenciesRecord!]!
-  fieldUsage(
-    """Filter to select what rows to return."""
-    filter: ServiceFieldUsageFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order ServiceFieldUsage by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [ServiceFieldUsageOrderBySpec!]
-  ): [ServiceFieldUsageRecord!]!
-  graphosCloudMetrics(
-    """Filter to select what rows to return."""
-    filter: ServiceGraphosCloudMetricsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order ServiceGraphosCloudMetrics by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [ServiceGraphosCloudMetricsOrderBySpec!]
-  ): [ServiceGraphosCloudMetricsRecord!]!
-  operationCheckStats(
-    """Filter to select what rows to return."""
-    filter: ServiceOperationCheckStatsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order ServiceOperationCheckStats by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [ServiceOperationCheckStatsOrderBySpec!]
-  ): [ServiceOperationCheckStatsRecord!]!
-  queryStats(
-    """Filter to select what rows to return."""
-    filter: ServiceQueryStatsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order ServiceQueryStats by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [ServiceQueryStatsOrderBySpec!]
-  ): [ServiceQueryStatsRecord!]!
-
-  """From field rounded down to the nearest resolution."""
-  roundedDownFrom: Timestamp!
-
-  """To field rounded up to the nearest resolution."""
-  roundedUpTo: Timestamp!
-  tracePathErrorsRefs(
-    """Filter to select what rows to return."""
-    filter: ServiceTracePathErrorsRefsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order ServiceTracePathErrorsRefs by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [ServiceTracePathErrorsRefsOrderBySpec!]
-  ): [ServiceTracePathErrorsRefsRecord!]!
-  traceRefs(
-    """Filter to select what rows to return."""
-    filter: ServiceTraceRefsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order ServiceTraceRefs by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [ServiceTraceRefsOrderBySpec!]
-  ): [ServiceTraceRefsRecord!]!
-}
-
-"""Columns of ServiceTracePathErrorsRefs."""
-enum ServiceTracePathErrorsRefsColumn {
-  CLIENT_NAME
-  CLIENT_VERSION
-  DURATION_BUCKET
-  ERRORS_COUNT_IN_PATH
-  ERRORS_COUNT_IN_TRACE
-  ERROR_CODE
-  ERROR_MESSAGE
-  ERROR_SERVICE
-  PATH
-  QUERY_ID
-  QUERY_NAME
-  SCHEMA_HASH
-  SCHEMA_TAG
-  TIMESTAMP
-  TRACE_HTTP_STATUS_CODE
-  TRACE_ID
-  TRACE_SIZE_BYTES
-  TRACE_STARTS_AT
-}
-
-type ServiceTracePathErrorsRefsDimensions {
-  clientName: String
-  clientVersion: String
-  durationBucket: Int
-  errorCode: String
-  errorMessage: String
-  errorService: String
-  path: String
-  queryId: ID
-  queryName: String
-  schemaHash: String
-  schemaTag: String
-  traceHttpStatusCode: Int
-  traceId: ID
-  traceStartsAt: Timestamp
-}
-
-"""
-Filter for data in ServiceTracePathErrorsRefs. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input ServiceTracePathErrorsRefsFilter {
-  and: [ServiceTracePathErrorsRefsFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-
-  """
-  Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead.
-  """
-  durationBucket: Int
-
-  """
-  Selects rows whose errorCode dimension equals the given value if not null. To query for the null value, use {in: {errorCode: [null]}} instead.
-  """
-  errorCode: String
-
-  """
-  Selects rows whose errorMessage dimension equals the given value if not null. To query for the null value, use {in: {errorMessage: [null]}} instead.
-  """
-  errorMessage: String
-
-  """
-  Selects rows whose errorService dimension equals the given value if not null. To query for the null value, use {in: {errorService: [null]}} instead.
-  """
-  errorService: String
-  in: ServiceTracePathErrorsRefsFilterIn
-  not: ServiceTracePathErrorsRefsFilter
-  or: [ServiceTracePathErrorsRefsFilter!]
-
-  """
-  Selects rows whose path dimension equals the given value if not null. To query for the null value, use {in: {path: [null]}} instead.
-  """
-  path: String
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: ID
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead.
-  """
-  schemaHash: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose traceHttpStatusCode dimension equals the given value if not null. To query for the null value, use {in: {traceHttpStatusCode: [null]}} instead.
-  """
-  traceHttpStatusCode: Int
-
-  """
-  Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead.
-  """
-  traceId: ID
-}
-
-"""
-Filter for data in ServiceTracePathErrorsRefs. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input ServiceTracePathErrorsRefsFilterIn {
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  durationBucket: [Int]
-
-  """
-  Selects rows whose errorCode dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  errorCode: [String]
-
-  """
-  Selects rows whose errorMessage dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  errorMessage: [String]
-
-  """
-  Selects rows whose errorService dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  errorService: [String]
-
-  """
-  Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  path: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [ID]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaHash: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose traceHttpStatusCode dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  traceHttpStatusCode: [Int]
-
-  """
-  Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  traceId: [ID]
-}
-
-type ServiceTracePathErrorsRefsMetrics {
-  errorsCountInPath: Long!
-  errorsCountInTrace: Long!
-  traceSizeBytes: Long!
-}
-
-input ServiceTracePathErrorsRefsOrderBySpec {
-  column: ServiceTracePathErrorsRefsColumn!
-  direction: Ordering!
-}
-
-type ServiceTracePathErrorsRefsRecord {
-  """Dimensions of ServiceTracePathErrorsRefs that can be grouped by."""
-  groupBy: ServiceTracePathErrorsRefsDimensions!
-
-  """Metrics of ServiceTracePathErrorsRefs that can be aggregated over."""
-  metrics: ServiceTracePathErrorsRefsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of ServiceTraceRefs."""
-enum ServiceTraceRefsColumn {
-  CLIENT_NAME
-  CLIENT_VERSION
-  DURATION_BUCKET
-  OPERATION_SUBTYPE
-  OPERATION_TYPE
-  QUERY_ID
-  QUERY_NAME
-  SCHEMA_HASH
-  SCHEMA_TAG
-  TIMESTAMP
-  TRACE_COUNT
-  TRACE_ID
-}
-
-type ServiceTraceRefsDimensions {
-  clientName: String
-  clientVersion: String
-  durationBucket: Int
-  generatedTraceId: String
-  operationSubtype: String
-  operationType: String
-  queryId: ID
-  queryName: String
-  querySignature: String
-  schemaHash: String
-  schemaTag: String
-  traceId: ID
-}
-
-"""
-Filter for data in ServiceTraceRefs. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input ServiceTraceRefsFilter {
-  and: [ServiceTraceRefsFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-
-  """
-  Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead.
-  """
-  durationBucket: Int
-  in: ServiceTraceRefsFilterIn
-  not: ServiceTraceRefsFilter
-
-  """
-  Selects rows whose operationSubtype dimension equals the given value if not null. To query for the null value, use {in: {operationSubtype: [null]}} instead.
-  """
-  operationSubtype: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [ServiceTraceRefsFilter!]
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: ID
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead.
-  """
-  schemaHash: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead.
-  """
-  traceId: ID
-}
-
-"""
-Filter for data in ServiceTraceRefs. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input ServiceTraceRefsFilterIn {
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  durationBucket: [Int]
-
-  """
-  Selects rows whose operationSubtype dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationSubtype: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [ID]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaHash: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  traceId: [ID]
-}
-
-type ServiceTraceRefsMetrics {
-  traceCount: Long!
-}
-
-input ServiceTraceRefsOrderBySpec {
-  column: ServiceTraceRefsColumn!
-  direction: Ordering!
-}
-
-type ServiceTraceRefsRecord {
-  """Dimensions of ServiceTraceRefs that can be grouped by."""
-  groupBy: ServiceTraceRefsDimensions!
-
-  """Metrics of ServiceTraceRefs that can be aggregated over."""
-  metrics: ServiceTraceRefsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
 input SetCustomCheckConfigurationInput {
   secretToken: String
   url: String!
 }
 
-"""Input to update a proposal description"""
-input SetMergeBaseCompositionIdInput {
-  """The composition id of the source variant this proposal is based on."""
-  mergeBaseCompositionId: ID!
-}
-
-union SetMergeBaseCompositionIdResult = PermissionError | Proposal | ValidationError
-
-union SetMinApproversResult = PermissionError | Service | ValidationError
-
-input SetMinProposalApproversInput {
-  minApprovers: Int
-}
-
-"""Represents the possible outcomes of a setNextVersion mutation"""
-union SetNextVersionResult = RouterVersion | InvalidInputErrors | InternalServerError
-
-input SetProposalDefaultReviewersInput {
-  reviewerUserIds: [ID!]!
-}
-
-union SetProposalDefaultReviewersResult = PermissionError | Service | ValidationError
-
-input SetProposalDescriptionTemplateInput {
-  descriptionTemplate: String
-}
-
-union SetProposalDescriptionTemplateResult = PermissionError | Service | ValidationError
-
-union SetProposalImplementationVariantResult = PermissionError | Service | ValidationError
-
-input SetProposalNotificationStatusInput {
-  """NotificationStatus to set for the current active user. """
-  status: NotificationStatus!
-}
-
-union SetProposalNotificationStatusResult = PermissionError | Service | ValidationError
-
-input SetProposalRolesInput {
-  create: UserPermission
-  edit: UserPermission
-}
-
-union SetProposalRolesResult = PermissionError | Service | ValidationError
-
-union SetProposalsMustBeReApprovedOnChangeResult = PermissionError | Service | ValidationError
-
-union SetupIntentResult = NotFoundError | PermissionError | SetupIntentSuccess
-
-type SetupIntentSuccess {
-  clientSecret: String!
-}
-
 """A SHA-256 hash, represented as a lowercase hexadecimal string."""
 scalar SHA256
-
-"""
-Shard for Cloud Routers
-
-This represents a specific shard where a Cloud Router can run
-"""
-type Shard {
-  id: ID!
-  region: RegionDescription!
-  tier: CloudTier!
-  provider: CloudProvider!
-  routerUsage: Int!
-  routerCapacity: Int
-  gcuUsage: Int!
-  gcuCapacity: Int
-  status: ShardStatus!
-  reason: String
-  routers(first: Int, offset: Int): [Router!]!
-
-  """Details of this shard for a specific provider"""
-  providerDetails: ShardProvider!
-}
-
-"""Provider-specific information for a Shard"""
-union ShardProvider = AwsShard | FlyShard
-
-"""Represents the possible outcomes of a shard mutation"""
-union ShardResult = ShardSuccess | InvalidInputErrors | InternalServerError
-
-"""Current status of Cloud Shards"""
-enum ShardStatus {
-  """The Shard is active and ready to accept new Cloud Routers"""
-  ACTIVE
-
-  """
-  The Shard is suffering from a temporary degradation that might impact provisioning new
-  Cloud Routers
-  """
-  IMPAIRED
-
-  """
-  The Shard is working as expected, but should not be used to provision new Cloud Routers
-  """
-  DEPRECATED
-
-  """
-  The Shard is currently being updated and should temporarily not be used to provision new
-  Cloud Routers
-  """
-  UPDATING
-
-  """The Shard no long exists"""
-  DELETED
-}
-
-"""Success branch of an shard mutation"""
-type ShardSuccess {
-  shard: Shard!
-}
-
-"""Slack notification channel"""
-type SlackChannel implements Channel {
-  id: ID!
-  name: String!
-  subscriptions: [ChannelSubscription!]!
-  url: String!
-}
-
-"""Slack notification channel parameters"""
-input SlackChannelInput {
-  name: String
-  url: String!
-}
-
-input SlackNotificationField {
-  key: String!
-  value: String!
-}
-
-"""Slack notification message"""
-input SlackNotificationInput {
-  color: String
-  fallback: String!
-  fields: [SlackNotificationField!]
-  iconUrl: String
-  text: String
-  timestamp: Timestamp
-  title: String
-  titleLink: String
-  username: String
-}
 
 """A location in a source code file."""
 type SourceLocation {
@@ -18133,258 +5423,6 @@ type SourceLocation {
 
   """Line number."""
   line: Int!
-}
-
-type SsoConfig {
-  """
-  Returns all SSO connections for the account, including those disabled or incomplete
-  """
-  allConnections: [SsoConnection!]!
-
-  """Returns the current enabled SSO connection for the account"""
-  currentConnection: SsoConnection
-  defaultRole: UserPermission!
-}
-
-interface SsoConnection {
-  domains: [String!]!
-  id: ID!
-  idpId: ID!
-  scim: SsoScimProvisioningDetails
-  state: SsoConnectionState! @deprecated(reason: "Use stateV2 instead")
-  stateV2: SsoConnectionStateV2!
-}
-
-enum SsoConnectionState {
-  DISABLED
-  ENABLED
-}
-
-enum SsoConnectionStateV2 {
-  """The connection has been archived and is no longer in use"""
-  ARCHIVED
-
-  """The connection has been disabled by an admin"""
-  DISABLED
-
-  """
-  The connection has been finalized. a connection can only go from VALIDATED->ENABLED
-  """
-  ENABLED
-
-  """The initial state for base connections - setup still in progress"""
-  INITIALIZED
-
-  """
-  The connection has been configured as either SAML/OIDC and can be used to login
-  """
-  STAGED
-
-  """
-  The connection has had at least one successful login - connections automatically transition from STAGED->VALIDATED on first login
-  """
-  VALIDATED
-}
-
-type SsoMutation {
-  deleteSsoConnection(id: ID!): SsoConnection
-  disableSsoConnection(id: ID!): SsoConnection
-  enableScimProvisioning(connectionId: ID!): SsoScimProvisioningDetails
-  enableSsoConnection(id: ID!): SsoConnection
-}
-
-type SsoQuery {
-  """Parses a SAML IDP metadata XML string and returns the parsed metadata"""
-  parseSamlIdpMetadata(metadata: String!): ParsedSamlIdpMetadata
-}
-
-type SsoScimProvisioningDetails {
-  scimEnabled: Boolean!
-  scimEndpoint: String
-}
-
-union StartUsageBasedPlanResult = Account | NotFoundError | PermissionError | StartUsageBasedPlanSuccess | ValidationError
-
-type StartUsageBasedPlanSuccess {
-  customerPlanId: String!
-}
-
-"""A time window with a specified granularity."""
-type StatsWindow {
-  billingUsageStats(
-    """Filter to select what rows to return."""
-    filter: BillingUsageStatsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order BillingUsageStats by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [BillingUsageStatsOrderBySpec!]
-  ): [BillingUsageStatsRecord!]!
-  cardinalityStats(
-    """Filter to select what rows to return."""
-    filter: CardinalityStatsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order CardinalityStats by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [CardinalityStatsOrderBySpec!]
-  ): [CardinalityStatsRecord!]!
-  coordinateUsage(
-    """Filter to select what rows to return."""
-    filter: CoordinateUsageFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order CoordinateUsage by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [CoordinateUsageOrderBySpec!]
-  ): [CoordinateUsageRecord!]!
-  edgeServerInfos(
-    """Filter to select what rows to return."""
-    filter: EdgeServerInfosFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order EdgeServerInfos by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [EdgeServerInfosOrderBySpec!]
-  ): [EdgeServerInfosRecord!]!
-  errorStats(
-    """Filter to select what rows to return."""
-    filter: ErrorStatsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order ErrorStats by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [ErrorStatsOrderBySpec!]
-  ): [ErrorStatsRecord!]!
-  federatedErrorStats(
-    """Filter to select what rows to return."""
-    filter: FederatedErrorStatsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order FederatedErrorStats by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [FederatedErrorStatsOrderBySpec!]
-  ): [FederatedErrorStatsRecord!]!
-  fieldExecutions(
-    """Filter to select what rows to return."""
-    filter: FieldExecutionsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order FieldExecutions by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [FieldExecutionsOrderBySpec!]
-  ): [FieldExecutionsRecord!]!
-  fieldLatencies(
-    """Filter to select what rows to return."""
-    filter: FieldLatenciesFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order FieldLatencies by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [FieldLatenciesOrderBySpec!]
-  ): [FieldLatenciesRecord!]!
-  fieldUsage(
-    """Filter to select what rows to return."""
-    filter: FieldUsageFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order FieldUsage by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [FieldUsageOrderBySpec!]
-  ): [FieldUsageRecord!]!
-  graphosCloudMetrics(
-    """Filter to select what rows to return."""
-    filter: GraphosCloudMetricsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order GraphosCloudMetrics by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [GraphosCloudMetricsOrderBySpec!]
-  ): [GraphosCloudMetricsRecord!]!
-  operationCheckStats(
-    """Filter to select what rows to return."""
-    filter: OperationCheckStatsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order OperationCheckStats by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [OperationCheckStatsOrderBySpec!]
-  ): [OperationCheckStatsRecord!]!
-  queryStats(
-    """Filter to select what rows to return."""
-    filter: QueryStatsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order QueryStats by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [QueryStatsOrderBySpec!]
-  ): [QueryStatsRecord!]!
-
-  """From field rounded down to the nearest resolution."""
-  roundedDownFrom: Timestamp!
-
-  """To field rounded up to the nearest resolution."""
-  roundedUpTo: Timestamp!
-  tracePathErrorsRefs(
-    """Filter to select what rows to return."""
-    filter: TracePathErrorsRefsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order TracePathErrorsRefs by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [TracePathErrorsRefsOrderBySpec!]
-  ): [TracePathErrorsRefsRecord!]!
-  traceRefs(
-    """Filter to select what rows to return."""
-    filter: TraceRefsFilter
-
-    """The maximum number of entries to return, cannot be more than 15000."""
-    limit: Int = 10000
-
-    """
-    A list of OrderBySpecs to order TraceRefs by. The earlier an OrderBySpec appears in the list, the higher priority it has in the final ordering. When empty or null, defaults to sorting by ascending timestamp.
-    """
-    orderBy: [TraceRefsOrderBySpec!]
-  ): [TraceRefsRecord!]!
 }
 
 """Possible status of a Cloud Router version"""
@@ -18407,61 +5445,6 @@ enum Status {
   supported at some point in the future.
   """
   DEPRECATED
-}
-
-type StoredApprovedChange {
-  code: ChangeCode!
-  parentNode: NamedIntrospectionTypeNoDescription
-  childNode: NamedIntrospectionValueNoDescription
-  argNode: NamedIntrospectionArgNoDescription
-}
-
-type StoreSchemaError {
-  code: StoreSchemaErrorCode!
-  message: String!
-}
-
-enum StoreSchemaErrorCode {
-  SCHEMA_IS_NOT_PARSABLE
-  SCHEMA_IS_NOT_VALID
-}
-
-type StoreSchemaResponse {
-  sha256: SHA256!
-}
-
-union StoreSchemaResponseOrError = StoreSchemaResponse | StoreSchemaError
-
-"""A paginated connection of strings."""
-type StringConnection {
-  """A list of edges containing a cursor and a string node for pagination."""
-  edges: [StringEdge!]!
-
-  """Information to aid in pagination."""
-  pageInfo: PageInfo!
-}
-
-"""An edge in a connection, containing a string node and its cursor."""
-type StringEdge {
-  """
-  A cursor for use in pagination, unique identifier for this edge's position.
-  """
-  cursor: String!
-
-  """The string value at this position in the connection."""
-  node: String!
-}
-
-scalar StringOrInt
-
-type StringToString {
-  key: String!
-  value: String!
-}
-
-input StringToStringInput {
-  key: String!
-  value: String!
 }
 
 """A subgraph in a federated Studio supergraph."""
@@ -18487,9 +5470,6 @@ type Subgraph {
   The subgraph's routing URL, provided to gateways that use managed federation.
   """
   routingURL: String!
-
-  """The subgraph schema document."""
-  sdl(graphId: ID!): String!
 
   """Timestamp of when the subgraph was published."""
   updatedAt: Timestamp
@@ -18539,43 +5519,8 @@ input SubgraphCheckAsyncInput {
   """The proposed subgraph schema to perform checks with."""
   proposedSchema: GraphQLDocument!
 
-  """
-  The source variant that this check should use the operations check configuration from
-  """
-  sourceVariant: String
-
   """The name of the subgraph to check schema changes for."""
   subgraphName: String!
-
-  """
-  The user that triggered this check. If null, defaults to authContext to determine user.
-  """
-  triggeredBy: ActorInput
-}
-
-"""A subgraph in a federated Studio supergraph."""
-input SubgraphCheckInput {
-  """
-  The subgraph schema document's SHA256 hash, represented as a hexadecimal string.
-  """
-  hash: String!
-
-  """The subgraph's registered name."""
-  name: String!
-}
-
-type SubgraphConfig {
-  schemaHash: String!
-  sdl: String!
-  name: String!
-  id: ID!
-  url: String!
-}
-
-input SubgraphHashInput {
-  """SHA256 of the subgraph schema sdl."""
-  hash: String!
-  name: String!
 }
 
 input SubgraphInput {
@@ -18592,332 +5537,19 @@ input SubgraphInput {
   schemaRef: String
 }
 
-type SubgraphKeyMap {
-  subgraphName: String!
-  keys: [String!]!
-}
-
 input SubgraphSdlCheckInput {
   name: String!
   sdl: GraphQLDocument!
-}
-
-type SubgraphWithConflicts {
-  conflicts: [MergeConflict!]!
-  partialMergeSdl: String!
-  subgraphName: String!
-}
-
-type SubscriptionCapability {
-  label: String!
-  subscription: BillingSubscription!
-  value: Boolean!
-}
-
-type SubscriptionLimit {
-  label: String!
-  subscription: BillingSubscription!
-  value: Long
-}
-
-type SubscriptionOptions {
-  """Enables notifications for schema updates"""
-  schemaUpdates: Boolean!
-}
-
-input SubscriptionOptionsInput {
-  """Enables notifications for schema updates"""
-  schemaUpdates: Boolean!
-}
-
-enum SubscriptionState {
-  ACTIVE
-  CANCELED
-  EXPIRED
-  FUTURE
-  PAST_DUE
-  PAUSED
-  PENDING
-  SOFT_CANCELED
-  UNKNOWN
-}
-
-type SupportTicket {
-  """The environment affected by the issue"""
-  affectedEnv: AffectedEnv
-
-  """The org id this issue belongs to"""
-  apolloOrgId: String
-
-  """The date the issue was created"""
-  created: Timestamp!
-
-  """The description of the issue"""
-  description: String!
-
-  """The graph this issue is related to"""
-  graph: Service
-
-  """The id of the issue"""
-  id: Int!
-
-  """The key of the issue, ie TH-###"""
-  key: String!
-
-  """The priority of the issue. Returns P3 if null in Jira"""
-  priority: TicketPriority!
-
-  """The status of the issue"""
-  status: TicketStatus!
-
-  """The summary of the issue"""
-  summary: String!
-
-  """The apollo user who created this issue"""
-  user: User
-}
-
-input SupportTicketInput {
-  affectedEnv: AffectedEnv
-  apolloOrgId: String
-  description: String!
-  displayName: String!
-  email: String!
-  emailUsers: [String!]
-  graphId: String
-  graphType: GraphType
-  priority: TicketPriority!
-  summary: String!
-}
-
-type Survey {
-  id: String!
-  isComplete: Boolean!
-  questionAnswers: [SurveyQuestionAnswer!]!
-  shouldShow: Boolean!
-}
-
-type SurveyQuestionAnswer {
-  answerDetails: String
-  answerValue: String
-  questionKey: String!
-}
-
-input SurveyQuestionInput {
-  answerDetails: String
-  answerKey: String!
-  answerKeyVersion: Int
-  answerValue: String
-  questionKey: String!
-  questionKeyVersion: Int
-  wasSkipped: Boolean!
-}
-
-union SyncBillingAccountResult = PermissionError | SyncBillingAccountSuccess
-
-type SyncBillingAccountSuccess {
-  message: String!
-}
-
-"""User input for a resource share mutation"""
-input SyncPrivateSubgraphsInput {
-  """A unique identifier for the private subgraph"""
-  identifier: String!
-
-  """The cloud provider where the private subgraph is hosted"""
-  provider: CloudProvider!
 }
 
 type TaskError {
   message: String!
 }
 
-type TemporaryURL {
-  url: String!
-}
-
-type TestRouter {
-  id: ID!
-  status: TestRouterStatus!
-  router: Router
-}
-
-"""The current state of a [`TestRouter`]"""
-enum TestRouterStatus {
-  """The router is spinning up"""
-  LAUNCHING
-
-  """The router is running"""
-  RUNNING
-
-  """The router is spinning down"""
-  DELETING
-
-  """The router has been destroyed"""
-  DELETED
-
-  """The router has entered an errored state as a result of the above"""
-  ERRORED
-}
-
-enum ThemeName {
-  DARK
-  LIGHT
-}
-
-"""Throttle error"""
-type ThrottleError implements Error {
-  message: String!
-  retryAfter: Int
-}
-
-enum TicketPriority {
-  """Note that JSM does not have P0"""
-  P0
-  P1
-  P2
-  P3
-
-  """Note that Zendesk does not have P4"""
-  P4
-}
-
-enum TicketStatus {
-  """Canceled"""
-  CANCELLED
-
-  """Closed"""
-  CLOSED
-
-  """Escalated"""
-  ESCALATED
-
-  """Zendesk status hold"""
-  HOLD
-
-  """In Progress"""
-  IN_PROGRESS
-
-  """Zendesk status new"""
-  NEW
-
-  """Zendesk status open"""
-  OPEN
-
-  """Zendesk status pending"""
-  PENDING
-
-  """Reopened"""
-  REOPENED
-
-  """Resolved"""
-  RESOLVED
-
-  """Zendesk status solved"""
-  SOLVED
-
-  """Waiting for customer"""
-  WAITING_FOR_CUSTOMER
-
-  """Waiting for support"""
-  WAITING_FOR_SUPPORT
-}
-
 """
 ISO 8601, extended format with nanoseconds, Zulu (or "[+-]seconds" as a string or number relative to now)
 """
 scalar Timestamp
-
-"""Filter options to represent a timestamp range"""
-input TimestampFilterInput {
-  """The start of the range"""
-  from: Timestamp
-
-  """The end of the range"""
-  to: Timestamp
-}
-
-type TimezoneOffset {
-  minutesOffsetFromUTC: Int!
-  zoneID: String!
-}
-
-type TopNOperationsByErrorPercentageRecord implements TopNOperationsRecord {
-  """
-  A substring of the query signature for unnamed operations, otherwise the operation name.
-  """
-  displayName: String!
-  errorPercentage: Float!
-
-  """The operation name or null if the operation is unnamed."""
-  name: String
-
-  """The unique id for this operation."""
-  queryID: String!
-  type: OperationType
-}
-
-type TopNOperationsByP95Record implements TopNOperationsRecord {
-  """
-  A substring of the query signature for unnamed operations, otherwise the operation name.
-  """
-  displayName: String!
-
-  """The operation name or null if the operation is unnamed."""
-  name: String
-
-  """The unique id for this operation."""
-  queryID: String!
-  serviceTimeP95Ms: Float!
-  type: OperationType
-}
-
-type TopNOperationsByRequestRateRecord implements TopNOperationsRecord {
-  """
-  A substring of the query signature for unnamed operations, otherwise the operation name.
-  """
-  displayName: String!
-
-  """The operation name or null if the operation is unnamed."""
-  name: String
-
-  """The unique id for this operation."""
-  queryID: String!
-  requestCountPerMin: Float!
-  type: OperationType
-}
-
-input TopNOperationsFilterInput {
-  clientName: String
-  clientVersion: String
-  in: TopNOperationsFilterInput
-  or: [TopNOperationsFilterInput!]
-}
-
-interface TopNOperationsRecord {
-  """
-  A substring of the query signature for unnamed operations, otherwise the operation name.
-  """
-  displayName: String!
-
-  """The operation name or null if the operation is unnamed."""
-  name: String
-
-  """The unique id for this operation."""
-  queryID: String!
-  type: OperationType
-}
-
-type TopNOperationsResult {
-  """Top N operations by error percentage (descending)."""
-  byErrorPercentage: [TopNOperationsByErrorPercentageRecord!]!
-
-  """Top N operations by p95 latency (descending)."""
-  byP95: [TopNOperationsByP95Record!]!
-
-  """Top N operations by request rate (descending)."""
-  byRequestRate: [TopNOperationsByRequestRateRecord!]!
-}
 
 type TopOperationRecord {
   """The graph this operation was reported from."""
@@ -19000,553 +5632,6 @@ type TotalChangeSummaryCounts {
   deprecations: Int!
 }
 
-type Trace {
-  agentVersion: String
-  cacheMaxAgeMs: Float
-  cacheScope: CacheScope
-  clientName: String
-  clientVersion: String
-  durationMs: Float!
-  endTime: Timestamp!
-  http: TraceHTTP
-  id: ID!
-
-  """
-  True if the report containing the trace was submitted as potentially incomplete, which can happen if the Router's
-  trace buffer fills up while constructing the trace. If this is true, the trace might be missing some nodes.
-  """
-  isIncomplete: Boolean!
-  operationName: String
-  protobuf: Protobuf!
-  root: TraceNode!
-  signature: String!
-  startTime: Timestamp!
-  unexecutedOperationBody: String
-  unexecutedOperationName: String
-  variablesJSON: [StringToString!]!
-}
-
-type TraceError {
-  errorCode: String
-  errorService: String
-  json: String!
-  locations: [TraceSourceLocation!]!
-  message: String!
-  timestamp: Timestamp
-}
-
-type TraceHTTP {
-  method: HTTPMethod!
-  requestHeaders: [StringToString!]!
-  responseHeaders: [StringToString!]!
-  statusCode: Int!
-}
-
-type TraceNode {
-  """Additional metadata for the node, presented in key-value pairs."""
-  attributes: [StringToString!]!
-  cacheMaxAgeMs: Float
-  cacheScope: CacheScope
-
-  """The total number of children, including the ones that were truncated."""
-  childCount: Int!
-
-  """
-  Whether the children of this node have been truncated because the number of children is over the max.
-  """
-  childrenAreTruncated: Boolean!
-
-  """
-  All children, and the children of those children, and so on. Children that have been truncated
-  are not included.
-  """
-  descendants: [TraceNode!]!
-
-  """
-  The end time of the node. If this is a fetch node (meaning isFetch is true), this will be the
-  time that the gateway/router received the response from the subgraph server in the
-  gateway/routers clock time.
-  """
-  endTime: Timestamp!
-  errors: [TraceError!]!
-  id: ID!
-
-  """
-  Whether the fetch node in question is a descendent of a Deferred node in the trace's query plan. The nodes
-  in query plans can be complicated and nested, so this is a fairly simple representation of the structure.
-  """
-  isDeferredFetch: Boolean!
-
-  """
-  Whether the node in question represents a fetch node within a query plan. If so, this will contain
-  children with timestamps that are calculated by the router/gateway rather than subgraph and the
-  fields subgraphStartTime and subgraphEndTime will be non-null.
-  """
-  isFetch: Boolean!
-  key: StringOrInt
-
-  """
-  A classification which helps to differentiate between types of nodes (intended for display / filtering purposes).
-  """
-  kind: TraceNodeKind!
-  originalFieldName: String
-  parentId: ID
-
-  """
-  If the node is a field resolver, the field's parent type; e.g. "User" for User.email
-  otherwise null.
-  """
-  parentType: String
-
-  """
-  The start time of the node. If this is a fetch node (meaning isFetch is true), this will be the
-  time that the gateway/router sent the request to the subgraph server in the gateway/router's clock
-  time.
-  """
-  startTime: Timestamp!
-
-  """
-  Only present when the node in question is a fetch node, this will indicate the timestamp at which
-  the subgraph server returned a response to the gateway/router. This timestamp is based on the
-  subgraph server's clock, so if there is a clock skew between the subgraph and the gateway/router,
-  this and endTime will not be in sync. If this is a fetch node but we don't receive subgraph traces
-  (e.g. if the subgraph doesn't support federated traces), this value will be null.
-  """
-  subgraphEndTime: Timestamp
-
-  """If present, indicates the subgraph context a node is associated with."""
-  subgraphName: String
-
-  """
-  Only present when the node in question is a fetch node, this will indicate the timestamp at which
-  the fetch was received by the subgraph server. This timestamp is based on the subgraph server's
-  clock, so if there is a clock skew between the subgraph and the gateway/router, this and startTime
-  will not be in sync. If this is a fetch node but we don't receive subgraph traces (e.g. if the
-  subgraph doesn't support federated traces), this value will be null.
-  """
-  subgraphStartTime: Timestamp
-
-  """
-  If the node is a field resolver, the field's return type; e.g. "String!" for User.email:String!
-  otherwise an empty string.
-  """
-  type: String
-}
-
-enum TraceNodeKind {
-  ARRAY_INDEX_RESOLVER
-  FIELD_RESOLVER
-  REQUEST
-  ROUTER_INTERNAL
-  SUBGRAPH_REQUEST
-  USER_PLUGIN
-}
-
-"""Columns of TracePathErrorsRefs."""
-enum TracePathErrorsRefsColumn {
-  CLIENT_NAME
-  CLIENT_VERSION
-  DURATION_BUCKET
-  ERRORS_COUNT_IN_PATH
-  ERRORS_COUNT_IN_TRACE
-  ERROR_CODE
-  ERROR_MESSAGE
-  ERROR_SERVICE
-  PATH
-  QUERY_ID
-  QUERY_NAME
-  SCHEMA_HASH
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-  TRACE_HTTP_STATUS_CODE
-  TRACE_ID
-  TRACE_SIZE_BYTES
-  TRACE_STARTS_AT
-}
-
-type TracePathErrorsRefsDimensions {
-  clientName: String
-  clientVersion: String
-  durationBucket: Int
-  errorCode: String
-  errorMessage: String
-  errorService: String
-
-  """
-  If metrics were collected from a federated service, this field will be prefixed with `service:<SERVICE_NAME>.`
-  """
-  path: String
-  queryId: ID
-  queryName: String
-  schemaHash: String
-  schemaTag: String
-  serviceId: ID
-  traceHttpStatusCode: Int
-  traceId: ID
-  traceStartsAt: Timestamp
-}
-
-"""
-Filter for data in TracePathErrorsRefs. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input TracePathErrorsRefsFilter {
-  and: [TracePathErrorsRefsFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-
-  """
-  Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead.
-  """
-  durationBucket: Int
-
-  """
-  Selects rows whose errorCode dimension equals the given value if not null. To query for the null value, use {in: {errorCode: [null]}} instead.
-  """
-  errorCode: String
-
-  """
-  Selects rows whose errorMessage dimension equals the given value if not null. To query for the null value, use {in: {errorMessage: [null]}} instead.
-  """
-  errorMessage: String
-
-  """
-  Selects rows whose errorService dimension equals the given value if not null. To query for the null value, use {in: {errorService: [null]}} instead.
-  """
-  errorService: String
-  in: TracePathErrorsRefsFilterIn
-  not: TracePathErrorsRefsFilter
-  or: [TracePathErrorsRefsFilter!]
-
-  """
-  Selects rows whose path dimension equals the given value if not null. To query for the null value, use {in: {path: [null]}} instead.
-  """
-  path: String
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: ID
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead.
-  """
-  schemaHash: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-
-  """
-  Selects rows whose traceHttpStatusCode dimension equals the given value if not null. To query for the null value, use {in: {traceHttpStatusCode: [null]}} instead.
-  """
-  traceHttpStatusCode: Int
-
-  """
-  Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead.
-  """
-  traceId: ID
-}
-
-"""
-Filter for data in TracePathErrorsRefs. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input TracePathErrorsRefsFilterIn {
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  durationBucket: [Int]
-
-  """
-  Selects rows whose errorCode dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  errorCode: [String]
-
-  """
-  Selects rows whose errorMessage dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  errorMessage: [String]
-
-  """
-  Selects rows whose errorService dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  errorService: [String]
-
-  """
-  Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  path: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [ID]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaHash: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-
-  """
-  Selects rows whose traceHttpStatusCode dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  traceHttpStatusCode: [Int]
-
-  """
-  Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  traceId: [ID]
-}
-
-type TracePathErrorsRefsMetrics {
-  errorsCountInPath: Long!
-  errorsCountInTrace: Long!
-  traceSizeBytes: Long!
-}
-
-input TracePathErrorsRefsOrderBySpec {
-  column: TracePathErrorsRefsColumn!
-  direction: Ordering!
-}
-
-type TracePathErrorsRefsRecord {
-  """Dimensions of TracePathErrorsRefs that can be grouped by."""
-  groupBy: TracePathErrorsRefsDimensions!
-
-  """Metrics of TracePathErrorsRefs that can be aggregated over."""
-  metrics: TracePathErrorsRefsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-"""Columns of TraceRefs."""
-enum TraceRefsColumn {
-  CLIENT_NAME
-  CLIENT_VERSION
-  DURATION_BUCKET
-  OPERATION_SUBTYPE
-  OPERATION_TYPE
-  QUERY_ID
-  QUERY_NAME
-  SCHEMA_HASH
-  SCHEMA_TAG
-  SERVICE_ID
-  TIMESTAMP
-  TRACE_COUNT
-  TRACE_ID
-}
-
-type TraceRefsDimensions {
-  clientName: String
-  clientVersion: String
-  durationBucket: Int
-  generatedTraceId: String
-  operationSubtype: String
-  operationType: String
-  queryId: ID
-  queryName: String
-  querySignature: String
-  schemaHash: String
-  schemaTag: String
-  serviceId: ID
-  traceId: ID
-}
-
-"""
-Filter for data in TraceRefs. Fields with dimension names represent equality checks. All fields are implicitly ANDed together.
-"""
-input TraceRefsFilter {
-  and: [TraceRefsFilter!]
-
-  """
-  Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead.
-  """
-  clientName: String
-
-  """
-  Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead.
-  """
-  clientVersion: String
-
-  """
-  Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead.
-  """
-  durationBucket: Int
-  in: TraceRefsFilterIn
-  not: TraceRefsFilter
-
-  """
-  Selects rows whose operationSubtype dimension equals the given value if not null. To query for the null value, use {in: {operationSubtype: [null]}} instead.
-  """
-  operationSubtype: String
-
-  """
-  Selects rows whose operationType dimension equals the given value if not null. To query for the null value, use {in: {operationType: [null]}} instead.
-  """
-  operationType: String
-  or: [TraceRefsFilter!]
-
-  """
-  Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead.
-  """
-  queryId: ID
-
-  """
-  Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead.
-  """
-  queryName: String
-
-  """
-  Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead.
-  """
-  schemaHash: String
-
-  """
-  Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead.
-  """
-  schemaTag: String
-
-  """
-  Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead.
-  """
-  serviceId: ID
-
-  """
-  Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead.
-  """
-  traceId: ID
-}
-
-"""
-Filter for data in TraceRefs. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together.
-"""
-input TraceRefsFilterIn {
-  """
-  Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientName: [String]
-
-  """
-  Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  clientVersion: [String]
-
-  """
-  Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  durationBucket: [Int]
-
-  """
-  Selects rows whose operationSubtype dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationSubtype: [String]
-
-  """
-  Selects rows whose operationType dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  operationType: [String]
-
-  """
-  Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryId: [ID]
-
-  """
-  Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  queryName: [String]
-
-  """
-  Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaHash: [String]
-
-  """
-  Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  schemaTag: [String]
-
-  """
-  Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  serviceId: [ID]
-
-  """
-  Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension.
-  """
-  traceId: [ID]
-}
-
-type TraceRefsMetrics {
-  traceCount: Long!
-}
-
-input TraceRefsOrderBySpec {
-  column: TraceRefsColumn!
-  direction: Ordering!
-}
-
-type TraceRefsRecord {
-  """Dimensions of TraceRefs that can be grouped by."""
-  groupBy: TraceRefsDimensions!
-
-  """Metrics of TraceRefs that can be aggregated over."""
-  metrics: TraceRefsMetrics!
-
-  """Starting segment timestamp."""
-  timestamp: Timestamp!
-}
-
-type TraceSourceLocation {
-  column: Int!
-  line: Int!
-}
-
 """
 Counts of changes at the type level, including interfaces, unions, enums, scalars, input objects, etc.
 """
@@ -19566,92 +5651,9 @@ type TypeChangeSummaryCounts {
 }
 
 """
-the TypeFilterConfig is used to isolate
-types, and subsequent fields, through
-various configuration settings.
-
-It defaults to filter towards user defined
-types only
-"""
-input TypeFilterConfig {
-  """include abstract types (interfaces and unions)"""
-  includeAbstractTypes: Boolean = true
-
-  """include built in scalars (i.e. Boolean, Int, etc)"""
-  includeBuiltInTypes: Boolean = false
-
-  """include reserved introspection types (i.e. __Type)"""
-  includeIntrospectionTypes: Boolean = false
-}
-
-type UnignoreOperationsInChecksResult {
-  graph: Service!
-}
-
-type UnlinkPersistedQueryListResult {
-  graphVariant: GraphVariant!
-  unlinkedPersistedQueryList: PersistedQueryList!
-}
-
-"""
 The result/error union returned by GraphVariantMutation.unlinkPersistedQueryList.
 """
-union UnlinkPersistedQueryListResultOrError = PermissionError | UnlinkPersistedQueryListResult | VariantAlreadyUnlinkedError
-
-type UpcomingMeteredBill {
-  creditGrantLineItem: MeteredBillCreditGrantLineItem!
-  flatFeeLineItems: [MeteredBillFlatFeeLineItem!]!
-  meteredLineItems: [MeteredBillMeteredLineItem!]!
-  totalInCents: Int!
-}
-
-"""Input to update an AWS shard"""
-input UpdateAwsShardInput {
-  region: String
-  accountId: String
-  iamRoleArn: String
-  loadbalancers: [AwsLoadBalancerInput!]
-  loadbalancerSecurityGroupId: String
-  ecsClusterArn: String
-  vpcId: String
-  subnetIds: [String!]
-  permissionsBoundaryArn: String
-  coldStartTargetGroupArns: [String!]
-}
-
-input UpdateBillingPlanDescriptorsInput {
-  description: String
-  name: String
-  readableId: ID
-}
-
-input UpdateBillingPlanInput {
-  billingModel: BillingModel!
-  clientVersions: Boolean
-  clients: Boolean
-  contracts: Boolean
-  datadog: Boolean
-  errors: Boolean!
-  federation: Boolean
-  intervalLength: Int!
-  intervalUnit: String!
-  kind: BillingPlanKind!
-  launches: Boolean
-  maxAuditInDays: Int
-  maxRangeInDays: Int
-  maxSelfHostedRequestsPerMonth: Long
-  metrics: Boolean
-  notifications: Boolean
-  operationRegistry: Boolean
-  persistedQueries: Boolean
-  proposals: Boolean
-  public: Boolean!
-  schemaValidation: Boolean
-  sso: Boolean
-  traces: Boolean
-  userRoles: Boolean
-  webhooks: Boolean
-}
+union UnlinkPersistedQueryListResultOrError = PermissionError | VariantAlreadyUnlinkedError
 
 """Input to update a proposal description"""
 input UpdateDescriptionInput {
@@ -19662,12 +5664,6 @@ input UpdateDescriptionInput {
 union UpdateOperationCollectionEntryResult = OperationCollectionEntry | PermissionError | ValidationError
 
 union UpdateOperationCollectionResult = OperationCollection | PermissionError | ValidationError
-
-union UpdatePaymentMethodResult = Account | NotFoundError | PermissionError | UpdatePaymentMethodSuccess
-
-type UpdatePaymentMethodSuccess {
-  paymentMethodId: String!
-}
 
 """
 The result of a successful call to PersistedQueryListMutation.updateMetadata.
@@ -19681,13 +5677,6 @@ The result/error union returned by PersistedQueryListMutation.updateMetadata.
 """
 union UpdatePersistedQueryListMetadataResultOrError = PermissionError | UpdatePersistedQueryListMetadataResult
 
-input UpdateProposalLifecycleSubscriptionInput {
-  events: [ProposalLifecycleEvent!]!
-  id: ID!
-}
-
-union UpdateProposalLifecycleSubscriptionResult = NotFoundError | PermissionError | ProposalLifecycleSubscription | ValidationError
-
 union UpdateProposalResult = PermissionError | Proposal | ValidationError
 
 input UpdateRequestedReviewersInput {
@@ -19697,64 +5686,8 @@ input UpdateRequestedReviewersInput {
 
 union UpdateRequestedReviewersResult = PermissionError | Proposal | ValidationError
 
-"""Input for updating a  Cloud Router"""
-input UpdateRouterInput {
-  """Router version for the Cloud Router"""
-  routerVersion: String
-
-  """Configuration for the Cloud Router"""
-  routerConfig: String
-
-  """Graph composition ID, also known as launch ID"""
-  graphCompositionId: String
-
-  """
-  Number of GCUs allocated for the Cloud Router
-  
-  This is ignored for serverless Cloud Routers
-  """
-  gcus: Int
-
-  """Unique identifier for ordering orders"""
-  orderingId: String!
-}
-
-"""Represents the possible outcomes of an updateRouter mutation"""
-union UpdateRouterResult = UpdateRouterSuccess | InvalidInputErrors | InternalServerError
-
-"""
-Success branch of an updateRouter mutation.
-id of the order can be polled via Query.cloud().order(id: ID!) to check-in
-on the progress of the underlying operation
-"""
-type UpdateRouterSuccess {
-  order: Order!
-}
-
-"""Result of an updateVersion mutation"""
-union UpdateRouterVersionResult = RouterVersion | InvalidInputErrors | InternalServerError
-
-input UpdateRuleEnforcementInput {
-  """
-  A json string representing any parameters necessary for the policy's enforcement. Explicit null setting is allowed.
-  """
-  params: [StringToStringInput!]
-}
-
-"""Input to update an existing Shard"""
-input UpdateShardInput {
-  shardId: String!
-  gcuCapacity: Int
-  gcuUsage: Int
-  routerCapacity: Int
-  routerUsage: Int
-  status: ShardStatus
-  reason: String
-  aws: UpdateAwsShardInput
-}
-
 """Describes the result of publishing a schema to a graph variant."""
-type UploadSchemaMutationResponse {
+type SchemaPublicationResult {
   """
   A machine-readable response code that indicates the type of result (e.g., `UPLOAD_SUCCESS` or `NO_CHANGES`)
   """
@@ -19768,29 +5701,13 @@ type UploadSchemaMutationResponse {
   """A Human-readable message describing the type of result."""
   message: String!
 
-  """If successful, the corresponding publication."""
-  tag: SchemaTag
-
   """
   If the publish operation succeeded, this contains its details. Otherwise, this is null.
   """
-  publication: SchemaTag
+  publication: SchemaPublication
 }
-
-input UpsertReviewInput {
-  comment: String
-  decision: ReviewDecision!
-  revisionId: ID!
-}
-
-union UpsertReviewResult = PermissionError | Proposal | ValidationError
 
 union UpsertRouterResult = GraphVariant | RouterUpsertFailure
-
-type URI {
-  """A GCS URI"""
-  gcs: String!
-}
 
 """A registered Apollo Studio user."""
 type User implements Identity {
@@ -19804,76 +5721,12 @@ type User implements Identity {
 
   """The user's first and last name."""
   name: String!
-  acceptedPrivacyPolicyAt: Timestamp
 
   """Returns a list of all active user API keys for the user."""
   apiKeys(includeCookies: Boolean = false): [UserApiKey!]!
-  betaFeaturesOn: Boolean!
-  canUpdateAvatar: Boolean!
-  canUpdateEmail: Boolean!
-  canUpdateFullName: Boolean!
-  createdAt: Timestamp!
-  email: String
-  emailModifiedAt: Timestamp
-  emailVerified: Boolean!
-  fullName: String!
-
-  """
-  The user's GitHub username, if they log in via GitHub. May be null even for GitHub users in some edge cases.
-  """
-  githubUsername: String
-
-  """
-  This role is reserved exclusively for internal Apollo employees, and it controls what access they may have to other
-  organizations. Only admins are allowed to see this field.
-  """
-  internalAdminRole: InternalMdgAdminRole
-
-  """Whether or not this user is and internal Apollo employee"""
-  isInternalUser: Boolean!
-  isSsoV2: Boolean!
-
-  """Last time any API token from this user was used against AGM services"""
-  lastAuthenticatedAt: Timestamp
-  loginFlowSource: LoginFlowSource
-  logoutAfterIdleMs: Int
 
   """A list of the user's memberships in Apollo Studio organizations."""
   memberships: [UserMembership!]!
-  synchronized: Boolean!
-  type: UserType!
-
-  """
-  Get an URL to which an avatar image can be uploaded. Client uploads by sending a PUT request
-  with the image data to MediaUploadInfo.url. Client SHOULD set the "Content-Type" header to the
-  browser-inferred MIME type, and SHOULD set the "x-apollo-content-filename" header to the
-  filename, if such information is available. Client MUST set the "x-apollo-csrf-token" header to
-  MediaUploadInfo.csrfToken.
-  """
-  avatarUpload: AvatarUploadResult
-
-  """
-  Get an image URL for the user's avatar. Note that CORS is not enabled for these URLs. The size
-  argument is used for bandwidth reduction, and should be the size of the image as displayed in the
-  application. Apollo's media server will downscale larger images to at least the requested size,
-  but this will not happen for third-party media servers.
-  """
-  avatarUrl(size: Int! = 40): String
-  featureIntros: FeatureIntros
-  odysseyTasks(in: [ID!]): [OdysseyTask!]
-  odysseyCourses: [OdysseyCourse!]
-  odysseyCourse(courseId: ID!): OdysseyCourse
-  odysseyCertifications: [OdysseyCertification!]!
-  odysseyCertification(certificationId: ID!): OdysseyCertification
-  odysseyAttempts: [OdysseyAttempt!]
-  odysseyAttempt(id: ID!): OdysseyAttempt
-  odysseyHasEarlyAccess: Boolean! @deprecated(reason: "Unused. Remove from application usage")
-  odysseyHasRequestedEarlyAccess: Boolean! @deprecated(reason: "Unused. Remove from application usage")
-  education: Education
-  sandboxOperationCollections: [OperationCollection!]!
-
-  """List of support tickets this user has submitted"""
-  supportTickets: [SupportTicket!]
 }
 
 """
@@ -19894,7 +5747,7 @@ type UserApiKey implements ApiKey {
 """A single user's membership in a single Apollo Studio organization."""
 type UserMembership {
   """The organization that the user belongs to."""
-  account: Account!
+  account: Organization!
 
   """The timestamp when the user was added to the organization."""
   createdAt: Timestamp!
@@ -19910,11 +5763,6 @@ type UserMembership {
 }
 
 type UserMutation {
-  acceptPrivacyPolicy: Void
-
-  """Change the user's password"""
-  changePassword(newPassword: String!, previousPassword: String!): Void
-
   """
   Hard deletes the associated user. Throws an error otherwise with reason included.
   """
@@ -19929,11 +5777,6 @@ type UserMutation {
   """
   provisionKey(keyName: String! = "add-a-name"): ApiKeyProvision
 
-  """
-  Refresh information about the user from its upstream service (e.g. list of organizations from GitHub)
-  """
-  refresh: User
-
   """Deletes the user API key with the provided ID, if any."""
   removeKey(
     """API key ID"""
@@ -19944,48 +5787,6 @@ type UserMutation {
   Sets a new name for the user API key with the provided ID, if any. This does not invalidate the key or change its value.
   """
   renameKey(id: ID!, newKeyName: String): UserApiKey
-  resendVerificationEmail: Void
-
-  """Update information about a user; all arguments are optional"""
-  update(email: String, fullName: String, referrer: String, trackingGoogleClientId: String, trackingMarketoClientId: String, userSegment: UserSegment, utmCampaign: String, utmMedium: String, utmSource: String): User
-
-  """Updates this users' preference concerning opting into beta features."""
-  updateBetaFeaturesOn(betaFeaturesOn: Boolean!): User
-
-  """
-  Update user to have the given internal mdg admin role.
-  It is necessary to be an MDG_INTERNAL_SUPER_ADMIN to perform update.
-  Additionally, upserting a null value explicitly revokes this user's
-  admin status.
-  """
-  updateRole(newRole: InternalMdgAdminRole): User
-  user: User!
-  verifyEmail(token: String!): User
-
-  """Delete the user's avatar. Requires User.canUpdateAvatar to be true."""
-  deleteAvatar: AvatarDeleteError
-
-  """
-  Update the status of a feature for this. For example, if you want to hide an introductory popup.
-  """
-  updateFeatureIntros(newFeatureIntros: FeatureIntrosInput): User
-  setOdysseyTask(task: OdysseyTaskInput!, courseId: ID, courseLanguage: String): OdysseyTask
-  createOdysseyTasks(tasks: [OdysseyTaskInput!]!): [OdysseyTask!]
-  deleteOdysseyTasks(taskIds: [String!]!): [OdysseyTask]!
-  setOdysseyCourse(course: OdysseyCourseInput!): OdysseyCourse
-  deleteOdysseyCourse(courseId: String!): OdysseyCourse
-  createOdysseyCourses(courses: [OdysseyCourseInput!]!): [OdysseyCourse!]
-  createOdysseyCertification(certificationId: String!, source: String): OdysseyCertification
-  deleteOdysseyCertification(id: ID!): OdysseyCertification
-  createOdysseyAttempt(testId: String!): OdysseyAttempt
-  deleteOdysseyAttempt(id: ID!): OdysseyAttempt
-  updateOdysseyAttempt(id: ID!, pass: Boolean, completedAt: Timestamp): OdysseyAttempt
-  setOdysseyResponse(response: OdysseyResponseInput!): OdysseyResponse
-  completeOdysseyAttempt(id: ID!, responses: [OdysseyResponseCorrectnessInput!]!, pass: Boolean!): OdysseyAttempt
-  setOdysseyCourseLanguage(courseId: ID!, language: String!): OdysseyCourse!
-
-  """Submit a support ticket for this user"""
-  submitSupportTicket(ticket: SupportTicketInput!): SupportTicket
 }
 
 enum UserPermission {
@@ -20000,98 +5801,10 @@ enum UserPermission {
   PERSISTED_QUERY_PUBLISHER
 }
 
-enum UserSegment {
-  JOIN_MY_TEAM
-  LOCAL_DEVELOPMENT
-  NOT_SPECIFIED
-  ODYSSEY
-  PRODUCTION_GRAPHS
-  SANDBOX
-  SANDBOX_OPERATION_COLLECTIONS
-  SANDBOX_PREFLIGHT_SCRIPTS
-  TRY_TEAM
-}
-
-type UserSettings {
-  appNavCollapsed: Boolean!
-  autoManageVariables: Boolean!
-  id: String!
-  mockingResponses: Boolean!
-  preflightScriptEnabled: Boolean!
-  responseHints: ResponseHints!
-  tableMode: Boolean!
-  themeName: ThemeName!
-}
-
-"""Explorer user settings input"""
-input UserSettingsInput {
-  appNavCollapsed: Boolean
-  autoManageVariables: Boolean
-  mockingResponses: Boolean
-  preflightScriptEnabled: Boolean
-  responseHints: ResponseHints
-  tableMode: Boolean
-  themeName: ThemeName
-}
-
-input UserTrackingInput {
-  referrer: String
-  referrerDetails: String
-  sessionReferrer: String
-  sessionReferrerCreatedAt: Timestamp
-  sessionReferrerDetail: String
-  trackingGoogleClientId: String
-  trackingMarketoClientId: String
-  userSegment: UserSegment
-  utmCampaign: String
-  utmMedium: String
-  utmSource: String
-}
-
-enum UserType {
-  APOLLO
-  GITHUB
-  SSO
-}
-
-type ValidateOperationsResult {
-  validationResults: [ValidationResult!]!
-}
-
 """An error that occurs when an operation contains invalid user input."""
 type ValidationError implements Error {
   """The error's details."""
   message: String!
-}
-
-enum ValidationErrorCode {
-  NON_PARSEABLE_DOCUMENT
-  INVALID_OPERATION
-  DEPRECATED_FIELD
-}
-
-enum ValidationErrorType {
-  FAILURE
-  WARNING
-  INVALID
-}
-
-"""
-Represents a single validation error, with information relating to the error
-and its respective operation
-"""
-type ValidationResult {
-  """The type of validation error thrown - warning, failure, or invalid."""
-  type: ValidationErrorType!
-
-  """The validation result's error code"""
-  code: ValidationErrorCode!
-
-  """Description of the validation error"""
-  description: String!
-
-  """The operation related to this validation result"""
-  operation: OperationDocument!
 }
 
 """
@@ -20169,9 +5882,6 @@ type VariantCheckConfiguration {
 }
 
 type VariantCheckConfigurationCustomChecks {
-  """ID of the check configuration"""
-  checkConfigurationId: ID!
-
   """
   When true, indicates that graph-level configuration is used for this variant setting. The default at variant creation is true.
   """
@@ -20313,28 +6023,3 @@ enum ViolationLevel {
 
 """Always null"""
 scalar Void
-
-"""Webhook notification channel"""
-type WebhookChannel implements Channel {
-  id: ID!
-  name: String!
-  secretToken: String
-
-  """
-  List of the subscriptions this channel is subscribed to, except for ProposalLifecycleSubscriptions.
-  """
-  subscriptions: [ChannelSubscription!]!
-  url: String!
-
-  """
-  List of the Schema Proposal Lifecycle Subscriptions this Channel is subscribed to.
-  """
-  proposalLifecycleSubscriptions: [ProposalLifecycleSubscription!]!
-}
-
-"""PagerDuty notification channel parameters"""
-input WebhookChannelInput {
-  name: String
-  secretToken: String
-  url: String!
-}

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -248,10 +248,21 @@ async fn main() -> anyhow::Result<()> {
     } else if !args.operations.is_empty() {
         OperationSource::from(args.operations)
     } else if let Some(collection_id) = &args.collection {
-        OperationSource::Collection(CollectionSource::Id(
-            collection_id.clone(),
-            args.platform_api_config()?,
-        ))
+        if collection_id == "default" {
+            OperationSource::Collection(CollectionSource::Default(
+                args.apollo_graph_ref
+                    .clone()
+                    .ok_or(ServerError::EnvironmentVariable(String::from(
+                        "APOLLO_GRAPH_REF",
+                    )))?,
+                args.platform_api_config()?,
+            ))
+        } else {
+            OperationSource::Collection(CollectionSource::Id(
+                collection_id.clone(),
+                args.platform_api_config()?,
+            ))
+        }
     } else if args.uplink {
         OperationSource::from(ManifestSource::Uplink(args.uplink_config()?))
     } else {


### PR DESCRIPTION
This adds support for reading the default mcp server tool collection. Right now it uses the `--collection default` arg as the way to configure this. But I'm open to alternatives. 