### PR TITLE
Invalid operation should not crash the MCP Server

### DIFF
--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -13,7 +13,7 @@ use rmcp::{
 use serde_json::Value;
 use tokio::sync::{Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 
 use crate::{
     custom_scalar_map::CustomScalarMap,
@@ -68,7 +68,7 @@ impl Running {
                 ) {
                     Ok(operation) => operation,
                     Err(error) => {
-                        warn!("Invalid operation: {}", error);
+                        error!("Invalid operation: {}", error);
                         None
                     }
                 }
@@ -111,7 +111,7 @@ impl Running {
                     ) {
                         Ok(operation) => operation,
                         Err(error) => {
-                            warn!("Invalid operation: {}", error);
+                            error!("Invalid operation: {}", error);
                             None
                         }
                     }

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -10,7 +10,7 @@ use rmcp::{
 };
 use tokio::sync::{Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 use crate::{
     errors::ServerError,
@@ -45,7 +45,7 @@ impl Starting {
                 ) {
                     Ok(operation) => operation,
                     Err(error) => {
-                        warn!("Invalid operation: {}", error);
+                        error!("Invalid operation: {}", error);
                         None
                     }
                 }


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/GT-285 -->

Currently, the MCP server crashes when it encounters syntactically incorrect GraphQL operations. Since users can create such operations in Operation Collections or static files, this can lead to a frustrating experience and reliability issues in production. This PR implements graceful error handling by skipping invalid operations, ensuring that only valid ones are available.

## Testing

Given the following operation: 

```graphql
query GetAlerts($state: String!) {
  alerts(state: $state) {
    severity
    description
    instruction
  }

```

(Notice there is no closing curly bracket at the end.)

### Before: Invalid GraphQL operations crashed the entire MCP server

![Shot 2025-07-07 at 16 12 59](https://github.com/user-attachments/assets/baab0161-e7b0-4099-80f1-8c3cc9d6c02a)

### After: Invalid operations are logged and skipped, while the server continues running

![Shot 2025-07-07 at 16 13 56](https://github.com/user-attachments/assets/50b644b6-dcd8-4f27-af05-ab7851cecd04)

![Shot 2025-07-07 at 16 19 16](https://github.com/user-attachments/assets/e2b6c443-bc60-4266-9bcd-a276632d08b4)
