### PR TITLE
Document why we don't support token passthrough

### DIFF
--- a/docs/source/best-practices.mdx
+++ b/docs/source/best-practices.mdx
@@ -39,4 +39,3 @@ To maintain clear trust boundaries, MCP servers must only accept tokens explicit
 Forwarding client tokens downstream is not allowed.
 
 Our team is actively working on a robust authentication mechanism that follows OAuth 2.1 best practices and aligns with the MCP authorization model.
-Our goal is to deliver a secure, standards-compliant, and maintainable solution.


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/GT-270 -->

This adds a section in our docs that explicitly call out why we're not supporting token passthrough.