### PR TITLE
Include Operation Name with graphql requests

### DIFF
--- a/.changesets/feat_dale_include_operation_name.md
+++ b/.changesets/feat_dale_include_operation_name.md
@@ -1,0 +1,19 @@
+### Include operation name with GraphQL requests - @DaleSeo PR #166
+
+Include the operation name with GraphQL requests if it's available.
+
+```diff
+{
+   "query":"query GetAlerts($state: String!) { alerts(state: $state) { severity description instruction } }",
+   "variables":{
+      "state":"CO"
+   },
+   "extensions":{
+      "ApolloClientMetadata":{
+         "type":"mcp",
+         "version":"0.4.2"
+      }
+   },
++  "operationName":"GetAlerts"
+}
+```

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -11,22 +11,25 @@ pub struct Request<'a> {
     pub headers: HeaderMap,
 }
 
+#[derive(Debug, PartialEq)]
+pub struct OperationDetails {
+    pub query: String,
+    pub operation_name: Option<String>,
+}
+
 /// Able to be executed as a GraphQL operation
 pub trait Executable {
     /// Get the persisted query ID to be executed, if any
     fn persisted_query_id(&self) -> Option<String>;
 
-    /// Get the operation to execute
-    fn operation(&self, input: Value) -> Result<String, McpError>;
+    /// Get the operation to execute and its name
+    fn operation(&self, input: Value) -> Result<OperationDetails, McpError>;
 
     /// Get the variables to execute the operation with
     fn variables(&self, input: Value) -> Result<Value, McpError>;
 
     /// Get the headers to execute the operation with
     fn headers(&self, default_headers: &HeaderMap<HeaderValue>) -> HeaderMap<HeaderValue>;
-
-    /// Get the operation name
-    fn operation_name(&self) -> Option<String>;
 
     /// Execute as a GraphQL operation using the endpoint and headers
     async fn execute(&self, request: Request<'_>) -> Result<CallToolResult, McpError> {
@@ -52,20 +55,22 @@ pub trait Executable {
                 }),
             );
         } else {
-            request_body.insert(
-                String::from("query"),
-                Value::String(self.operation(request.input)?),
-            );
+            let OperationDetails {
+                query,
+                operation_name,
+            } = self.operation(request.input)?;
+
+            request_body.insert(String::from("query"), Value::String(query));
             request_body.insert(
                 String::from("extensions"),
                 serde_json::json!({
                     "ApolloClientMetadata": client_metadata,
                 }),
             );
-        }
 
