### PR TITLE
Update to Rust MCP SDK version 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,7 @@ dependencies = [
  "apollo-compiler",
  "apollo-federation",
  "apollo-mcp-registry",
+ "axum",
  "bon",
  "clap",
  "futures",
@@ -2094,13 +2095,18 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.1.5"
-source = "git+https://github.com/modelcontextprotocol/rust-sdk.git?rev=915bc3fb37fe259fba1a853a9dd03566593f3310#915bc3fb37fe259fba1a853a9dd03566593f3310"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37f2048a81a7ff7e8ef6bc5abced70c3d9114c8f03d85d7aaaafd9fd04f12e9e"
 dependencies = [
  "axum",
  "base64",
+ "bytes",
  "chrono",
  "futures",
+ "http",
+ "http-body",
+ "http-body-util",
  "paste",
  "pin-project-lite",
  "rand",
@@ -2108,19 +2114,23 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "0.1.5"
-source = "git+https://github.com/modelcontextprotocol/rust-sdk.git?rev=915bc3fb37fe259fba1a853a9dd03566593f3310#915bc3fb37fe259fba1a853a9dd03566593f3310"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72398e694b9f6dbb5de960cf158c8699e6a1854cb5bbaac7de0646b2005763c4"
 dependencies = [
+ "darling",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -2471,6 +2481,19 @@ checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,3 @@ expect_used = "deny"
 indexing_slicing = "deny"
 unwrap_used = "deny"
 panic = "deny"
-
-[patch.crates-io]
-# The Rust MCP SDK has not had a release in a long time, so we need to depend on it through GitHub to pick up things
-# like Streamable HTTP support. This particular commit is pinned because it is before a change to the way shutdown is
-# handled through Axum which broke the ability to shut down the server with Ctrl-C.
-rmcp = { git = 'https://github.com/modelcontextprotocol/rust-sdk.git', rev = '915bc3fb37fe259fba1a853a9dd03566593f3310' }

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -10,13 +10,14 @@ anyhow = "1.0.98"
 apollo-compiler.workspace = true
 apollo-federation.workspace = true
 apollo-mcp-registry = { path = "../apollo-mcp-registry" }
+axum = "0.8.4"
 bon = "3.6.3"
 clap = { version = "4.5.36", features = ["derive", "env"] }
 futures.workspace = true
 lz-str = "0.2.1"
 regex = "1.11.1"
 reqwest.workspace = true
-rmcp = { version = "0.1", features = [
+rmcp = { version = "0.2", features = [
   "server",
   "transport-io",
   "transport-sse-server",

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -1,12 +1,11 @@
 use std::{net::SocketAddr, sync::Arc};
 
 use apollo_compiler::{Name, Schema, ast::OperationType, validation::Valid};
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::{StreamableHttpServerConfig, StreamableHttpService};
 use rmcp::{
     ServiceExt as _,
-    transport::{
-        SseServer, StreamableHttpServer, sse_server::SseServerConfig, stdio,
-        streamable_http_server::axum::StreamableHttpServerConfig,
-    },
+    transport::{SseServer, sse_server::SseServerConfig, stdio},
 };
 use tokio::sync::{Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -20,7 +19,7 @@ use crate::{
     server::Transport,
 };
 
-use super::{Config, Running};
+use super::{Config, Running, shutdown_signal};
 
 pub(super) struct Starting {
     pub(super) config: Config,
@@ -115,14 +114,19 @@ impl Starting {
                 info!(port = ?port, address = ?address, "Starting MCP server in Streamable HTTP mode");
                 let running = running.clone();
                 let listen_address = SocketAddr::new(address, port);
-                StreamableHttpServer::serve_with_config(StreamableHttpServerConfig {
-                    bind: listen_address,
-                    path: "/mcp".to_string(),
-                    ct: cancellation_token,
-                    sse_keep_alive: None,
-                })
-                .await?
-                .with_service(move || running.clone());
+                let service = StreamableHttpService::new(
+                    move || Ok(running.clone()),
+                    LocalSessionManager::default().into(),
+                    StreamableHttpServerConfig {
+                        sse_keep_alive: None,
+                        stateful_mode: true,
+                    },
+                );
+                let router = axum::Router::new().nest_service("/mcp", service);
+                let tcp_listener = tokio::net::TcpListener::bind(listen_address).await?;
+                axum::serve(tcp_listener, router)
+                    .with_graceful_shutdown(shutdown_signal())
+                    .await?;
             }
             Transport::SSE { address, port } => {
                 info!(port = ?port, address = ?address, "Starting MCP server in SSE mode");

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -1,8 +1,8 @@
 use std::{net::SocketAddr, sync::Arc};
 
 use apollo_compiler::{Name, Schema, ast::OperationType, validation::Valid};
+use rmcp::transport::StreamableHttpService;
 use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
-use rmcp::transport::{StreamableHttpServerConfig, StreamableHttpService};
 use rmcp::{
     ServiceExt as _,
     transport::{SseServer, sse_server::SseServerConfig, stdio},
@@ -117,10 +117,7 @@ impl Starting {
                 let service = StreamableHttpService::new(
                     move || Ok(running.clone()),
                     LocalSessionManager::default().into(),
-                    StreamableHttpServerConfig {
-                        sse_keep_alive: None,
-                        stateful_mode: true,
-                    },
+                    Default::default(),
                 );
                 let router = axum::Router::new().nest_service("/mcp", service);
                 let tcp_listener = tokio::net::TcpListener::bind(listen_address).await?;


### PR DESCRIPTION
There are new [2.x versions of the Rust MCP SDK](https://crates.io/crates/rmcp/versions). Update to the latest 2.x version.

Previously, we had pinned an old version of the SDK due to shutdown problems. But I think that was a mistake. With the latest SDK, pressing Ctrl+C will not work if there are open connections. But I believe this is likely the intended behavior. If you close all open connections, then Ctrl+C will work. The Apollo MCP Server has the same behavior here as the MCP SDK examples.

Also note that `stateful_mode` seems to affect this behavior. If `false`, it would exit the same as it did with previous SDK versions. But I'm setting `stateful_mode` to `true` here, since we'd want the advantages of stateful mode in the server.