### PR TITLE
Fix an issue with rmcp 0.2.x upgrade

### DIFF
--- a/.changesets/fix_pubmodmatt_rmcp_2_fix.md
+++ b/.changesets/fix_pubmodmatt_rmcp_2_fix.md
@@ -1,0 +1,3 @@
+### Fix an issue with rmcp 0.2.x upgrade - @pubmodmatt PR #181
+
+Fix an issue where the server was unresponsive to external events such as changes to operation collections.

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -59,19 +59,16 @@ impl Running {
             .cloned()
             .map(|operation| operation.into_inner())
             .filter_map(|operation| {
-                match operation.into_operation(
+                operation.into_operation(
                     &schema,
                     self.custom_scalar_map.as_ref(),
                     self.mutation_mode,
                     self.disable_type_description,
                     self.disable_schema_description,
-                ) {
-                    Ok(operation) => operation,
-                    Err(error) => {
-                        error!("Invalid operation: {}", error);
-                        None
-                    }
-                }
+                ).unwrap_or_else(|error| {
+                    error!("Invalid operation: {}", error);
+                    None
+                })
             })
             .collect();
 
@@ -102,19 +99,16 @@ impl Running {
             let updated_operations: Vec<Operation> = operations
                 .into_iter()
                 .filter_map(|operation| {
-                    match operation.into_operation(
+                    operation.into_operation(
                         schema,
                         self.custom_scalar_map.as_ref(),
                         self.mutation_mode,
                         self.disable_type_description,
                         self.disable_schema_description,
-                    ) {
-                        Ok(operation) => operation,
-                        Err(error) => {
-                            error!("Invalid operation: {}", error);
-                            None
-                        }
-                    }
+                    ).unwrap_or_else(|error| {
+                        error!("Invalid operation: {}", error);
+                        None
+                    })
                 })
                 .collect();
 

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -59,16 +59,18 @@ impl Running {
             .cloned()
             .map(|operation| operation.into_inner())
             .filter_map(|operation| {
-                operation.into_operation(
-                    &schema,
-                    self.custom_scalar_map.as_ref(),
-                    self.mutation_mode,
-                    self.disable_type_description,
-                    self.disable_schema_description,
-                ).unwrap_or_else(|error| {
-                    error!("Invalid operation: {}", error);
-                    None
-                })
+                operation
+                    .into_operation(
+                        &schema,
+                        self.custom_scalar_map.as_ref(),
+                        self.mutation_mode,
+                        self.disable_type_description,
+                        self.disable_schema_description,
+                    )
+                    .unwrap_or_else(|error| {
+                        error!("Invalid operation: {}", error);
+                        None
+                    })
             })
             .collect();
 
@@ -99,16 +101,18 @@ impl Running {
             let updated_operations: Vec<Operation> = operations
                 .into_iter()
                 .filter_map(|operation| {
-                    operation.into_operation(
-                        schema,
-                        self.custom_scalar_map.as_ref(),
-                        self.mutation_mode,
-                        self.disable_type_description,
-                        self.disable_schema_description,
-                    ).unwrap_or_else(|error| {
-                        error!("Invalid operation: {}", error);
-                        None
-                    })
+                    operation
+                        .into_operation(
+                            schema,
+                            self.custom_scalar_map.as_ref(),
+                            self.mutation_mode,
+                            self.disable_type_description,
+                            self.disable_schema_description,
+                        )
+                        .unwrap_or_else(|error| {
+                            error!("Invalid operation: {}", error);
+                            None
+                        })
                 })
                 .collect();
 

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -35,16 +35,18 @@ impl Starting {
             .operations
             .into_iter()
             .filter_map(|operation| {
-                operation.into_operation(
-                    &self.schema,
-                    self.config.custom_scalar_map.as_ref(),
-                    self.config.mutation_mode,
-                    self.config.disable_type_description,
-                    self.config.disable_schema_description,
-                ).unwrap_or_else(|error| {
-                    error!("Invalid operation: {}", error);
-                    None
-                })
+                operation
+                    .into_operation(
+                        &self.schema,
+                        self.config.custom_scalar_map.as_ref(),
+                        self.config.mutation_mode,
+                        self.config.disable_type_description,
+                        self.config.disable_schema_description,
+                    )
+                    .unwrap_or_else(|error| {
+                        error!("Invalid operation: {}", error);
+                        None
+                    })
             })
             .collect();
 
@@ -121,15 +123,15 @@ impl Starting {
                 );
                 let router = axum::Router::new().nest_service("/mcp", service);
                 let tcp_listener = tokio::net::TcpListener::bind(listen_address).await?;
-                tokio::spawn(
-                    async move {
-                        if let Err(e) = axum::serve(tcp_listener, router)
-                            .with_graceful_shutdown(shutdown_signal())
-                            .await {
-                            // This can never really happen
-                            error!("Failed to start MCP server: {e:?}");
-                        }
-                    });
+                tokio::spawn(async move {
+                    if let Err(e) = axum::serve(tcp_listener, router)
+                        .with_graceful_shutdown(shutdown_signal())
+                        .await
+                    {
+                        // This can never really happen
+                        error!("Failed to start MCP server: {e:?}");
+                    }
+                });
             }
             Transport::SSE { address, port } => {
                 info!(port = ?port, address = ?address, "Starting MCP server in SSE mode");

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -121,9 +121,15 @@ impl Starting {
                 );
                 let router = axum::Router::new().nest_service("/mcp", service);
                 let tcp_listener = tokio::net::TcpListener::bind(listen_address).await?;
-                axum::serve(tcp_listener, router)
-                    .with_graceful_shutdown(shutdown_signal())
-                    .await?;
+                tokio::spawn(
+                    async move {
+                        if let Err(e) = axum::serve(tcp_listener, router)
+                            .with_graceful_shutdown(shutdown_signal())
+                            .await {
+                            // This can never really happen
+                            error!("Failed to start MCP server: {e:?}");
+                        }
+                    });
             }
             Transport::SSE { address, port } => {
                 info!(port = ?port, address = ?address, "Starting MCP server in SSE mode");

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -35,19 +35,16 @@ impl Starting {
             .operations
             .into_iter()
             .filter_map(|operation| {
-                match operation.into_operation(
+                operation.into_operation(
                     &self.schema,
                     self.config.custom_scalar_map.as_ref(),
                     self.config.mutation_mode,
                     self.config.disable_type_description,
                     self.config.disable_schema_description,
-                ) {
-                    Ok(operation) => operation,
-                    Err(error) => {
-                        error!("Invalid operation: {}", error);
-                        None
-                    }
-                }
+                ).unwrap_or_else(|error| {
+                    error!("Invalid operation: {}", error);
+                    None
+                })
             })
             .collect();
 


### PR DESCRIPTION
The changes to upgrade to rmcp 0.2.x caused the state machine to be blocked on startup, so no events could be processed until the axum server was shut down (for example, by Ctrl+C). Fix by spawning like the old 0.1.x method did.