### PR TITLE
Change default schema and operation source behaviour

### DIFF
--- a/.changesets/breaking_jeffrey_change_default_arg_behaviour.md
+++ b/.changesets/breaking_jeffrey_change_default_arg_behaviour.md
@@ -1,5 +1,4 @@
-### Remove --uplink argument - @Jephuff PR #154
+### Deprecate -u,--uplink argument and use default collection - @Jephuff PR #154
 
-The `--uplink` argument was removed. The schema will now be fetched from uplink by default if no schema is passed in.
-To use the persisted queries from uplink, you can now pass in `--uplink-manifest`.
+`--uplink` and `-u` are deprecated and will act as an alias for `--uplink-manifest`. If a schema isn't provided, it will get fetched from uplink by default, and `--uplink-manifest` can be used to fetch the persisted queries from uplink.
 The server will now default to the default MCP tools from operation collections.

--- a/.changesets/breaking_jeffrey_change_default_arg_behaviour.md
+++ b/.changesets/breaking_jeffrey_change_default_arg_behaviour.md
@@ -1,0 +1,5 @@
+### Remove --uplink argument - @Jephuff PR #154
+
+The `--uplink` argument was removed. The schema will now be fetched from uplink by default if no schema is passed in.
+To use the persisted queries from uplink, you can now pass in `--uplink-manifest`.
+The server will now default to the default MCP tools from operation collections.

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -91,7 +91,7 @@ struct Args {
     operations: Vec<PathBuf>,
 
     /// The path to the persisted query manifest containing operations
-    #[arg(long, conflicts_with_all(["operations", "collection, uplink_manifest"]))]
+    #[arg(long, conflicts_with_all(["operations", "collection", "uplink_manifest"]))]
     manifest: Option<PathBuf>,
 
     /// collection id to expose as MCP tools, or `default` to expose the default tools for the variant (requires APOLLO_KEY)

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -99,7 +99,11 @@ struct Args {
         long,
         conflicts_with_all(["operations", "manifest", "uplink_manifest"]),
         requires = "apollo_key",
-        requires_if("default", "apollo_graph_ref")
+        requires_ifs([
+            ("default", "apollo_graph_ref"),
+            ("Default", "apollo_graph_ref"),
+            ("DEFAULT", "apollo_graph_ref")
+        ])
     )]
     collection: Option<String>,
 
