### PR TITLE
feat: adding apollo-mcp-proxy crate and config values for it

### DIFF
--- a/.idea/runConfigurations/Run_spacedevs.xml
+++ b/.idea/runConfigurations/Run_spacedevs.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run spacedevs" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
-    <option name="command" value="run --package apollo-mcp-server --bin apollo-mcp-server -- --operations graphql/TheSpaceDevs/operations --schema graphql/TheSpaceDevs/api.graphql" />
+    <option name="command" value="run --package apollo-mcp-server --bin apollo-mcp-server -- ./graphql/TheSpaceDevs/config.yaml" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="true" />

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "apollo-mcp-proxy"
+version = "0.5.2"
+dependencies = [
+ "axum",
+ "clap",
+ "rmcp",
+ "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "apollo-mcp-registry"
 version = "0.5.2"
 dependencies = [
@@ -202,6 +215,7 @@ dependencies = [
  "anyhow",
  "apollo-compiler",
  "apollo-federation",
+ "apollo-mcp-proxy",
  "apollo-mcp-registry",
  "apollo-schema-index",
  "axum",
@@ -518,6 +532,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -544,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -556,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -1130,8 +1150,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1141,9 +1163,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1360,6 +1384,23 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
@@ -1598,6 +1639,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,6 +1823,12 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.3",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz-str"
@@ -2294,6 +2352,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand 0.9.1",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.12",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,6 +2604,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -2501,21 +2615,41 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
+ "webpki-roots 0.26.11",
  "windows-registry",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2535,6 +2669,7 @@ dependencies = [
  "paste",
  "pin-project-lite",
  "rand 0.9.1",
+ "reqwest",
  "rmcp-macros",
  "schemars 0.8.22",
  "serde",
@@ -2668,6 +2803,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2682,7 +2831,19 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3037,6 +3198,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3358,17 +3525,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.45.0"
+name = "tinyvec"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.46.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -3392,6 +3576,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+dependencies = [
+ "rustls",
  "tokio",
 ]
 
@@ -3474,6 +3668,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3640,6 +3846,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3803,6 +4015,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3810,6 +4035,34 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.1",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3845,15 +4098,15 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-strings 0.4.0",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -3880,9 +4133,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-registry"
@@ -3897,9 +4150,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
@@ -3915,9 +4168,9 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/apollo-mcp-server",
   "crates/apollo-mcp-registry",
   "crates/apollo-schema-index",
+  "crates/apollo-mcp-proxy",
 ]
 
 [workspace.package]
@@ -13,6 +14,7 @@ version = "0.5.2"
 [workspace.dependencies]
 apollo-compiler = "1.27.0"
 apollo-federation = "2.1.3"
+axum = "0.8.4"
 futures = { version = "0.3.31", features = ["thread-pool"] }
 insta = { version = "1.43.1", features = [
   "json",
@@ -24,6 +26,12 @@ reqwest = { version = "0.12.15", default-features = false, features = [
   "gzip",
   "json",
   "native-tls-vendored",
+] }
+rmcp = { version = "0.2", features = [
+  "server",
+  "transport-io",
+  "transport-sse-server",
+  "transport-streamable-http-server",
 ] }
 rstest = "0.25.0"
 secrecy = { version = "0.10.3", features = ["serde"] }

--- a/crates/apollo-mcp-proxy/Cargo.toml
+++ b/crates/apollo-mcp-proxy/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "apollo-mcp-proxy"
+edition = "2024"
+authors.workspace = true
+version.workspace = true
+
+[dependencies]
+axum.workspace = true
+clap = { version = "4.5.40", features = ["derive"] }
+tokio.workspace = true
+rmcp = { workspace = true, features = [
+    "client",
+    "reqwest",
+    "transport-streamable-http-client",
+]}
+tracing.workspace = true
+tracing-appender = "0.2.3"
+tracing-subscriber.workspace = true
+
+[lints]
+workspace = true

--- a/crates/apollo-mcp-proxy/src/client.rs
+++ b/crates/apollo-mcp-proxy/src/client.rs
@@ -1,0 +1,42 @@
+use crate::server::ProxyServer;
+use rmcp::transport::stdio;
+use rmcp::{
+    ServiceExt,
+    model::{ClientCapabilities, ClientInfo, Implementation},
+    transport::StreamableHttpClientTransport,
+};
+use std::error::Error;
+use tracing::{debug, error, info};
+
+pub async fn start_proxy_client(url: &str) -> Result<(), Box<dyn Error>> {
+    let transport = StreamableHttpClientTransport::from_uri(url);
+    let client_info = ClientInfo {
+        protocol_version: Default::default(),
+        capabilities: ClientCapabilities::default(),
+        client_info: Implementation {
+            name: "mcp remote rust client".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        },
+    };
+
+    let client = match client_info.serve(transport).await.inspect_err(|e| {
+        error!("[Proxy] client error: {:?}", e);
+    }) {
+        Ok(client) => client,
+        Err(e) => {
+            error!("[Proxy] client startup error: {:?}", e);
+            return Err(e.into());
+        }
+    };
+
+    let server_info = client.peer_info();
+    info!("[Proxy] Connected to server");
+    debug!("{server_info:#?}");
+
+    let proxy_server = ProxyServer::new(client.peer().clone(), client.peer_info());
+    let stdio_transport = stdio();
+    let server = proxy_server.serve(stdio_transport).await?;
+
+    server.waiting().await?;
+    Ok(())
+}

--- a/crates/apollo-mcp-proxy/src/lib.rs
+++ b/crates/apollo-mcp-proxy/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod client;
+
+pub mod server;

--- a/crates/apollo-mcp-proxy/src/main.rs
+++ b/crates/apollo-mcp-proxy/src/main.rs
@@ -1,0 +1,34 @@
+use clap::Parser;
+use apollo_mcp_proxy::client::start_proxy_client;
+use std::error::Error;
+use tracing_appender::rolling::{RollingFileAppender, Rotation};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+#[derive(Parser)]
+struct Args {
+    #[arg(short, long)]
+    url: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // Initialize logging
+    let file_appender = RollingFileAppender::builder()
+        .rotation(Rotation::NEVER)
+        .filename_prefix("apollo_mcp_proxy")
+        .filename_suffix("log")
+        .build("./logs")?;
+
+    let (non_blocking_writer, _guard) = tracing_appender::non_blocking(file_appender);
+
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().with_writer(non_blocking_writer))
+        .init();
+
+    let args = Args::parse();
+
+    let _ = start_proxy_client(&args.url).await;
+
+    Ok(())
+}

--- a/crates/apollo-mcp-proxy/src/server.rs
+++ b/crates/apollo-mcp-proxy/src/server.rs
@@ -1,0 +1,339 @@
+use rmcp::model::{
+    CallToolRequestParam, CallToolResult, Content, GetPromptRequestParam, GetPromptResult,
+    Implementation, InitializeRequestParam, InitializeResult, ListPromptsResult,
+    ListResourceTemplatesResult, ListResourcesResult, ListToolsResult, PaginatedRequestParam,
+    ReadResourceRequestParam, ReadResourceResult, ServerInfo,
+};
+use rmcp::service::{NotificationContext, RequestContext};
+use rmcp::{Error as McpError, Peer, RoleClient, RoleServer, ServerHandler};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tracing::{debug, error, info};
+
+pub struct ProxyServer {
+    client: Arc<Mutex<Peer<RoleClient>>>,
+    server_info: Arc<ServerInfo>,
+}
+
+impl ProxyServer {
+    pub fn new(client_peer: Peer<RoleClient>, peer_info: Option<&ServerInfo>) -> Self {
+        let mut server_info = ServerInfo::default();
+
+        if let Some(info) = peer_info {
+            server_info = ServerInfo {
+                protocol_version: info.protocol_version.clone(),
+                server_info: Implementation {
+                    name: info.server_info.name.clone(),
+                    version: info.server_info.version.clone(),
+                },
+                instructions: info.instructions.clone(),
+                capabilities: info.capabilities.clone(),
+            };
+        }
+
+        debug!("[Proxy]server info: {:?}", server_info);
+
+        Self {
+            client: Arc::new(Mutex::new(client_peer)),
+            server_info: Arc::new(server_info),
+        }
+    }
+}
+
+impl ServerHandler for ProxyServer {
+    async fn initialize(
+        &self,
+        _request: InitializeRequestParam,
+        context: RequestContext<RoleServer>,
+    ) -> Result<InitializeResult, McpError> {
+        if let Some(http_request_part) = context.extensions.get::<axum::http::request::Parts>() {
+            let initialize_headers = &http_request_part.headers;
+            let initialize_uri = &http_request_part.uri;
+            info!(?initialize_headers, %initialize_uri, "initialize from http server");
+        }
+
+        Ok(self.get_info())
+    }
+
+    async fn complete(
+        &self,
+        request: rmcp::model::CompleteRequestParam,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<rmcp::model::CompleteResult, McpError> {
+        let client = self.client.clone();
+        let guard = client.lock().await;
+
+        match guard.complete(request).await {
+            Ok(result) => {
+                debug!("[Proxy] Proxying complete response");
+                Ok(result)
+            }
+            Err(err) => {
+                error!("[Proxy] Error completing: {:?}", err);
+                Err(McpError::internal_error(
+                    format!("Error completing: {err}"),
+                    None,
+                ))
+            }
+        }
+    }
+
+    async fn get_prompt(
+        &self,
+        request: GetPromptRequestParam,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<GetPromptResult, McpError> {
+        if self.server_info.capabilities.prompts.is_none() {
+            error!("[Proxy] Server doesn't support the prompts capability");
+            return Err(McpError::internal_error(
+                "Server doesn't support the prompts capability".to_string(),
+                None,
+            ));
+        }
+
+        let client = self.client.clone();
+        let guard = client.lock().await;
+
+        match guard.get_prompt(request).await {
+            Ok(result) => {
+                debug!("[Proxy] Proxying get_prompt response");
+                Ok(result)
+            }
+            Err(err) => {
+                error!("[Proxy] Error getting prompt: {:?}", err);
+                Err(McpError::internal_error(
+                    format!("Error getting prompt: {err}"),
+                    None,
+                ))
+            }
+        }
+    }
+
+    async fn list_prompts(
+        &self,
+        request: Option<PaginatedRequestParam>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListPromptsResult, McpError> {
+        if self.server_info.capabilities.prompts.is_none() {
+            error!("[Proxy] Server doesn't support the prompts capability");
+            return Err(McpError::internal_error(
+                "Server doesn't support the prompts capability".to_string(),
+                None,
+            ));
+        }
+
+        let client = self.client.clone();
+        let guard = client.lock().await;
+
+        match guard.list_prompts(request).await {
+            Ok(result) => {
+                debug!("[Proxy] Proxying list_prompts response");
+                Ok(result)
+            }
+            Err(err) => {
+                error!("[Proxy] Error listing prompts: {:?}", err);
+                Ok(ListPromptsResult::default())
+            }
+        }
+    }
+
+    async fn list_resources(
+        &self,
+        request: Option<PaginatedRequestParam>,
+        _: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, McpError> {
+        if self.server_info.capabilities.resources.is_none() {
+            error!("[Proxy] Server doesn't support the resources capability");
+            return Err(McpError::internal_error(
+                "Server doesn't support the resources capability".to_string(),
+                None,
+            ));
+        }
+
+        let client_guard = self.client.lock().await;
+
+        match client_guard.list_resources(request).await {
+            Ok(list_resources_result) => {
+                debug!(
+                    "Proxying list_resources response: {:?}",
+                    list_resources_result
+                );
+                Ok(list_resources_result)
+            }
+            Err(e) => {
+                error!("[Proxy] Error listing resources: {:?}", e);
+                Ok(ListResourcesResult::default())
+            }
+        }
+    }
+
+    async fn list_resource_templates(
+        &self,
+        request: Option<PaginatedRequestParam>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourceTemplatesResult, McpError> {
+        if self.server_info.capabilities.resources.is_none() {
+            error!("[Proxy] Server doesn't support the resources capability");
+            return Err(McpError::internal_error(
+                "Server doesn't support the resources capability".to_string(),
+                None,
+            ));
+        }
+
+        let client = self.client.clone();
+        let guard = client.lock().await;
+
+        // TODO: Check if the server has resources capability and forward the request
+        match guard.list_resource_templates(request).await {
+            Ok(list_resource_templates_result) => {
+                debug!(
+                    "Proxying list_resource_templates response: {:?}",
+                    list_resource_templates_result
+                );
+                Ok(list_resource_templates_result)
+            }
+            Err(err) => {
+                error!("[Proxy] Error listing resource templates: {:?}", err);
+                Ok(ListResourceTemplatesResult::default())
+            }
+        }
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParam,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, McpError> {
+        if self.server_info.capabilities.resources.is_none() {
+            error!("[Proxy] Server doesn't support the resources capability");
+            return Err(McpError::internal_error(
+                "Server doesn't support the resources capability".to_string(),
+                None,
+            ));
+        }
+
+        let client = self.client.clone();
+        let guard = client.lock().await;
+
+        // TODO: Check if the server has resources capability and forward the request
+        match guard
+            .read_resource(ReadResourceRequestParam {
+                uri: request.uri.clone(),
+            })
+            .await
+        {
+            Ok(result) => {
+                debug!(
+                    "Proxying read_resource response for {}: {:?}",
+                    request.uri, result
+                );
+                Ok(result)
+            }
+            Err(err) => {
+                error!("[Proxy] Error reading resource: {:?}", err);
+                Err(McpError::internal_error(
+                    format!("Error reading resource: {err}"),
+                    None,
+                ))
+            }
+        }
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParam,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        if self.server_info.capabilities.tools.is_none() {
+            error!("[Proxy] Server doesn't support the tools capability");
+            return Err(McpError::internal_error(
+                "Server doesn't support the tools capability".to_string(),
+                None,
+            ));
+        }
+
+        let client = self.client.clone();
+        let guard = client.lock().await;
+
+        match guard.call_tool(request.clone()).await {
+            Ok(result) => {
+                debug!("[Proxy] Tool call succeeded: {:?}", result);
+                Ok(result)
+            }
+            Err(err) => {
+                error!("[Proxy] Error calling tool: {:?}", err);
+                Ok(CallToolResult::error(vec![Content::text(format!("Error: {err}"))]))
+            }
+        }
+    }
+
+    async fn list_tools(
+        &self,
+        request: Option<PaginatedRequestParam>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        if self.server_info.capabilities.tools.is_none() {
+            error!("[Proxy] Server doesn't support the tools capability");
+            return Err(McpError::internal_error(
+                "Server doesn't support the tools capability".to_string(),
+                None,
+            ));
+        }
+
+        let client = self.client.clone();
+        let guard = client.lock().await;
+
+        match guard.list_tools(request).await {
+            Ok(result) => {
+                debug!(
+                    "Proxying list_tools response with {} tools: {:?}",
+                    result.tools.len(),
+                    result
+                );
+                Ok(result)
+            }
+            Err(err) => {
+                error!("[Proxy] Error listing tools: {:?}", err);
+                Ok(ListToolsResult::default())
+            }
+        }
+    }
+
+    async fn on_cancelled(
+        &self,
+        notification: rmcp::model::CancelledNotificationParam,
+        _context: NotificationContext<RoleServer>,
+    ) {
+        let client = self.client.clone();
+        let guard = client.lock().await;
+        match guard.notify_cancelled(notification).await {
+            Ok(_) => {
+                debug!("[Proxy] Proxying cancelled notification");
+            }
+            Err(err) => {
+                error!("[Proxy] Error notifying cancelled: {:?}", err);
+            }
+        }
+    }
+
+    async fn on_progress(
+        &self,
+        notification: rmcp::model::ProgressNotificationParam,
+        _context: NotificationContext<RoleServer>,
+    ) {
+        let client = self.client.clone();
+        let guard = client.lock().await;
+        match guard.notify_progress(notification).await {
+            Ok(_) => {
+                debug!("[Proxy] Proxying progress notification");
+            }
+            Err(err) => {
+                error!("[Proxy] Error notifying progress: {:?}", err);
+            }
+        }
+    }
+
+    fn get_info(&self) -> ServerInfo {
+        self.server_info.as_ref().clone()
+    }
+}

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -11,7 +11,8 @@ apollo-compiler.workspace = true
 apollo-federation.workspace = true
 apollo-mcp-registry = { path = "../apollo-mcp-registry" }
 apollo-schema-index = { path = "../apollo-schema-index" }
-axum = "0.8.4"
+apollo-mcp-proxy = { path = "../apollo-mcp-proxy" }
+axum.workspace = true
 bon = "3.6.3"
 clap = { version = "4.5.36", features = ["derive", "env"] }
 figment = { version = "0.10.19", features = ["env", "yaml"] }
@@ -19,12 +20,7 @@ futures.workspace = true
 lz-str = "0.2.1"
 regex = "1.11.1"
 reqwest.workspace = true
-rmcp = { version = "0.2", features = [
-  "server",
-  "transport-io",
-  "transport-sse-server",
-  "transport-streamable-http-server",
-] }
+rmcp.workspace = true
 schemars = { version = "1.0.1", features = ["url2"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -14,6 +14,7 @@ use clap::builder::styling::{AnsiColor, Effects};
 use runtime::IdOrDefault;
 use tracing::{Level, info, warn};
 use tracing_subscriber::EnvFilter;
+use apollo_mcp_proxy::client::start_proxy_client;
 
 mod runtime;
 
@@ -130,8 +131,8 @@ async fn main() -> anyhow::Result<()> {
         .then(|| config.graphos.graph_ref())
         .transpose()?;
 
-    Ok(Server::builder()
-        .transport(config.transport)
+    let mcp_server = Server::builder()
+        .transport(config.transport.clone())
         .schema_source(schema_source)
         .operation_source(operation_source)
         .endpoint(config.endpoint)
@@ -150,6 +151,24 @@ async fn main() -> anyhow::Result<()> {
                 .transpose()?,
         )
         .build()
-        .start()
-        .await?)
+        .start();
+
+    match config.transport {
+        Transport::StreamableHttp { proxy, proxy_endpoint, .. } => {
+            if proxy {
+                let mut endpoint = proxy_endpoint;
+                if !endpoint.starts_with("http") {
+                    endpoint = format!("http://{endpoint}");
+                }
+                
+                let proxy_client = start_proxy_client(endpoint.as_str());
+                let (_, _ ) = tokio::join!(mcp_server, proxy_client);
+            } else {
+                mcp_server.await?;
+            }
+        }
+        _ => { mcp_server.await?; }
+    }
+
+    Ok(())
 }

--- a/crates/apollo-mcp-server/src/server.rs
+++ b/crates/apollo-mcp-server/src/server.rs
@@ -63,6 +63,14 @@ pub enum Transport {
         /// The port to bind to
         #[serde(default = "Transport::default_port")]
         port: u16,
+
+        /// Flag indicating whether to spin up a proxy server
+        #[serde(default = "Transport::default_proxy")]
+        proxy: bool,
+
+        /// Proxy server endpoint
+        #[serde(default = "Transport::default_proxy_endpoint")]
+        proxy_endpoint: String,
     },
 }
 
@@ -73,6 +81,14 @@ impl Transport {
 
     fn default_port() -> u16 {
         5000
+    }
+
+    fn default_proxy() -> bool {
+        false
+    }
+
+    fn default_proxy_endpoint() -> String {
+        format!("http://{}:{}/mcp", Self::default_address(), Self::default_port())
     }
 }
 

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -121,7 +121,7 @@ impl Starting {
         };
 
         match self.config.transport {
-            Transport::StreamableHttp { address, port } => {
+            Transport::StreamableHttp { address, port, .. } => {
                 info!(port = ?port, address = ?address, "Starting MCP server in Streamable HTTP mode");
                 let running = running.clone();
                 let listen_address = SocketAddr::new(address, port);


### PR DESCRIPTION
Adding an MCP proxy crate that brings in a proxy server that can be run standalone or as part of a binary. The proxy server will proxy communication between a locally running MCP server and a client.

1. Added new crate and moved some dependencies to the workspace level.
2. Imported crate to apollo-mcp-server and added config values for proxy and proxy endpoint.
3. If proxy is enabled, starting up the proxy client along with the MCP server.