### PR TITLE
Fix clientLibrary extension name

### DIFF
--- a/crates/apollo-mcp-registry/src/uplink.rs
+++ b/crates/apollo-mcp-registry/src/uplink.rs
@@ -396,6 +396,8 @@ where
     let res = client
         .post(url)
         .header("x-apollo-mcp-server-version", env!("CARGO_PKG_VERSION"))
+        .header("apollographql-client-name", "apollo-mcp-server")
+        .header("apollographql-client-version", env!("CARGO_PKG_VERSION"))
         .json(request_body)
         .send()
         .await

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -64,7 +64,7 @@ pub trait Executable {
             request_body.insert(
                 String::from("extensions"),
                 serde_json::json!({
-                    "ApolloClientMetadata": client_metadata,
+                    "clientLibrary": client_metadata,
                 }),
             );
 


### PR DESCRIPTION
A previous fix to the `clientLibrary` extension name only fixed one of two cases. This should allow GraphQL requests through the Apollo Router to be reported as coming from the Apollo MCP Server.

Additionally, set the correct headers on the uplink request, such that uplink requests from the Apollo MCP Server can be identified.