### PR TITLE
Fix client metadata extension name

### DIFF
--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -34,7 +34,7 @@ pub trait Executable {
     /// Execute as a GraphQL operation using the endpoint and headers
     async fn execute(&self, request: Request<'_>) -> Result<CallToolResult, McpError> {
         let client_metadata = serde_json::json!({
-            "type": "mcp",
+            "name": "mcp",
             "version": std::env!("CARGO_PKG_VERSION")
         });
 
@@ -51,7 +51,7 @@ pub trait Executable {
                         "version": 1,
                         "sha256Hash": id,
                     },
-                    "ApolloClientMetadata": client_metadata,
+                    "clientLibrary": client_metadata,
                 }),
             );
         } else {


### PR DESCRIPTION
I had used a client metadata key from an outdated doc. The actual extension name [used by the router](https://github.com/apollographql/router/blob/413ec9c4b25ec03705237b4ceb1215d8a4b17c44/apollo-router/src/plugins/enhanced_client_awareness/mod.rs#L13) is `clientLibrary` and the key is `name` instead of `type`.