### PR TITLE
docs: simplify operations configuration

### DIFF
--- a/docs/source/guides/index.mdx
+++ b/docs/source/guides/index.mdx
@@ -208,7 +208,7 @@ npx @modelcontextprotocol/inspector \
   target/debug/apollo-mcp-server \
   --directory <absolute path to this git repo> \
   --schema graphql/weather/api.graphql \
-  --operations graphql/weather/operations/forecast.graphql graphql/weather/operations/alerts.graphql graphql/weather/operations/all.graphql
+  --operations graphql/weather/operations
 ```
 
 <ExpansionPanel title="Example output">
@@ -240,7 +240,7 @@ target/debug/apollo-mcp-server \
   --directory <absolute path to this git repo> \
   --http-port 5000 \
   --schema graphql/weather/api.graphql \
-  --operations graphql/weather/operations/forecast.graphql graphql/weather/operations/alerts.graphql graphql/weather/operations/all.graphql
+  --operations graphql/weather/operations
 ```
 
 1. Start the MCP Inspector:

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -61,7 +61,7 @@ The example files located in `graphql/TheSpaceDevs/` include:
     ```sh showLineNumbers=false
     rover dev --supergraph-config ./graphql/TheSpaceDevs/supergraph.yaml \
     --mcp \
-    --mcp-operations ./graphql/TheSpaceDevs/operations/ExploreCelestialBodies.graphql ./graphql/TheSpaceDevs/operations/GetAstronautDetails.graphql ./graphql/TheSpaceDevs/operations/GetAstronautsCurrentlyInSpace.graphql ./graphql/TheSpaceDevs/operations/SearchUpcomingLaunches.graphql
+    --mcp-operations ./graphql/TheSpaceDevs/operations 
     ```
 
     This command:


### PR DESCRIPTION
No one would want to list every operation file manually when they can simply give the folder that contains them. 😁