### PR TITLE
docs: updating mcp server quickstart docs

### DIFF
--- a/docs/source/guides/index.mdx
+++ b/docs/source/guides/index.mdx
@@ -256,6 +256,12 @@ npx @modelcontextprotocol/inspector
 
 1. Click **Connect** and **List Tools**. You should see the tools for the operations you provided.
 
+#### MCP Inspector Connection Issues
+- **Error**: "Failed to connect to server"
+  - Solution: Ensure the MCP server is running (check terminal output)
+  - Solution: Verify you're using the correct URL (`http://127.0.0.1:5000/mcp`)
+  - Solution: Check if your firewall is blocking the connection
+
 ## Custom scalars configuration
 
 You can specify a custom scalars configuration JSON file to map a custom scalar to a [JSON schema type](https://json-schema.org/understanding-json-schema/reference/type). The JSON file is an object with custom scalar names as keys and JSON schema types as values:

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -43,48 +43,39 @@ If you learn best with videos and exercises, this [interactive course](https://w
 - Install MCP Server like so:
 
 
-<Tabs>
-    <Tab label="Linux / macOS">
-        To install or upgrade to the **latest release** of Apollo MCP Server:
-    
-        ```sh showLineNumbers=false
-        curl -sSL https://mcp.apollo.dev/download/nix/latest | sh
-        ```
-    
-        To install or upgrade to a **specific version** of Apollo MCP Server (recommended for CI environments to ensure predictable behavior):
-    
-        ```bash
-        # Note the `v` prefixing the version number
-        curl -sSL https://mcp.apollo.dev/download/nix/v0.4.2| sh
-        ```
-    
-        If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
-    </Tab>
-    <Tab label="Windows">
-        **Powershell**
-    
-        To install or upgrade to the **latest release** of Apollo MCP Server:
-    
-        ```bash
-        iwr 'https://mcp.apollo.dev/download/win/latest' | iex
-        ```
-    
-        To install or upgrade to a **specific version** of Apollo MCP Server (recommended for CI environments to ensure predictable behavior):
-    
-        ```bash
-        # Note the `v` prefixing the version number
-        iwr 'https://mcp.apollo.dev/download/win/v0.4.2' | iex
-        ```
-    </Tab>
-</Tabs>
-
+    <Tabs>
+        <Tab label="Linux / macOS">
+            To install or upgrade to the **latest release** of Apollo MCP Server:
         
-
-      </Tab>
-      <Tab label="Windows">
-
-      
-      </Tab>
+            ```sh showLineNumbers=false
+            curl -sSL https://mcp.apollo.dev/download/nix/latest | sh
+            ```
+        
+            To install or upgrade to a **specific version** of Apollo MCP Server (recommended for CI environments to ensure predictable behavior):
+        
+            ```bash
+            # Note the `v` prefixing the version number
+            curl -sSL https://mcp.apollo.dev/download/nix/v0.4.2| sh
+            ```
+        
+            If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
+        </Tab>
+        <Tab label="Windows">
+            **Powershell**
+        
+            To install or upgrade to the **latest release** of Apollo MCP Server:
+        
+            ```bash
+            iwr 'https://mcp.apollo.dev/download/win/latest' | iex
+            ```
+        
+            To install or upgrade to a **specific version** of Apollo MCP Server (recommended for CI environments to ensure predictable behavior):
+        
+            ```bash
+            # Note the `v` prefixing the version number
+            iwr 'https://mcp.apollo.dev/download/win/v0.4.2' | iex
+            ```
+        </Tab>
     </Tabs>
 
 ## Step 1: Understand the Example

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -56,7 +56,7 @@ The example files located in `graphql/TheSpaceDevs/` include:
 
 ## Step 2: Run the MCP server
 
-1. From the root directory of your local repo, run `rover dev` to start a local graph with an MCP Server:
+1. From the root directory of your local Apollo MCP Server repo, run `rover dev` to start a local graph with an MCP Server:
 
     ```sh showLineNumbers=false
     rover dev --supergraph-config ./graphql/TheSpaceDevs/supergraph.yaml \

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -54,7 +54,41 @@ The example files located in `graphql/TheSpaceDevs/` include:
   - `GetAstronautsCurrentlyInSpace` - See who's in space right now
   - `SearchUpcomingLaunches` - Find upcoming rocket launches
 
-## Step 2: Run the MCP Server
+## Step 2: Install the MCP Server
+
+### Linux / MacOS installer
+
+To install or upgrade to the **latest release** of Apollo MCP Server:
+
+```sh showLineNumbers=false
+curl -sSL https://mcp.apollo.dev/download/nix/latest | sh
+```
+
+To install or upgrade to a **specific version** of Apollo MCP Server (recommended for CI environments to ensure predictable behavior):
+
+```bash
+# Note the `v` prefixing the version number
+curl -sSL https://mcp.apollo.dev/download/nix/v0.4.2| sh
+```
+
+If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
+
+### Windows PowerShell installer
+
+To install or upgrade to the **latest release** of Apollo MCP Server:
+
+```bash
+iwr 'https://mcp.apollo.dev/download/win/latest' | iex
+```
+
+To install or upgrade to a **specific version** of Apollo MCP Server (recommended for CI environments to ensure predictable behavior):
+
+```bash
+# Note the `v` prefixing the version number
+iwr 'https://mcp.apollo.dev/download/win/v0.4.2' | iex
+```
+
+## Step 3: Run the MCP Server
 
 1. From the root directory of your local repo, run `rover dev` to start a local graph with an MCP Server:
 
@@ -69,22 +103,16 @@ The example files located in `graphql/TheSpaceDevs/` include:
     - Starts an MCP Server with the `--mcp` flag
     - Exposes the specified operations as MCP tools
 
-2. Start MCP Inspector to verify the server is running:
+2. Open a browser and go to [`http://127.0.0.1:6274`](http://127.0.0.1:6274)
 
-    ```sh
-    npx @modelcontextprotocol/inspector
-    ```
-
-3. Open a browser and go to [`http://127.0.0.1:6274`](http://127.0.0.1:6274)
-
-4. In Inspector:
+3. In Inspector:
     - Select `Streamable HTTP` as the Transport Type
     - Enter `http://127.0.0.1:5000/mcp` as the URL
     - Click **Connect**, then **List Tools**
 
     You should see the tools from your server listed.
 
-## Step 3: Connect Claude Desktop
+## Step 4: Connect Claude Desktop
 
 We're using [Claude](https://claude.ai/download) as our AI Assistant (acting as our MCP Client).
 
@@ -119,7 +147,7 @@ You need Node v18 or later installed for `mcp-remote` to work. If you have an ol
 
 2. Restart Claude.
 
-## Step 4: Test Your Setup
+## Step 5: Test Your Setup
 
 Let's verify everything is working:
 
@@ -144,12 +172,6 @@ Let's verify everything is working:
 - **Error**: "Failed to load supergraph configuration"
   - Solution: Verify you're running the command from the repo root directory
   - Solution: Check that the path to `supergraph.yaml` is correct
-
-#### MCP Inspector Connection Issues
-- **Error**: "Failed to connect to server"
-  - Solution: Ensure the MCP server is running (check terminal output)
-  - Solution: Verify you're using the correct URL (`http://127.0.0.1:5000/mcp`)
-  - Solution: Check if your firewall is blocking the connection
 
 #### Claude Desktop Issues
 - **Problem**: Claude doesn't recognize the tools
@@ -212,6 +234,8 @@ You can run the MCP Server using STDIO transport instead of Streamable HTTP. Thi
     --operations operations \
     --endpoint https://thespacedevs-production.up.railway.app/
     ```
+
+For MCP Inspector connections issues checkout of the [user guide](/apollo-mcp-server/guides/#mcp-inspector-connection-issues).
 
 3. Configure Claude Desktop to use STDIO:
 

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -40,44 +40,52 @@ If you learn best with videos and exercises, this [interactive course](https://w
 
 - Clone the [Apollo MCP Server repo](https://github.com/apollographql/apollo-mcp-server)
 - Install [Apollo Rover CLI](/rover/getting-started) v0.32 or later
-- Install MCP Server like so: 
-  <Tabs>
+- Install MCP Server like so:
+
+
+<Tabs>
     <Tab label="Linux / macOS">
-
-    To install or upgrade to the **latest release** of Apollo MCP Server:
-
-      ```sh showLineNumbers=false
-      curl -sSL https://mcp.apollo.dev/download/nix/latest | sh
-      ```
-
-    To install or upgrade to a **specific version** of Apollo MCP Server (recommended for CI environments to ensure predictable behavior):
-
-      ```bash
-      # Note the `v` prefixing the version number
-      curl -sSL https://mcp.apollo.dev/download/nix/v0.4.2| sh
-      ```
-
-    If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
-
+        To install or upgrade to the **latest release** of Apollo MCP Server:
+    
+        ```sh showLineNumbers=false
+        curl -sSL https://mcp.apollo.dev/download/nix/latest | sh
+        ```
+    
+        To install or upgrade to a **specific version** of Apollo MCP Server (recommended for CI environments to ensure predictable behavior):
+    
+        ```bash
+        # Note the `v` prefixing the version number
+        curl -sSL https://mcp.apollo.dev/download/nix/v0.4.2| sh
+        ```
+    
+        If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
     </Tab>
     <Tab label="Windows">
-
-    **Powershell**
-
-    To install or upgrade to the **latest release** of Apollo MCP Server:
-
-      ```bash
-      iwr 'https://mcp.apollo.dev/download/win/latest' | iex
-      ```
-
-    To install or upgrade to a **specific version** of Apollo MCP Server (recommended for CI environments to ensure predictable behavior):
-
-      ```bash
-      # Note the `v` prefixing the version number
-      iwr 'https://mcp.apollo.dev/download/win/v0.4.2' | iex
-      ```
+        **Powershell**
+    
+        To install or upgrade to the **latest release** of Apollo MCP Server:
+    
+        ```bash
+        iwr 'https://mcp.apollo.dev/download/win/latest' | iex
+        ```
+    
+        To install or upgrade to a **specific version** of Apollo MCP Server (recommended for CI environments to ensure predictable behavior):
+    
+        ```bash
+        # Note the `v` prefixing the version number
+        iwr 'https://mcp.apollo.dev/download/win/v0.4.2' | iex
+        ```
     </Tab>
 </Tabs>
+
+        
+
+      </Tab>
+      <Tab label="Windows">
+
+      
+      </Tab>
+    </Tabs>
 
 ## Step 1: Understand the Example
 

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -40,6 +40,44 @@ If you learn best with videos and exercises, this [interactive course](https://w
 
 - Clone the [Apollo MCP Server repo](https://github.com/apollographql/apollo-mcp-server)
 - Install [Apollo Rover CLI](/rover/getting-started) v0.32 or later
+- Install MCP Server like so: 
+  <Tabs>
+    <Tab label="Linux / macOS">
+
+    To install or upgrade to the **latest release** of Apollo MCP Server:
+
+      ```sh showLineNumbers=false
+      curl -sSL https://mcp.apollo.dev/download/nix/latest | sh
+      ```
+
+    To install or upgrade to a **specific version** of Apollo MCP Server (recommended for CI environments to ensure predictable behavior):
+
+      ```bash
+      # Note the `v` prefixing the version number
+      curl -sSL https://mcp.apollo.dev/download/nix/v0.4.2| sh
+      ```
+
+    If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
+
+    </Tab>
+    <Tab label="Windows">
+
+    **Powershell**
+
+    To install or upgrade to the **latest release** of Apollo MCP Server:
+
+      ```bash
+      iwr 'https://mcp.apollo.dev/download/win/latest' | iex
+      ```
+
+    To install or upgrade to a **specific version** of Apollo MCP Server (recommended for CI environments to ensure predictable behavior):
+
+      ```bash
+      # Note the `v` prefixing the version number
+      iwr 'https://mcp.apollo.dev/download/win/v0.4.2' | iex
+      ```
+    </Tab>
+</Tabs>
 
 ## Step 1: Understand the Example
 
@@ -53,40 +91,6 @@ The example files located in `graphql/TheSpaceDevs/` include:
   - `GetAstronautDetails` - Get info about specific astronauts  
   - `GetAstronautsCurrentlyInSpace` - See who's in space right now
   - `SearchUpcomingLaunches` - Find upcoming rocket launches
-
-## Step 2: Install the MCP Server
-
-### Linux / MacOS installer
-
-To install or upgrade to the **latest release** of Apollo MCP Server:
-
-```sh showLineNumbers=false
-curl -sSL https://mcp.apollo.dev/download/nix/latest | sh
-```
-
-To install or upgrade to a **specific version** of Apollo MCP Server (recommended for CI environments to ensure predictable behavior):
-
-```bash
-# Note the `v` prefixing the version number
-curl -sSL https://mcp.apollo.dev/download/nix/v0.4.2| sh
-```
-
-If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
-
-### Windows PowerShell installer
-
-To install or upgrade to the **latest release** of Apollo MCP Server:
-
-```bash
-iwr 'https://mcp.apollo.dev/download/win/latest' | iex
-```
-
-To install or upgrade to a **specific version** of Apollo MCP Server (recommended for CI environments to ensure predictable behavior):
-
-```bash
-# Note the `v` prefixing the version number
-iwr 'https://mcp.apollo.dev/download/win/v0.4.2' | iex
-```
 
 ## Step 3: Run the MCP Server
 

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -61,7 +61,7 @@ The example files located in `graphql/TheSpaceDevs/` include:
     ```sh showLineNumbers=false
     rover dev --supergraph-config ./graphql/TheSpaceDevs/supergraph.yaml \
     --mcp \
-    --mcp-operations ./graphql/TheSpaceDevs/operations/ExploreCelestialBodies.graphql ./graphql/TheSpaceDevs/operations/GetAstronautDetails.graphql ./graphql/TheSpaceDevs/operations/GetAstronautsCurrentlyInSpace.graphql ./graphql/TheSpaceDevs/operations/SearchUpcomingLaunches.graphql
+    --mcp-operations ./graphql/TheSpaceDevs/operations
     ```
 
     This command:

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -235,7 +235,7 @@ You can run the MCP Server using STDIO transport instead of Streamable HTTP. Thi
     --endpoint https://thespacedevs-production.up.railway.app/
     ```
 
-For MCP Inspector connections issues checkout of the [user guide](/apollo-mcp-server/guides/#mcp-inspector-connection-issues).
+For MCP Inspector connections issues checkout the [user guide](/apollo-mcp-server/guides/#mcp-inspector-connection-issues).
 
 3. Configure Claude Desktop to use STDIO:
 

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -120,9 +120,17 @@ The example files located in `graphql/TheSpaceDevs/` include:
 We're using [Claude](https://claude.ai/download) as our AI Assistant (acting as our MCP Client).
 
 First, locate your Claude configuration file:
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-- **Linux**: `~/.config/Claude/claude_desktop_config.json`
+<Tabs>
+    <Tab label="macOS">
+        `~/Library/Application Support/Claude/claude_desktop_config.json`
+    </Tab>
+    <Tab label="Windows">
+        `%APPDATA%\Claude\claude_desktop_config.json`
+    </Tab>
+    <Tab label="Linux">
+        `~/.config/Claude/claude_desktop_config.json`
+    </Tab>
+</Tabs>
 
 Then add the following configuration
 

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -40,45 +40,8 @@ If you learn best with videos and exercises, this [interactive course](https://w
 
 - Clone the [Apollo MCP Server repo](https://github.com/apollographql/apollo-mcp-server)
 - Install [Apollo Rover CLI](/rover/getting-started) v0.32 or later
-- Install MCP Server like so:
 
-
-    <Tabs>
-        <Tab label="Linux / macOS">
-            To install or upgrade to the **latest release** of Apollo MCP Server:
-        
-            ```sh showLineNumbers=false
-            curl -sSL https://mcp.apollo.dev/download/nix/latest | sh
-            ```
-        
-            To install or upgrade to a **specific version** of Apollo MCP Server (recommended for CI environments to ensure predictable behavior):
-        
-            ```bash
-            # Note the `v` prefixing the version number
-            curl -sSL https://mcp.apollo.dev/download/nix/v0.4.2| sh
-            ```
-        
-            If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
-        </Tab>
-        <Tab label="Windows">
-            **Powershell**
-        
-            To install or upgrade to the **latest release** of Apollo MCP Server:
-        
-            ```bash
-            iwr 'https://mcp.apollo.dev/download/win/latest' | iex
-            ```
-        
-            To install or upgrade to a **specific version** of Apollo MCP Server (recommended for CI environments to ensure predictable behavior):
-        
-            ```bash
-            # Note the `v` prefixing the version number
-            iwr 'https://mcp.apollo.dev/download/win/v0.4.2' | iex
-            ```
-        </Tab>
-    </Tabs>
-
-## Step 1: Understand the Example
+## Step 1: Understand the example
 
 This guide uses an MCP example from the Apollo MCP Server repo. The example uses APIs from [The Space Devs](https://thespacedevs.com/), and it defines a federated graph and the GraphQL operations of the graph to expose as MCP tools.
 
@@ -91,7 +54,7 @@ The example files located in `graphql/TheSpaceDevs/` include:
   - `GetAstronautsCurrentlyInSpace` - See who's in space right now
   - `SearchUpcomingLaunches` - Find upcoming rocket launches
 
-## Step 3: Run the MCP Server
+## Step 2: Run the MCP server
 
 1. From the root directory of your local repo, run `rover dev` to start a local graph with an MCP Server:
 
@@ -106,31 +69,14 @@ The example files located in `graphql/TheSpaceDevs/` include:
     - Starts an MCP Server with the `--mcp` flag
     - Exposes the specified operations as MCP tools
 
-2. Open a browser and go to [`http://127.0.0.1:6274`](http://127.0.0.1:6274)
-
-3. In Inspector:
-    - Select `Streamable HTTP` as the Transport Type
-    - Enter `http://127.0.0.1:5000/mcp` as the URL
-    - Click **Connect**, then **List Tools**
-
-    You should see the tools from your server listed.
-
-## Step 4: Connect Claude Desktop
+## Step 3: Connect Claude Desktop
 
 We're using [Claude](https://claude.ai/download) as our AI Assistant (acting as our MCP Client).
 
 First, locate your Claude configuration file:
-<Tabs>
-    <Tab label="macOS">
-        `~/Library/Application Support/Claude/claude_desktop_config.json`
-    </Tab>
-    <Tab label="Windows">
-        `%APPDATA%\Claude\claude_desktop_config.json`
-    </Tab>
-    <Tab label="Linux">
-        `~/.config/Claude/claude_desktop_config.json`
-    </Tab>
-</Tabs>
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+- **Linux**: `~/.config/Claude/claude_desktop_config.json`
 
 Then add the following configuration
 
@@ -156,9 +102,9 @@ You need Node v18 or later installed for `mcp-remote` to work. If you have an ol
 
 </Note>
 
-2. Restart Claude.
+2. Restart Claude Desktop.
 
-## Step 5: Test Your Setup
+## Step 5: Test your setup
 
 Let's verify everything is working:
 
@@ -246,7 +192,7 @@ You can run the MCP Server using STDIO transport instead of Streamable HTTP. Thi
     --endpoint https://thespacedevs-production.up.railway.app/
     ```
 
-For MCP Inspector connections issues checkout the [user guide](/apollo-mcp-server/guides/#mcp-inspector-connection-issues).
+For MCP Inspector connection issues check out the [user guide](/apollo-mcp-server/guides/#mcp-inspector-connection-issues).
 
 3. Configure Claude Desktop to use STDIO:
 


### PR DESCRIPTION
Updating the quickstart docs to include:

1. Removing direct references to MCP Inspector except from the advanced options section.
2. Adding MCP connection issues excerpt to user guide where Debugging with MCP Inspector to mentioned.
3. Adding a link to this connection issues section to the Advanced Options in the quickstart.

The git repo cloning piece has remained since it is still fairly helpful for pulling down the sample files.