### PR TITLE
Update links in Quickstart's `Next steps`

### DIFF
--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -181,11 +181,11 @@ If you're still having issues:
 ## Next Steps
 
 See the [user guide](/apollo-mcp-server/guides) to learn how to create tools from:
-- [Operation schema files](/apollo-mcp-server/guides#from-operation-schema-files)
+- [Operation schema files](/apollo-mcp-server/guides#from-operation-files)
 - [Persisted query manifests](/apollo-mcp-server/guides/#from-persisted-query-manifests)
 - [Schema introspection](/apollo-mcp-server/guides/#from-schema-introspection)
 
-When you are ready, [deploy the MCP server](https://www.apollographql.com/docs/apollo-mcp-server/guides#deploying-the-MCP-server).
+When you are ready, [deploy the MCP server](https://www.apollographql.com/docs/apollo-mcp-server/guides#deploying-the-mcp-server).
 
 ### Additional Resources
 

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -236,4 +236,3 @@ You can run the MCP Server using STDIO transport instead of Streamable HTTP. Thi
     ```
   
 </details>
-

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -181,7 +181,7 @@ If you're still having issues:
 ## Next Steps
 
 See the [user guide](/apollo-mcp-server/guides) to learn how to create tools from:
-- [Operation schema files](/apollo-mcp-server/guides#from-operation-files)
+- [Operation files](/apollo-mcp-server/guides#from-operation-files)
 - [Persisted query manifests](/apollo-mcp-server/guides/#from-persisted-query-manifests)
 - [Schema introspection](/apollo-mcp-server/guides/#from-schema-introspection)
 

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -181,7 +181,7 @@ If you're still having issues:
 ## Next Steps
 
 See the [user guide](/apollo-mcp-server/guides) to learn how to create tools from:
-- [Operation files](/apollo-mcp-server/guides#from-operation-files)
+- [Operation schema files](/apollo-mcp-server/guides#from-operation-files)
 - [Persisted query manifests](/apollo-mcp-server/guides/#from-persisted-query-manifests)
 - [Schema introspection](/apollo-mcp-server/guides/#from-schema-introspection)
 

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -236,3 +236,4 @@ You can run the MCP Server using STDIO transport instead of Streamable HTTP. Thi
     ```
   
 </details>
+


### PR DESCRIPTION
## What changed?

This (tiny) PR:

1. Updates a couple of links located in the [Next steps section of our MCP quickstart](https://www.apollographql.com/docs/apollo-mcp-server/quickstart#next-steps) that are currently not behaving as expected:
a. "Operation schema files" currently redirects to `/guides#from-operation-schema-files`, but is meant to be `/guides#from-operation-files`
b. "When you are ready, deploy the MCP server" currently redirects to https://www.apollographql.com/docs/apollo-mcp-server/guides#deploying-the-MCP-server, but `MCP` in the URL is meant to be lowercase.

2. Renames "Operation schema files" to "Operation files" to remain consistent with what's in the `User guide`.

## How to test
- Check out the updated `quickstart.mdx` file
- Go to 🔗 [Next steps](https://www.apollographql.com/docs/deploy-preview/9c36c1a60bcbafac73046a8e/apollo-mcp-server/quickstart#next-steps) in the deploy preview and make sure the links work as expected. Clicking on **Operation files** should take you to the "From operation files" section of the User Guide, and clicking on **When you're ready, deploy the MCP server** should redirect to the "Deploying the MCP server" section of the User Guide.