-        if let Some(op_name) = self.operation_name() {
-            request_body.insert("operationName".to_string(), Value::String(op_name));
+            if let Some(op_name) = operation_name {
+                request_body.insert(String::from("operationName"), Value::String(op_name));
+            }
         }
 
         reqwest::Client::new()

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -26,37 +26,50 @@ pub trait Executable {
     /// Get the headers to execute the operation with
     fn headers(&self, default_headers: &HeaderMap<HeaderValue>) -> HeaderMap<HeaderValue>;
 
+    /// Get the operation name
+    fn operation_name(&self) -> Option<String>;
+
     /// Execute as a GraphQL operation using the endpoint and headers
     async fn execute(&self, request: Request<'_>) -> Result<CallToolResult, McpError> {
         let client_metadata = serde_json::json!({
             "type": "mcp",
             "version": std::env!("CARGO_PKG_VERSION")
         });
+
+        let mut request_body = if let Some(id) = self.persisted_query_id() {
+            serde_json::json!({
+                "variables": self.variables(request.input)?,
+                "extensions": {
+                    "persistedQuery": {
+                        "version": 1,
+                        "sha256Hash": id,
+                    },
+                    "ApolloClientMetadata": client_metadata,
+                },
+            })
+        } else {
+            serde_json::json!({
+                "query": self.operation(request.input.clone())?,
+                "variables": self.variables(request.input)?,
+                "extensions": {
+                    "ApolloClientMetadata": client_metadata,
+                },
+            })
+        };
+
+        if let Some(op_name) = self.operation_name() {
+            if let Some(obj) = request_body.as_object_mut() {
+                obj.insert(
+                    "operationName".to_string(),
+                    serde_json::Value::String(op_name),
+                );
+            }
+        }
+
         reqwest::Client::new()
             .post(request.endpoint)
             .headers(self.headers(&request.headers))
-            .body(if let Some(id) = self.persisted_query_id() {
-                serde_json::json!({
-                    "extensions": {
-                        "persistedQuery": {
-                            "version": 1,
-                            "sha256Hash": id,
-                        },
-                        "ApolloClientMetadata": client_metadata,
-                    },
-                    "variables": self.variables(request.input)?,
-                })
-                .to_string()
-            } else {
-                serde_json::json!({
-                    "query": self.operation(request.input.clone())?,
-                    "variables": self.variables(request.input)?,
-                    "extensions": {
-                        "ApolloClientMetadata": client_metadata,
-                    },
-                })
-                .to_string()
-            })
+            .body(request_body.to_string())
             .send()
             .await
             .map_err(|reqwest_error| {

--- a/crates/apollo-mcp-server/src/introspection/tools/execute.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/execute.rs
@@ -1,6 +1,9 @@
 use crate::errors::McpError;
-use crate::operations::{MutationMode, operation_defs};
-use crate::{graphql, schema_from_type};
+use crate::operations::{MutationMode, operation_defs, operation_name};
+use crate::{
+    graphql::{self, OperationDetails},
+    schema_from_type,
+};
 use reqwest::header::{HeaderMap, HeaderValue};
 use rmcp::model::{ErrorCode, Tool};
 use rmcp::schemars::JsonSchema;
@@ -45,16 +48,22 @@ impl graphql::Executable for Execute {
         None
     }
 
-    fn operation(&self, input: Value) -> Result<String, McpError> {
+    fn operation(&self, input: Value) -> Result<OperationDetails, McpError> {
         let input = serde_json::from_value::<Input>(input).map_err(|_| {
             McpError::new(ErrorCode::INVALID_PARAMS, "Invalid input".to_string(), None)
         })?;
 
         // validate the operation
-        operation_defs(&input.query, self.mutation_mode == MutationMode::All, None)
-            .map_err(|e| McpError::new(ErrorCode::INVALID_PARAMS, e.to_string(), None))?;
+        let operation_defs =
+            operation_defs(&input.query, self.mutation_mode == MutationMode::All, None)
+                .map_err(|e| McpError::new(ErrorCode::INVALID_PARAMS, e.to_string(), None))?;
 
-        Ok(input.query)
+        Ok(OperationDetails {
+            query: input.query,
+            operation_name: operation_defs.and_then(|(_, operation_def, source_path)| {
+                operation_name(&operation_def, source_path).ok()
+            }),
+        })
     }
 
     fn variables(&self, input: Value) -> Result<Value, McpError> {
@@ -79,18 +88,12 @@ impl graphql::Executable for Execute {
     fn headers(&self, default_headers: &HeaderMap<HeaderValue>) -> HeaderMap<HeaderValue> {
         default_headers.clone()
     }
-
-    fn operation_name(&self) -> Option<String> {
-        // For ad-hoc operations, we don't have access to the input here,
-        // so we can't extract the operation name. This is acceptable for ad-hoc queries.
-        None
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::errors::McpError;
-    use crate::graphql::Executable;
+    use crate::graphql::{Executable, OperationDetails};
     use crate::introspection::tools::execute::Execute;
     use crate::operations::MutationMode;
     use rmcp::model::ErrorCode;
@@ -110,7 +113,10 @@ mod tests {
 
         assert_eq!(
             Executable::operation(&execute, input.clone()),
-            Ok(query.to_string())
+            Ok(OperationDetails {
+                query: query.to_string(),
+                operation_name: Some("GetUser".to_string()),
+            })
         );
         assert_eq!(Executable::variables(&execute, input), Ok(variables));
     }
@@ -129,7 +135,10 @@ mod tests {
 
         assert_eq!(
             Executable::operation(&execute, input.clone()),
-            Ok(query.to_string())
+            Ok(OperationDetails {
+                query: query.to_string(),
+                operation_name: Some("GetUser".to_string()),
+            })
         );
         assert_eq!(Executable::variables(&execute, input), Ok(variables));
     }
@@ -146,9 +155,30 @@ mod tests {
 
         assert_eq!(
             Executable::operation(&execute, input.clone()),
-            Ok(query.to_string())
+            Ok(OperationDetails {
+                query: query.to_string(),
+                operation_name: Some("GetUser".to_string()),
+            })
         );
         assert_eq!(Executable::variables(&execute, input), Ok(Value::Null));
+    }
+
+    #[test]
+    fn execute_query_anonymous_operation() {
+        let execute = Execute::new(MutationMode::None);
+
+        let query = "{ user(id: \"123\") { id name } }";
+        let input = json!({
+            "query": query,
+        });
+
+        assert_eq!(
+            Executable::operation(&execute, input.clone()),
+            Ok(OperationDetails {
+                query: query.to_string(),
+                operation_name: None,
+            })
+        );
     }
 
     #[test]

--- a/crates/apollo-mcp-server/src/introspection/tools/execute.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/execute.rs
@@ -79,6 +79,12 @@ impl graphql::Executable for Execute {
     fn headers(&self, default_headers: &HeaderMap<HeaderValue>) -> HeaderMap<HeaderValue> {
         default_headers.clone()
     }
+
+    fn operation_name(&self) -> Option<String> {
+        // For ad-hoc operations, we don't have access to the input here,
+        // so we can't extract the operation name. This is acceptable for ad-hoc queries.
+        None
+    }
 }
 
 #[cfg(test)]

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -341,6 +341,7 @@ impl RawOperation {
 pub struct Operation {
     tool: Tool,
     inner: RawOperation,
+    operation_name: String,
 }
 
 impl AsRef<Tool> for Operation {
@@ -493,6 +494,7 @@ impl Operation {
             Ok(Some(Operation {
                 tool,
                 inner: raw_operation,
+                operation_name,
             }))
         } else {
             Ok(None)
@@ -1021,18 +1023,7 @@ impl graphql::Executable for Operation {
     }
 
     fn operation_name(&self) -> Option<String> {
-        match Parser::new().parse_ast(&self.inner.source_text, "operation") {
-            Ok(document) => {
-                // Find the first operation definition
-                for definition in document.definitions {
-                    if let Definition::OperationDefinition(operation) = definition {
-                        return operation.name.as_ref().map(|name| name.to_string());
-                    }
-                }
-                None
-            }
-            Err(_) => None,
-        }
+        Some(self.operation_name.clone())
     }
 }
 
@@ -1194,6 +1185,7 @@ mod tests {
                 variables: None,
                 source_path: None,
             },
+            operation_name: "MutationName",
         }
         "###);
     }
@@ -1246,6 +1238,7 @@ mod tests {
                 variables: None,
                 source_path: None,
             },
+            operation_name: "MutationName",
         }
         "###);
     }


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/GT-251 -->

This PR updates the code to include the operation name with GraphQL requests if it's available.

```diff
{
   "query":"query GetAlerts($state: String!) { alerts(state: $state) { severity description instruction } }",
   "variables":{
      "state":"CO"
   },
   "extensions":{
      "ApolloClientMetadata":{
         "type":"mcp",
         "version":"0.4.2"
      }
   },
+  "operationName":"GetAlerts"
}
```