### PR TITLE
Add documentation on Apollo Runtime container and link to next step

### DIFF
--- a/docs/source/guides/index.mdx
+++ b/docs/source/guides/index.mdx
@@ -144,7 +144,14 @@ Use a [contract variant](/graphos/platform/schema-management/delivery/contracts/
 TODO
 \*/}
 
-## Deploying a container
+## Deploying the MCP server
+
+There are two ways to deploy and operate the MCP server. 
+
+1. Using the [MCP server container](#deploying-the-mcp-server-container) or binary, which connects to an existing GraphQL API endpoint
+1. Using the [Apollo Runtime container](), which includes both an MCP server as well as the Apollo router
+
+### Deploying the MCP server container
 
 Apollo MCP Server is available as a standalone docker container. Container images are downloadable using
 the image `ghcr.io/apollographql/apollo-mcp-server`.
@@ -165,6 +172,26 @@ docker run \
     --operations operations/ \
     --endpoint https://thespacedevs-production.up.railway.app/
 ```
+
+### Deploying MCP using the Apollo Runtime container
+
+The Apollo Runtime container includes all services necessary to serve GraphQL and MCP requests, including the Router and MCP Server. It is the easiest way to operate a GraphQL API with MCP support.
+
+To server both MCP and GraphQL requests, both port `4000` and `5000` will need to be exposed. An example command which retrieves the schema from Uplink is:
+
+```bash title="Docker" {3, 6}
+docker run \
+  -p 4000:4000 \
+  -p 5000:5000 \
+  --env APOLLO_GRAPH_REF="<your-graph-ref>" \
+  --env APOLLO_KEY="<your-graph-api-key>" \
+  --env MCP_ENABLE=1 \
+  --env MCP_UPLINK=1 \
+  --rm \
+  ghcr.io/apollographql/apollo-runtime:latest
+```
+
+To learn more about the Apollo Runtime container, review the [documentation](/docs/graphos/routing/self-hosted/containerization/docker).
 
 ## Debugging with MCP Inspector
 

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -185,6 +185,8 @@ See the [user guide](/apollo-mcp-server/guides) to learn how to create tools fro
 - [Persisted query manifests](/apollo-mcp-server/guides/#from-persisted-query-manifests)
 - [Schema introspection](/apollo-mcp-server/guides/#from-schema-introspection)
 
+When you are ready, [deploy the MCP server](https://www.apollographql.com/docs/apollo-mcp-server/guides#deploying-the-MCP-server).
+
 ### Additional Resources
 
 Check out these blog posts to learn more about Apollo MCP Server:


### PR DESCRIPTION
This is a fairly cautious PR to add the Apollo Runtime container to the user guide, as well as link to the deployment steps in the `next steps` section of the quick start.