@@ -250,7 +254,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let collection_id = args.collection.as_ref().and_then(|c| {
-        if c == "default" {
+        if c == "default" || c == "Default" || c == "DEFAULT" {
             None
         } else {
             Some(c.clone())

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -77,7 +77,13 @@ struct Args {
     explorer: bool,
 
     /// Enable use of uplink to get the persisted queries (requires APOLLO_KEY and APOLLO_GRAPH_REF)
-    #[arg(long, requires = "apollo_key", requires = "apollo_graph_ref", conflicts_with_all(["operations", "collection", "manifest"]))]
+    #[arg(
+        long,
+        requires = "apollo_key",
+        requires = "apollo_graph_ref",
+        aliases = ["u", "uplink"], // Deprecated aliases for backward compatibility
+        conflicts_with_all(["operations", "collection", "manifest"])
+    )]
     uplink_manifest: bool,
 
     /// Operation files to expose as MCP tools

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -72,7 +72,7 @@ struct Args {
     #[arg(long, short = 'i')]
     introspection: bool,
 
-    /// Expose a tool to open queries in Apollo Explorer (requires APOLLO_GRAPH_REF)
+    /// Expose a tool that returns the URL to open a GraphQL operation in Apollo Explorer (requires APOLLO_GRAPH_REF)
     #[arg(long, short = 'x', requires = "apollo_graph_ref")]
     explorer: bool,
 

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -72,21 +72,30 @@ struct Args {
     #[arg(long, short = 'i')]
     introspection: bool,
 
-    /// Enable use of uplink to get the persisted queries (requires APOLLO_KEY and APOLLO_GRAPH_REF)
-    #[arg(long, requires = "apollo_key", requires = "apollo_graph_ref")]
-    uplink_manifest: bool,
-
     /// Expose a tool to open queries in Apollo Explorer (requires APOLLO_GRAPH_REF)
     #[arg(long, short = 'x', requires = "apollo_graph_ref")]
     explorer: bool,
+
+    /// Enable use of uplink to get the persisted queries (requires APOLLO_KEY and APOLLO_GRAPH_REF)
+    #[arg(long, requires = "apollo_key", requires = "apollo_graph_ref", conflicts_with_all(["operations", "collection", "manifest"]))]
+    uplink_manifest: bool,
 
     /// Operation files to expose as MCP tools
     #[arg(long = "operations", short = 'o', num_args=0..)]
     operations: Vec<PathBuf>,
 
     /// The path to the persisted query manifest containing operations
-    #[arg(long, conflicts_with_all(["operations", "collection"]))]
+    #[arg(long, conflicts_with_all(["operations", "collection, uplink_manifest"]))]
     manifest: Option<PathBuf>,
+
+    /// collection id to expose as MCP tools, or `default` to expose the default tools for the variant (requires APOLLO_KEY)
+    #[arg(
+        long, 
+        conflicts_with_all(["operations", "manifest", "uplink_manifest"]), 
+        requires = "apollo_key", 
+        requires_if("default", "apollo_graph_ref")
+    )]
+    collection: Option<String>,
 
     // Configure when to allow mutations
     #[clap(long, short = 'm', default_value_t, value_enum)]
@@ -115,15 +124,6 @@ struct Args {
     /// [default: 5000]
     #[arg(long, conflicts_with_all(["sse_port", "sse_address"]))]
     http_port: Option<u16>,
-
-    /// collection id to expose as MCP tools, or `default` to expose the default tools for the variant (requires APOLLO_KEY)
-    #[arg(
-        long, 
-        conflicts_with_all(["operations", "manifest"]), 
-        requires = "apollo_key", 
-        requires_if("default", "apollo_graph_ref")
-    )]
-    collection: Option<String>,
 
     /// The endpoints (comma separated) polled to fetch the latest supergraph schema.
     #[clap(long, env, action = ArgAction::Append)]

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -90,9 +90,9 @@ struct Args {
 
     /// collection id to expose as MCP tools, or `default` to expose the default tools for the variant (requires APOLLO_KEY)
     #[arg(
-        long, 
-        conflicts_with_all(["operations", "manifest", "uplink_manifest"]), 
-        requires = "apollo_key", 
+        long,
+        conflicts_with_all(["operations", "manifest", "uplink_manifest"]),
+        requires = "apollo_key",
         requires_if("default", "apollo_graph_ref")
     )]
     collection: Option<String>,
@@ -258,17 +258,16 @@ async fn main() -> anyhow::Result<()> {
     } else if args.uplink_manifest {
         OperationSource::from(ManifestSource::Uplink(args.uplink_config()?))
     } else if let Some(collection_id) = collection_id {
-            OperationSource::Collection(CollectionSource::Id(
-                collection_id,
-                args.platform_api_config()?,
-            ))
-        
+        OperationSource::Collection(CollectionSource::Id(
+            collection_id,
+            args.platform_api_config()?,
+        ))
     } else if let Some(graph_ref) = &args.apollo_graph_ref {
         OperationSource::Collection(CollectionSource::Default(
-                graph_ref.clone(),
-                args.platform_api_config()?,
-            ))
-    }else {
+            graph_ref.clone(),
+            args.platform_api_config()?,
+        ))
+    } else {
         if !args.introspection {
             bail!(ServerError::NoOperations);
         }

--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -106,7 +106,7 @@ apollo-mcp-server [OPTIONS] --directory <DIRECTORY>
 | `--http-port <HTTP_PORT>`                             | Start the server using the Streamable HTTP transport on the given port (default: 5000).                                                                                                                                              |
 | `--http-address <HTTP_ADDRESS>`                       | The IP address to bind the Streamable HTTP server to (default: 127.0.0.1).                                                                                                                                                           |
 | `-i, --introspection`                                 | Expose the schema to the MCP client through `introspect` and `execute` tools. [Learn more](/apollo-mcp-server/guides/#from-schema-introspection).                                                                                    |
-| `-u, --uplink`                                        | Enable use of uplink to get the schema and persisted queries (requires `APOLLO_KEY` and `APOLLO_GRAPH_REF`). [Learn more](/apollo-mcp-server/guides/#from-graphos-managed-persisted-queries).                                        |
+| `--uplink-manifest`                                   | Enable use of uplink to get the persisted queries (requires `APOLLO_KEY` and `APOLLO_GRAPH_REF`). [Learn more](/apollo-mcp-server/guides/#from-graphos-managed-persisted-queries).                                        |
 | `-x, --explorer`                                      | Expose a tool that returns the URL to open a GraphQL operation in Apollo Explorer (requires `APOLLO_GRAPH_REF`).                                                                                                                     |
 | `-o, --operations [<OPERATIONS>...]`                  | Operation files to expose as MCP tools. [Learn more](/apollo-mcp-server/guides/#from-operation-files).                                                                                                                               |
 | `--manifest <MANIFEST>`                               | The path to the persisted query manifest containing operations.                                                                                                                                                                      |
@@ -134,7 +134,7 @@ The mapping of `rover dev` options to MCP Server options:
 | `--mcp-port <PORT>`                                   | `--http-port <PORT>`                                  |
 | `--mcp-address <ADDRESS>`                             | `--http-address <ADDRESS>`                            |
 | `--mcp-introspection`                                 | `-i, --introspection`                                 |
-| `--mcp-uplink`                                        | `-u, --uplink`                                        |
+| `--mcp-uplink-manifest`                               | `-u, --uplink-manifest`                               |
 | `--mcp-operations [<OPERATIONS>...]`                  | `-o, --operations [<OPERATIONS>...]`                  |
 | `--mcp-header <HEADERS>`                              | `--header <HEADERS>`                                  |
 | `--mcp-manifest <MANIFEST>`                           | `--manifest <MANIFEST>`                               |

--- a/docs/source/guides/index.mdx
+++ b/docs/source/guides/index.mdx
@@ -67,7 +67,7 @@ docker image pull ghcr.io/apollographql/apollo-mcp-server:v0.2.0
 
 ## Set up graph
 
-An Apollo MCP Server must know the schema of GraphQL API it supports. You can use either [the `--schema` or `--uplink` option](/apollo-mcp-server/command-reference#options) to provide the schema. If using `--schema` option, it can be either an API or supergraph schema.
+An Apollo MCP Server must know the schema of GraphQL API it supports. You can use either [the `--schema` option to provide the schema or `--apollo-graph-ref` and `--apollo-key` options to get the schema from uplink](/apollo-mcp-server/command-reference#options). If using `--schema` option, it can be either an API or supergraph schema.
 
 The schema is required for three main purposes:
 
@@ -149,7 +149,7 @@ For graphs managed by GraphOS, Apollo MCP Server can get operations by reading p
 To use GraphOS persisted queries, you must:
 
 - Set `APOLLO_GRAPH_REF` and `APOLLO_KEY` environment variables for a GraphOS graph
-- Run Apollo MCP Server with the `--uplink` option
+- Run Apollo MCP Server with the `--uplink-manifest` option
 
 <Tip>
 
@@ -162,7 +162,7 @@ apollo-mcp-server \
   --directory <absolute path to this git repo> \
   --schema graphql/weather/api.graphql \
   --header "apollographql-client-name:my-web-app" \
-  --uplink
+  --uplink-manifest
 ```
 
 The MCP Server supports hot reloading of GraphOS-managed persisted queries, so it can automatically pick up changes from GraphOS without restarting.


### PR DESCRIPTION
- removes `--uplink`
    - uplink schema will be attempted automatically if no schema is passed in
- add `--uplink-manifest` as a new way to explicitly get persisted query manifest from uplink
- default to the default mcp tools if no other operation source is passed in 