### PR TITLE
Gt 167 log to a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .idea/*
 
+logs/*
+
 # Let run configurations be unignored so they can be shared if desired
 !.idea/runConfigurations/
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,6 @@ dependencies = [
  "bon",
  "clap",
  "futures",
- "home",
  "insta",
  "lz-str",
  "regex",
@@ -1133,15 +1132,6 @@ name = "hermit-abi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "http"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,7 @@ dependencies = [
  "bon",
  "clap",
  "futures",
+ "home",
  "insta",
  "lz-str",
  "regex",
@@ -219,6 +220,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "tracing-test",
  "url",
@@ -604,6 +606,21 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -1116,6 +1133,15 @@ name = "hermit-abi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "http"
@@ -2666,12 +2692,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -2679,6 +2707,16 @@ name = "time-core"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -2807,6 +2845,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ tokio-stream = "0.1"
 tracing = "0.1.41"
 tracing-core = "0.1.33"
 tracing-subscriber = { version = "0.3.19", features = ["json"] }
+tracing-appender = "0.2.3"
 url = "2.4"
 
 [workspace.metadata]

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -29,8 +29,10 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-appender.workspace = true
 tokio-util = "0.7.15"
 url.workspace = true
+home = "0.5.11"
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -32,7 +32,6 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tracing-appender.workspace = true
 tokio-util = "0.7.15"
 url.workspace = true
-home = "0.5.11"
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/apollo-mcp-server/src/lib.rs
+++ b/crates/apollo-mcp-server/src/lib.rs
@@ -5,6 +5,7 @@ mod explorer;
 mod graphql;
 mod introspection;
 pub mod json_schema;
+pub mod logging;
 pub mod operations;
 pub mod sanitize;
 pub(crate) mod schema_tree_shake;

--- a/crates/apollo-mcp-server/src/logging.rs
+++ b/crates/apollo-mcp-server/src/logging.rs
@@ -4,8 +4,8 @@ use std::sync::{Arc, Mutex};
 use tracing::Level;
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
-use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::EnvFilter;
+use tracing_subscriber::fmt::MakeWriter;
 
 enum LogDestination {
     File(Arc<Mutex<NonBlocking>>),
@@ -31,7 +31,7 @@ impl<'a> MakeWriter<'a> for LogWriter {
 }
 
 fn build_log_writer(
-    log_path: String
+    log_path: String,
 ) -> (
     impl for<'a> MakeWriter<'a> + Send + Sync + 'static,
     bool,
@@ -62,9 +62,7 @@ fn build_log_writer(
 
             (writer, false, Some(guard))
         }
-        Err(_) => {
-            (fallback_writer, true, None)
-        }
+        Err(_) => (fallback_writer, true, None),
     }
 }
 

--- a/crates/apollo-mcp-server/src/logging.rs
+++ b/crates/apollo-mcp-server/src/logging.rs
@@ -1,0 +1,83 @@
+use std::fs;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use tracing::Level;
+use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
+use tracing_appender::rolling::{RollingFileAppender, Rotation};
+use tracing_subscriber::fmt::MakeWriter;
+use tracing_subscriber::EnvFilter;
+
+enum LogDestination {
+    File(Arc<Mutex<NonBlocking>>),
+    Stderr,
+}
+
+struct LogWriter {
+    destination: LogDestination,
+}
+
+impl<'a> MakeWriter<'a> for LogWriter {
+    type Writer = Box<dyn std::io::Write + Send + Sync>;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        match &self.destination {
+            LogDestination::File(tracing_appender) => match tracing_appender.lock() {
+                Ok(tracing_appender) => Box::new(tracing_appender.clone()),
+                Err(_) => Box::new(std::io::stderr()),
+            },
+            LogDestination::Stderr => Box::new(std::io::stderr()),
+        }
+    }
+}
+
+fn build_log_writer(
+    log_path: String
+) -> (
+    impl for<'a> MakeWriter<'a> + Send + Sync + 'static,
+    bool,
+    Option<WorkerGuard>,
+) {
+    let fallback_writer = LogWriter {
+        destination: LogDestination::Stderr,
+    };
+
+    let log_dir = Path::new(log_path.as_str());
+
+    println!("Creating log dir: {:?}", log_dir);
+    if let Err(e) = fs::create_dir_all(log_dir) {
+        eprintln!("Failed to create log directory: {}", e);
+        return (fallback_writer, true, None);
+    }
+
+    match RollingFileAppender::builder()
+        .rotation(Rotation::NEVER)
+        .filename_prefix("apollo_mcp_server")
+        .filename_suffix("log")
+        .build(log_path)
+    {
+        Ok(file_appender) => {
+            let (non_blocking_writer, guard) = tracing_appender::non_blocking(file_appender);
+            let writer = LogWriter {
+                destination: LogDestination::File(Arc::new(Mutex::new(non_blocking_writer))),
+            };
+
+            (writer, false, Some(guard))
+        }
+        Err(e) => {
+            eprintln!("{:?}", e);
+            (fallback_writer, true, None)
+        }
+    }
+}
+
+pub fn setup_logging(log_path: String, log_level: Level) -> Option<WorkerGuard> {
+    let (log_writer, has_ansi, guard) = build_log_writer(log_path);
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive(log_level.into()))
+        .with_writer(log_writer)
+        .with_ansi(has_ansi)
+        .with_target(false)
+        .init();
+
+    guard
+}

--- a/crates/apollo-mcp-server/src/logging.rs
+++ b/crates/apollo-mcp-server/src/logging.rs
@@ -43,7 +43,6 @@ fn build_log_writer(
 
     let log_dir = Path::new(log_path.as_str());
 
-    println!("Creating log dir: {:?}", log_dir);
     if let Err(e) = fs::create_dir_all(log_dir) {
         eprintln!("Failed to create log directory: {}", e);
         return (fallback_writer, true, None);
@@ -63,8 +62,7 @@ fn build_log_writer(
 
             (writer, false, Some(guard))
         }
-        Err(e) => {
-            eprintln!("{:?}", e);
+        Err(_) => {
             (fallback_writer, true, None)
         }
     }

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -19,9 +19,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
 use std::{env};
-use std::env::home_dir;
 use tracing::{Level, info};
-use tracing_subscriber::EnvFilter;
 use url::{ParseError, Url};
 
 /// Clap styling

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -14,11 +14,11 @@ use clap::builder::Styles;
 use clap::builder::styling::{AnsiColor, Effects};
 use clap::{ArgAction, Parser};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use std::env;
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
-use std::{env};
 use tracing::{Level, info};
 use url::{ParseError, Url};
 


### PR DESCRIPTION
Add support for logging to a file. Defaults to `./logs` if a path is not given using the new `--out` argument. On any failure setting up the rolling file appender than logging fallbacks to stderr.