### PR TITLE
release: v0.5.2

### DIFF
--- a/.changesets/fix_pubmodmatt_server_info.md
+++ b/.changesets/fix_pubmodmatt_server_info.md
@@ -1,3 +1,0 @@
-### Fix ServerInfo - @pubmodmatt PR #183
-
-The server will now report the correct server name and version to clients, rather than the Rust MCP SDK name and version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [0.5.2] - 2025-07-10
+
+## 🐛 Fixes
+
+### Fix ServerInfo - @pubmodmatt PR #183
+
+The server will now report the correct server name and version to clients, rather than the Rust MCP SDK name and version.
+
+
+
 # [0.5.1] - 2025-07-08
 
 ## 🐛 Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-mcp-registry"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "derivative",
  "derive_more 2.0.1",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-mcp-server"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "apollo-compiler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/apollo-mcp-server", "crates/apollo-mcp-registry"]
 
 [workspace.package]
 authors = ["Apollo <opensource@apollographql.com>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [workspace.dependencies]
 apollo-compiler = "1.27.0"

--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -26,7 +26,7 @@ To download a **specific version** of Apollo MCP Server (recommended for CI envi
 
 ```bash
 # Note the `v` prefixing the version number
-docker image pull ghcr.io/apollographql/apollo-mcp-server:v0.5.1
+docker image pull ghcr.io/apollographql/apollo-mcp-server:v0.5.2
 ```
 
 To download a specific version of Apollo MCP Server that is a release candidate:
@@ -65,7 +65,7 @@ To install or upgrade to a **specific version** of Apollo MCP Server (recommende
 
 ```bash
 # Note the `v` prefixing the version number
-curl -sSL https://mcp.apollo.dev/download/nix/v0.5.1| sh
+curl -sSL https://mcp.apollo.dev/download/nix/v0.5.2| sh
 ```
 
 If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
@@ -82,7 +82,7 @@ To install or upgrade to a **specific version** of Apollo MCP Server (recommende
 
 ```bash
 # Note the `v` prefixing the version number
-iwr 'https://mcp.apollo.dev/download/win/v0.5.1' | iex
+iwr 'https://mcp.apollo.dev/download/win/v0.5.2' | iex
 ```
 
 ## Usage

--- a/scripts/nix/install.sh
+++ b/scripts/nix/install.sh
@@ -14,7 +14,7 @@ BINARY_DOWNLOAD_PREFIX="${APOLLO_MCP_SERVER_BINARY_DOWNLOAD_PREFIX:="https://git
 
 # Apollo MCP Server version defined in apollo-mcp-server's Cargo.toml
 # Note: Change this line manually during the release steps.
-PACKAGE_VERSION="v0.5.1"
+PACKAGE_VERSION="v0.5.2"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -8,7 +8,7 @@
 
 # Apollo MCP Server version defined in apollo-mcp-server's Cargo.toml
 # Note: Change this line manually during the release steps.
-$package_version = 'v0.5.1'
+$package_version = 'v0.5.2'
 
 function Install-Binary($apollo_mcp_server_install_args) {
   $old_erroractionpreference = $ErrorActionPreference


### PR DESCRIPTION
# [0.5.2] - 2025-07-10

## 🐛 Fixes

### Fix ServerInfo - @pubmodmatt PR #183

The server will now report the correct server name and version to clients, rather than the Rust MCP SDK name and version.