### PR TITLE
docs: update mcp spec version

### DIFF
--- a/docs/source/limitations.mdx
+++ b/docs/source/limitations.mdx
@@ -10,7 +10,7 @@ This feature is [experimental](/graphos/resources/feature-launch-stages#experime
 
 ## MCP authorization not supported
 
-Apollo MCP Server doesn't support [MCP transport-level authorization](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization).
+Apollo MCP Server doesn't support [MCP transport-level authorization](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization).
 
 Consequently, when running the MCP Server as a remote service, we recommend running it only in trusted environments and networks, not in public networks.
 


### PR DESCRIPTION
Just updating the limitations docs to reference the latest version of the MCP spec.