### PR TITLE
Docker container uses Streamable HTTP transport by default

### DIFF
--- a/docs/source/guides/index.mdx
+++ b/docs/source/guides/index.mdx
@@ -150,7 +150,7 @@ Apollo MCP Server is available as a standalone docker container. Container image
 the image `ghcr.io/apollographql/apollo-mcp-server`.
 
 By default, the container expects all schema and operation files to be present in the `/data` folder within the container
-and that clients will use SSE transport on container port 5000.
+and that clients will use the Streamable HTTP transport on container port 5000.
 
 An example `docker run` command that runs the MCP Server for the space dev example:
 


### PR DESCRIPTION
We changed the Docker container to use Streamable HTTP instead of SSE, but the documentation does not reflect this.

https://github.com/apollographql/apollo-mcp-server/blob/2ebcdfc3baa39a36193c08df9c185f8321d9b28f/flake.nix#L185-L189