### PR TITLE
Add --version argument

### DIFF
--- a/.changesets/feat_jeffrey_add_version.md
+++ b/.changesets/feat_jeffrey_add_version.md
@@ -1,0 +1,3 @@
+### Add --version argument
+
+`apollo-mcp-server --version` will not print the version of apollo-mcp-server

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -32,6 +32,7 @@ const STYLES: Styles = Styles::styled()
 /// Arguments to the MCP server
 #[derive(Debug, clap::Parser)]
 #[command(
+    version,
     styles = STYLES,
     about = "Apollo MCP Server - invoke GraphQL operations from an AI agent",
 )]

--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -115,6 +115,7 @@ apollo-mcp-server [OPTIONS] --directory <DIRECTORY>
 | `-m, --allow-mutations <ALLOW_MUTATIONS>`             | [default: `none`]<br /><br />Possible values:<ul><li>`none`: Don't allow any mutations</li><li>`explicit`: Allow explicit mutations, but don't allow the LLM to build them</li><li>`all`: Allow the LLM to build mutations</li></ul> |
 | `-l, --log <LOG_LEVEL>`                               | [default: `INFO`]<br /><br />Possible values:<ul><li>`TRACE`</li><li>`DEBUG`</li><li>`INFO`</li><li>`WARN`</li><li>`ERROR`</li></ul>                                                                                                 |
 | `-h, --help`                                          | Print help (see a summary with `-h`).                                                                                                                                                                                                |
+| `-V, --version`                                       | Print version                                                                                                                                                                                                                        |
 
 Specifying either the SSE port or address (or both) will enable the SSE transport.
 Specifying either the HTTP port or address (or both) will enable the Streamable HTTP transport.


### PR DESCRIPTION
enables the clap version argument
<img width="559" alt="image" src="https://github.com/user-attachments/assets/4d7c2d75-25de-4ca3-8c61-86ab9a307df8" />
Usage
<img width="702" alt="image" src="https://github.com/user-attachments/assets/b172a7e1-bfc8-4d21-8453-23d04ada3557" />
