### PR TITLE
feat: add mcp auth

### DIFF
--- a/.changesets/feat_nc_authnz.md
+++ b/.changesets/feat_nc_authnz.md
@@ -1,0 +1,38 @@
+### feat: add mcp auth - @nicholascioli PR #210
+
+The MCP server can now be configured to act as an OAuth 2.1 resource server, following
+guidelines from the official MCP specification on Authorization / Authentication (see
+[the spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)).
+
+To configure this new feature, a new `auth` section has been added to the SSE and
+Streamable HTTP transports. Below is an example configuration using Streamable HTTP:
+
+```yaml
+transport:
+  type: streamable_http
+  auth:
+    # List of upstream delegated OAuth servers
+    # Note: These need to support the OIDC metadata discovery endpoint
+    servers:
+    - https://auth.example.com
+
+    # List of accepted audiences from upstream signed JWTs
+    # See: https://www.ory.sh/docs/hydra/guides/audiences
+    audiences:
+    - mcp.example.audience
+
+    # The externally available URL pointing to this MCP server. Can be `localhost`
+    # when testing locally.
+    # Note: Subpaths must be preserved here as well. So append `/mcp` if using
+    # Streamable HTTP or `/sse` is using SSE.
+    resource: https://hosted.mcp.server/mcp
+
+    # Optional link to more documentation relating to this MCP server.
+    resource_documentation: https://info.mcp.server
+
+    # List of queryable OAuth scopes from the upstream OAuth servers
+    scopes:
+    - read
+    - mcp
+    - profile
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "bon",
+ "chrono",
  "clap",
  "figment",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,10 +205,12 @@ dependencies = [
  "apollo-mcp-registry",
  "apollo-schema-index",
  "axum",
+ "axum-extra",
  "bon",
  "clap",
  "figment",
  "futures",
+ "headers",
  "http",
  "humantime-serde",
  "insta",
@@ -381,6 +383,29 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "headers",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1270,6 +1295,30 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
 ]
 
 [[package]]
@@ -2998,6 +3047,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,8 +209,11 @@ dependencies = [
  "clap",
  "figment",
  "futures",
+ "http",
  "humantime-serde",
  "insta",
+ "jsonwebtoken",
+ "jwks",
  "lz-str",
  "regex",
  "reqwest",
@@ -222,6 +225,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "tracing-test",
@@ -1131,8 +1135,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1686,6 +1692,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
+name = "jwks"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c940b91cfb3b56645bab00ff7a7919c5decf1bc5c8f9327b6dcff34e2d95c9"
+dependencies = [
+ "base64",
+ "jsonwebtoken",
+ "reqwest",
+ "serde",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,10 +2003,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2142,6 +2196,16 @@ dependencies = [
  "proc-macro2-diagnostics",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+dependencies = [
+ "base64",
+ "serde",
 ]
 
 [[package]]
@@ -2533,6 +2597,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-registry",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2976,6 +3054,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.12",
+ "time",
+]
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3384,6 +3474,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3467,6 +3558,20 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.9.0",
+ "bytes",
+ "http",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -3655,6 +3760,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -13,7 +13,7 @@ apollo-federation.workspace = true
 apollo-mcp-registry = { path = "../apollo-mcp-registry" }
 apollo-schema-index = { path = "../apollo-schema-index" }
 axum = "0.8.4"
-axum-extra = { version = "0.10.1", features = [ "typed-header"] }
+axum-extra = { version = "0.10.1", features = ["typed-header"] }
 bon = "3.6.3"
 clap = { version = "4.5.36", features = ["derive", "env"] }
 figment = { version = "0.10.19", features = ["env", "yaml"] }

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -13,10 +13,12 @@ apollo-federation.workspace = true
 apollo-mcp-registry = { path = "../apollo-mcp-registry" }
 apollo-schema-index = { path = "../apollo-schema-index" }
 axum = "0.8.4"
+axum-extra = { version = "0.10.1", features = [ "typed-header"] }
 bon = "3.6.3"
 clap = { version = "4.5.36", features = ["derive", "env"] }
 figment = { version = "0.10.19", features = ["env", "yaml"] }
 futures.workspace = true
+headers = "0.4.1"
 http = "1.3.1"
 humantime-serde = "1.1.1"
 jsonwebtoken = "9"

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -44,6 +44,7 @@ tower-http = { version = "0.6.6", features = ["cors"] }
 url.workspace = true
 
 [dev-dependencies]
+chrono = { version = "0.4.41", default-features = false, features = ["now"] }
 figment = { version = "0.10.19", features = ["test"] }
 insta.workspace = true
 rstest.workspace = true

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -17,7 +17,10 @@ bon = "3.6.3"
 clap = { version = "4.5.36", features = ["derive", "env"] }
 figment = { version = "0.10.19", features = ["env", "yaml"] }
 futures.workspace = true
+http = "1.3.1"
 humantime-serde = "1.1.1"
+jsonwebtoken = "9"
+jwks = "0.4.0"
 lz-str = "0.2.1"
 regex = "1.11.1"
 reqwest.workspace = true
@@ -35,6 +38,7 @@ tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tokio-util = "0.7.15"
+tower-http = { version = "0.6.6", features = ["cors"] }
 url.workspace = true
 
 [dev-dependencies]

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -1,7 +1,7 @@
 use axum::{
     Json, Router,
     extract::{Request, State},
-    http::{HeaderMap, HeaderValue, StatusCode},
+    http::StatusCode,
     middleware::Next,
     response::Response,
     routing::get,
@@ -12,12 +12,11 @@ use axum_extra::{
 };
 use http::Method;
 use jsonwebtoken::{Algorithm, Validation, decode, decode_header};
-use jwks::{Jwks, JwksError};
-use reqwest::header::WWW_AUTHENTICATE;
+use jwks::Jwks;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tower_http::cors::{Any, CorsLayer};
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 use url::Url;
 
 mod www_authenticate;
@@ -132,7 +131,7 @@ async fn oauth_validate(
         _ => Err((
             StatusCode::UNAUTHORIZED,
             TypedHeader(WwwAuthenticate::Bearer {
-                resource_metadata: auth_config.resource,
+                resource_metadata: resource_url,
             }),
         )),
     }

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -1,0 +1,235 @@
+use axum::{
+    Json, Router,
+    extract::{Request, State},
+    http::{HeaderMap, HeaderValue, StatusCode},
+    middleware::Next,
+    response::Response,
+    routing::get,
+};
+use http::Method;
+use jsonwebtoken::{Algorithm, Validation, decode, decode_header};
+use jwks::{Jwks, JwksError};
+use reqwest::header::{AUTHORIZATION, WWW_AUTHENTICATE};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tower_http::cors::{Any, CorsLayer};
+use tracing::{error, info, warn};
+use url::Url;
+
+/// Auth configuration options
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct Config {
+    /// Disable authentication
+    #[serde(default)]
+    pub disable: bool,
+
+    /// List of upstream OAuth servers to delegate auth
+    pub servers: Vec<Url>,
+
+    /// List of accepted audiences for the OAuth tokens
+    pub audiences: Vec<String>,
+
+    /// The resource to protect.
+    ///
+    /// Note: This is usually the publically accessible URL of this running MCP server
+    pub resource: String,
+}
+
+/// A validated token string
+#[derive(Clone)]
+pub struct ValidToken(String);
+
+impl ValidToken {
+    /// Read the contents of the token, consuming it.
+    pub fn read(self) -> String {
+        self.0
+    }
+}
+
+// Note: Here we implement default for Config such that it disables auth when not
+// specified. If it is specified, however, the above `#[serde(default)]` ensures that
+// disabled is set to false.
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            disable: true,
+            servers: Vec::new(),
+            audiences: Vec::new(),
+            resource: String::new(),
+        }
+    }
+}
+
+impl Config {
+    pub fn enable_middleware(&self, router: axum::Router) -> axum::Router {
+        #[derive(Serialize)]
+        struct ProtectedResource {
+            resource: String,
+            authorization_servers: Vec<Url>,
+            bearer_methods_supported: Vec<String>,
+            scopes_supported: Vec<String>,
+            resource_documentation: String,
+        }
+
+        impl From<Config> for ProtectedResource {
+            fn from(value: Config) -> Self {
+                Self {
+                    resource: value.resource,
+                    authorization_servers: value.servers,
+                    bearer_methods_supported: vec!["header".to_string()],
+                    scopes_supported: ["profile", "email", "phone", "mcp-flow"]
+                        .into_iter()
+                        .map(str::to_string)
+                        .collect(),
+                    resource_documentation: "TODO".to_string(),
+                }
+            }
+        }
+
+        async fn protected_resource(State(auth_config): State<Config>) -> Json<ProtectedResource> {
+            Json(auth_config.into())
+        }
+
+        // Set up auth routes
+        let cors = CorsLayer::new()
+            // allow `GET` and `POST` when accessing the resource
+            .allow_methods([Method::GET])
+            // allow requests from any origin
+            .allow_origin(Any);
+        let auth_router = Router::new()
+            .route(
+                "/.well-known/oauth-protected-resource",
+                get(protected_resource),
+            )
+            .with_state(self.clone())
+            .layer(cors);
+
+        // Merge with MCP server routes
+        Router::new()
+            .merge(auth_router)
+            .merge(router.layer(axum::middleware::from_fn_with_state(
+                self.clone(),
+                oauth_validate,
+            )))
+    }
+}
+
+/// Helper for returning internal server errors
+macro_rules! internal_error {
+    ($msg:literal, $e:ident) => {{
+        error!("INTERNAL ERROR (This should not happen). {}: {}", $msg, $e);
+
+        (StatusCode::INTERNAL_SERVER_ERROR, Default::default())
+    }};
+}
+
+async fn oauth_validate(
+    State(auth_config): State<Config>,
+    headers: HeaderMap,
+    mut request: Request,
+    next: Next,
+) -> Result<Response, (StatusCode, HeaderMap)> {
+    match get_token(&headers) {
+        Some(token)
+            if token_is_valid(&auth_config, token)
+                .await
+                .map_err(|e| internal_error!("could not validate token", e))? =>
+        {
+            // Insert new context to ensure that handlers only use our enforced token verification
+            // for propagation
+            request
+                .extensions_mut()
+                .insert(ValidToken(token.to_string()));
+
+            let response = next.run(request).await;
+            Ok(response)
+        }
+
+        _ => Err((
+            StatusCode::UNAUTHORIZED,
+            HeaderMap::from_iter([(
+                WWW_AUTHENTICATE,
+                HeaderValue::from_str(&format!(
+                    r#"Bearer resource_metadata="{}/.well-known/oauth-protected-resource""#,
+                    auth_config.resource
+                ))
+                .map_err(|e| internal_error!("could not create resource metadata header", e))?,
+            )]),
+        )),
+    }
+}
+
+fn get_token(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get(AUTHORIZATION)
+        .map(HeaderValue::to_str)
+        .transpose()
+        .ok()
+        .flatten()
+}
+
+async fn token_is_valid(auth_config: &Config, token: &str) -> Result<bool, JwksError> {
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct Claims {
+        pub aud: String,
+        pub sub: String,
+    }
+
+    // The token should be in the form 'Bearer ...'
+    let bearer_prefix = "bearer ";
+    let Some((bearer, jwt)) = token.split_at_checked(bearer_prefix.len()) else {
+        return Ok(false);
+    };
+    if bearer.to_lowercase() != bearer_prefix {
+        return Ok(false);
+    }
+
+    let Ok(header) = decode_header(jwt) else {
+        return Ok(false);
+    };
+    let Some(ref key_id) = header.kid else {
+        return Ok(false);
+    };
+
+    for server in &auth_config.servers {
+        let jwks =
+            Jwks::from_oidc_url(format!("{server}/.well-known/oauth-authorization-server")).await?;
+
+        let Some(jwk) = jwks.keys.get(key_id) else {
+            continue;
+        };
+
+        let validation = {
+            let mut val = Validation::new(match jwk.alg {
+                jsonwebtoken::jwk::KeyAlgorithm::HS256 => Algorithm::HS256,
+                jsonwebtoken::jwk::KeyAlgorithm::HS384 => Algorithm::HS384,
+                jsonwebtoken::jwk::KeyAlgorithm::HS512 => Algorithm::HS512,
+                jsonwebtoken::jwk::KeyAlgorithm::ES256 => Algorithm::ES256,
+                jsonwebtoken::jwk::KeyAlgorithm::ES384 => Algorithm::ES384,
+                jsonwebtoken::jwk::KeyAlgorithm::RS256 => Algorithm::RS256,
+                jsonwebtoken::jwk::KeyAlgorithm::RS384 => Algorithm::RS384,
+                jsonwebtoken::jwk::KeyAlgorithm::RS512 => Algorithm::RS512,
+                jsonwebtoken::jwk::KeyAlgorithm::PS256 => Algorithm::PS256,
+                jsonwebtoken::jwk::KeyAlgorithm::PS384 => Algorithm::PS384,
+                jsonwebtoken::jwk::KeyAlgorithm::PS512 => Algorithm::PS512,
+                jsonwebtoken::jwk::KeyAlgorithm::EdDSA => Algorithm::EdDSA,
+                jsonwebtoken::jwk::KeyAlgorithm::RSA1_5 => todo!(),
+                jsonwebtoken::jwk::KeyAlgorithm::RSA_OAEP => todo!(),
+                jsonwebtoken::jwk::KeyAlgorithm::RSA_OAEP_256 => todo!(),
+            });
+            val.set_audience(&auth_config.audiences);
+
+            val
+        };
+        match decode::<Claims>(jwt, &jwk.decoding_key, &validation) {
+            Ok(claims) => {
+                info!("Token passed validation with claims: {claims:?}");
+                return Ok(true);
+            }
+            Err(e) => warn!("Token failed validation with error: {e}"),
+        };
+    }
+
+    info!("Token did not pass validation");
+    Ok(false)
+}

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -19,7 +19,10 @@ use tower_http::cors::{Any, CorsLayer};
 use tracing::{info, warn};
 use url::Url;
 
+mod valid_token;
 mod www_authenticate;
+
+pub(crate) use valid_token::ValidToken;
 use www_authenticate::WwwAuthenticate;
 
 /// Auth configuration options
@@ -35,17 +38,6 @@ pub struct Config {
     ///
     /// Note: This is usually the publicly accessible URL of this running MCP server
     pub resource: Url,
-}
-
-/// A validated token string
-#[derive(Clone)]
-pub struct ValidToken(String);
-
-impl ValidToken {
-    /// Read the contents of the token, consuming it.
-    pub fn read(self) -> String {
-        self.0
-    }
 }
 
 impl Config {

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -49,7 +49,7 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn enable_middleware(&self, router: axum::Router) -> axum::Router {
+    pub fn enable_middleware(&self, router: Router) -> Router {
         /// Simple handler to encode our config into the desired OAuth 2.1 protected
         /// resource format
         async fn protected_resource(State(auth_config): State<Config>) -> Json<ProtectedResource> {

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -11,20 +11,20 @@ use axum_extra::{
     headers::{Authorization, authorization::Bearer},
 };
 use http::Method;
-use jsonwebtoken::{Algorithm, Validation, decode, decode_header};
-use jwks::Jwks;
+use networked_token_validator::NetworkedTokenValidator;
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use tower_http::cors::{Any, CorsLayer};
-use tracing::{info, warn};
 use url::Url;
 
+mod networked_token_validator;
 mod protected_resource;
 mod valid_token;
 mod www_authenticate;
 
 use protected_resource::ProtectedResource;
 pub(crate) use valid_token::ValidToken;
+use valid_token::ValidateToken;
 use www_authenticate::WwwAuthenticate;
 
 /// Auth configuration options
@@ -86,93 +86,31 @@ async fn oauth_validate(
     mut request: Request,
     next: Next,
 ) -> Result<Response, (StatusCode, TypedHeader<WwwAuthenticate>)> {
-    let resource_url = {
+    // Consolidated unauthorized error for use with any fallible step in this process
+    let unauthorized_error = || {
         let mut resource = auth_config.resource.clone();
         resource.set_path("/.well-known/oauth-protected-resource");
 
-        resource
-    };
-
-    match token {
-        Some(bearer) if token_is_valid(&auth_config, bearer.token()).await => {
-            // Insert new context to ensure that handlers only use our enforced token verification
-            // for propagation
-            request.extensions_mut().insert(ValidToken(bearer.0));
-
-            let response = next.run(request).await;
-            Ok(response)
-        }
-
-        _ => Err((
+        (
             StatusCode::UNAUTHORIZED,
             TypedHeader(WwwAuthenticate::Bearer {
-                resource_metadata: resource_url,
+                resource_metadata: resource,
             }),
-        )),
-    }
-}
-
-/// Ensure that the supplied token is valid for the given config
-async fn token_is_valid(auth_config: &Config, jwt: &str) -> bool {
-    #[derive(Clone, Debug, Serialize, Deserialize)]
-    pub struct Claims {
-        pub aud: String,
-        pub sub: String,
-    }
-
-    let Ok(header) = decode_header(jwt) else {
-        return false;
-    };
-    let Some(ref key_id) = header.kid else {
-        return false;
+        )
     };
 
-    for server in &auth_config.servers {
-        let Ok(jwks) =
-            Jwks::from_oidc_url(format!("{server}/.well-known/oauth-authorization-server"))
-                .await
-                .inspect_err(|e| {
-                    warn!("could not fetch OIDC information from {server}: {e}. Skipping...");
-                })
-        else {
-            continue;
-        };
+    let validator = NetworkedTokenValidator::new(&auth_config.audiences, &auth_config.servers);
+    let token = token.ok_or_else(unauthorized_error)?;
 
-        let Some(jwk) = jwks.keys.get(key_id) else {
-            continue;
-        };
+    let valid_token = validator
+        .validate(token.0)
+        .await
+        .ok_or_else(unauthorized_error)?;
 
-        let validation = {
-            let mut val = Validation::new(match jwk.alg {
-                jsonwebtoken::jwk::KeyAlgorithm::HS256 => Algorithm::HS256,
-                jsonwebtoken::jwk::KeyAlgorithm::HS384 => Algorithm::HS384,
-                jsonwebtoken::jwk::KeyAlgorithm::HS512 => Algorithm::HS512,
-                jsonwebtoken::jwk::KeyAlgorithm::ES256 => Algorithm::ES256,
-                jsonwebtoken::jwk::KeyAlgorithm::ES384 => Algorithm::ES384,
-                jsonwebtoken::jwk::KeyAlgorithm::RS256 => Algorithm::RS256,
-                jsonwebtoken::jwk::KeyAlgorithm::RS384 => Algorithm::RS384,
-                jsonwebtoken::jwk::KeyAlgorithm::RS512 => Algorithm::RS512,
-                jsonwebtoken::jwk::KeyAlgorithm::PS256 => Algorithm::PS256,
-                jsonwebtoken::jwk::KeyAlgorithm::PS384 => Algorithm::PS384,
-                jsonwebtoken::jwk::KeyAlgorithm::PS512 => Algorithm::PS512,
-                jsonwebtoken::jwk::KeyAlgorithm::EdDSA => Algorithm::EdDSA,
-                jsonwebtoken::jwk::KeyAlgorithm::RSA1_5 => todo!(),
-                jsonwebtoken::jwk::KeyAlgorithm::RSA_OAEP => todo!(),
-                jsonwebtoken::jwk::KeyAlgorithm::RSA_OAEP_256 => todo!(),
-            });
-            val.set_audience(&auth_config.audiences);
+    // Insert new context to ensure that handlers only use our enforced token verification
+    // for propagation
+    request.extensions_mut().insert(valid_token);
 
-            val
-        };
-        match decode::<Claims>(jwt, &jwk.decoding_key, &validation) {
-            Ok(claims) => {
-                info!("Token passed validation with claims: {claims:?}");
-                return true;
-            }
-            Err(e) => warn!("Token failed validation with error: {e}"),
-        };
-    }
-
-    info!("Token did not pass validation");
-    false
+    let response = next.run(request).await;
+    Ok(response)
 }

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -97,9 +97,7 @@ async fn oauth_validate(
         Some(bearer) if token_is_valid(&auth_config, bearer.token()).await => {
             // Insert new context to ensure that handlers only use our enforced token verification
             // for propagation
-            request
-                .extensions_mut()
-                .insert(ValidToken(bearer.token().to_string()));
+            request.extensions_mut().insert(ValidToken(bearer.0));
 
             let response = next.run(request).await;
             Ok(response)

--- a/crates/apollo-mcp-server/src/auth/networked_token_validator.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_token_validator.rs
@@ -1,0 +1,42 @@
+use jwks::{Jwk, Jwks};
+use tracing::warn;
+use url::Url;
+
+use super::valid_token::ValidateToken;
+
+/// Implementation of the `ValidateToken` trait which fetches key information
+/// from the network.
+pub(super) struct NetworkedTokenValidator<'a> {
+    audiences: &'a Vec<String>,
+    upstreams: &'a Vec<Url>,
+}
+
+impl<'a> NetworkedTokenValidator<'a> {
+    pub fn new(audiences: &'a Vec<String>, upstreams: &'a Vec<Url>) -> Self {
+        Self {
+            audiences,
+            upstreams,
+        }
+    }
+}
+
+impl ValidateToken for NetworkedTokenValidator<'_> {
+    fn get_audiences(&self) -> &Vec<String> {
+        self.audiences
+    }
+
+    fn get_servers(&self) -> &Vec<Url> {
+        self.upstreams
+    }
+
+    async fn get_key(&self, server: &Url, key_id: &str) -> Option<Jwk> {
+        let jwks = Jwks::from_oidc_url(format!("{server}/.well-known/oauth-authorization-server"))
+            .await
+            .inspect_err(|e| {
+                warn!("could not fetch OIDC information from {server}: {e}");
+            })
+            .ok()?;
+
+        jwks.keys.get(key_id).cloned()
+    }
+}

--- a/crates/apollo-mcp-server/src/auth/networked_token_validator.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_token_validator.rs
@@ -30,7 +30,14 @@ impl ValidateToken for NetworkedTokenValidator<'_> {
     }
 
     async fn get_key(&self, server: &Url, key_id: &str) -> Option<Jwk> {
-        let jwks = Jwks::from_oidc_url(format!("{server}/.well-known/oauth-authorization-server"))
+        let oidc_url = {
+            let mut server_url = server.clone();
+            server_url.set_path("/.well-known/oauth-authorization-server");
+
+            server_url
+        };
+
+        let jwks = Jwks::from_oidc_url(oidc_url)
             .await
             .inspect_err(|e| {
                 warn!("could not fetch OIDC information from {server}: {e}");

--- a/crates/apollo-mcp-server/src/auth/protected_resource.rs
+++ b/crates/apollo-mcp-server/src/auth/protected_resource.rs
@@ -20,6 +20,7 @@ pub(super) struct ProtectedResource {
     scopes_supported: Vec<String>,
 
     /// Link to documentation about this resource
+    #[serde(skip_serializing_if = "Option::is_none")]
     resource_documentation: Option<Url>,
 }
 

--- a/crates/apollo-mcp-server/src/auth/protected_resource.rs
+++ b/crates/apollo-mcp-server/src/auth/protected_resource.rs
@@ -1,0 +1,36 @@
+use serde::Serialize;
+use url::Url;
+
+use super::Config;
+
+/// OAuth 2.1 Protected Resource Response
+// TODO: This might be better found in an existing rust crate (or contributed upstream to one)
+#[derive(Serialize)]
+pub(super) struct ProtectedResource {
+    /// The URL of the resource
+    resource: Url,
+
+    /// List of authorization servers protecting this resource
+    authorization_servers: Vec<Url>,
+
+    /// List of authentication methods allowed
+    bearer_methods_supported: Vec<String>,
+
+    /// Scopes allowed to request from the authorization servers
+    scopes_supported: Vec<String>,
+
+    /// Link to documentation about this resource
+    resource_documentation: Option<Url>,
+}
+
+impl From<Config> for ProtectedResource {
+    fn from(value: Config) -> Self {
+        Self {
+            resource: value.resource,
+            authorization_servers: value.servers,
+            bearer_methods_supported: vec!["header".to_string()], // The spec only supports header auth
+            scopes_supported: value.scopes,
+            resource_documentation: value.resource_documentation,
+        }
+    }
+}

--- a/crates/apollo-mcp-server/src/auth/valid_token.rs
+++ b/crates/apollo-mcp-server/src/auth/valid_token.rs
@@ -1,12 +1,17 @@
 use std::ops::Deref;
 
 use headers::{Authorization, authorization::Bearer};
+use jsonwebtoken::{Algorithm, Validation, decode, decode_header, jwk};
+use jwks::Jwk;
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+use url::Url;
 
 /// A validated authentication token
 ///
 /// Note: This is used as a marker to ensure that we have validated this
 /// separately from just reading the header itself.
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct ValidToken(pub(super) Authorization<Bearer>);
 
 impl Deref for ValidToken {
@@ -14,5 +19,281 @@ impl Deref for ValidToken {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+/// Trait to handle validation of tokens
+pub(super) trait ValidateToken {
+    /// Get the intended audiences
+    fn get_audiences(&self) -> &Vec<String>;
+
+    /// Get the available upstream servers
+    fn get_servers(&self) -> &Vec<Url>;
+
+    /// Fetch the key by its ID
+    async fn get_key(&self, server: &Url, key_id: &str) -> Option<Jwk>;
+
+    /// Attempt to validate a token against the validator
+    async fn validate(&self, token: Authorization<Bearer>) -> Option<ValidToken> {
+        /// Claims which must be present in the JWT (and must match validation)
+        /// in order for a JWT to be considered valid.
+        ///
+        /// See: https://auth0.com/docs/secure/tokens/json-web-tokens/json-web-token-claims#registered-claims
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        pub struct Claims {
+            /// The intended audience of this token.
+            pub aud: String,
+
+            /// The user who owns this token
+            pub sub: String,
+        }
+
+        let jwt = token.token();
+        let header = decode_header(jwt).ok()?;
+        let key_id = header.kid.as_ref()?;
+
+        for server in self.get_servers() {
+            let Some(jwk) = self.get_key(server, key_id).await else {
+                continue;
+            };
+
+            let validation = {
+                let mut val = Validation::new(match jwk.alg {
+                    jwk::KeyAlgorithm::HS256 => Algorithm::HS256,
+                    jwk::KeyAlgorithm::HS384 => Algorithm::HS384,
+                    jwk::KeyAlgorithm::HS512 => Algorithm::HS512,
+                    jwk::KeyAlgorithm::ES256 => Algorithm::ES256,
+                    jwk::KeyAlgorithm::ES384 => Algorithm::ES384,
+                    jwk::KeyAlgorithm::RS256 => Algorithm::RS256,
+                    jwk::KeyAlgorithm::RS384 => Algorithm::RS384,
+                    jwk::KeyAlgorithm::RS512 => Algorithm::RS512,
+                    jwk::KeyAlgorithm::PS256 => Algorithm::PS256,
+                    jwk::KeyAlgorithm::PS384 => Algorithm::PS384,
+                    jwk::KeyAlgorithm::PS512 => Algorithm::PS512,
+                    jwk::KeyAlgorithm::EdDSA => Algorithm::EdDSA,
+
+                    // No other validation key type is supported by this library, so we
+                    // warn and fail if we encounter one.
+                    other => {
+                        warn!("Skipping JWT signed by unsupported algorithm: {other}");
+                        continue;
+                    }
+                });
+                val.set_audience(self.get_audiences());
+
+                val
+            };
+
+            match decode::<Claims>(jwt, &jwk.decoding_key, &validation) {
+                Ok(_) => {
+                    return Some(ValidToken(token));
+                }
+                Err(e) => warn!("Token failed validation with error: {e}"),
+            };
+        }
+
+        info!("Token did not pass validation");
+        None
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use headers::{Authorization, authorization::Bearer};
+    use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, encode, jwk::KeyAlgorithm};
+    use jwks::Jwk;
+    use serde::Serialize;
+    use url::Url;
+
+    use super::ValidateToken;
+
+    struct TestTokenValidator {
+        audiences: Vec<String>,
+        key_pair: (String, Jwk),
+        servers: Vec<Url>,
+    }
+
+    impl ValidateToken for TestTokenValidator {
+        fn get_audiences(&self) -> &Vec<String> {
+            &self.audiences
+        }
+
+        fn get_servers(&self) -> &Vec<url::Url> {
+            &self.servers
+        }
+
+        async fn get_key(&self, server: &url::Url, key_id: &str) -> Option<jwks::Jwk> {
+            // Return nothing if the server is not known to us
+            if !self.get_servers().contains(server) {
+                return None;
+            }
+
+            // Only return the key if it is the one we know
+            self.key_pair
+                .0
+                .eq(key_id)
+                .then_some(self.key_pair.1.clone())
+        }
+    }
+
+    /// Creates a key for signing / verifying JWTs
+    fn create_key(base64_secret: &str) -> (EncodingKey, DecodingKey) {
+        let encode =
+            EncodingKey::from_base64_secret(base64_secret).expect("create valid encoding key");
+        let decode =
+            DecodingKey::from_base64_secret(base64_secret).expect("create valid decoding key");
+
+        (encode, decode)
+    }
+
+    fn create_jwt(
+        key_id: String,
+        key: EncodingKey,
+        audience: String,
+        expires_at: i64,
+    ) -> Authorization<Bearer> {
+        #[derive(Serialize)]
+        struct Claims {
+            aud: String,
+            exp: i64,
+            sub: String,
+        }
+
+        let header = {
+            let mut h = Header::new(Algorithm::HS512);
+            h.kid = Some(key_id);
+
+            h
+        };
+        let token = encode(
+            &header,
+            &Claims {
+                aud: audience,
+                exp: expires_at,
+                sub: "test user".to_string(),
+            },
+            &key,
+        )
+        .expect("encode JWT");
+
+        Authorization::bearer(&token).expect("create bearer token")
+    }
+
+    #[tokio::test]
+    async fn it_validates_jwt() {
+        let key_id = "some-example-id".to_string();
+        let (encode_key, decode_key) = create_key("DEADBEEF");
+        let jwk = Jwk {
+            alg: KeyAlgorithm::HS512,
+            decoding_key: decode_key,
+        };
+
+        let audience = "test-audience".to_string();
+        let in_the_future = chrono::Utc::now().timestamp() + 1000;
+        let jwt = create_jwt(key_id.clone(), encode_key, audience.clone(), in_the_future);
+
+        let server =
+            Url::from_str("https://auth.example.com").expect("should parse a valid example server");
+
+        let test_validator = TestTokenValidator {
+            audiences: vec![audience],
+            key_pair: (key_id, jwk),
+            servers: vec![server],
+        };
+
+        let token = jwt.token().to_string();
+        assert_eq!(
+            test_validator
+                .validate(jwt)
+                .await
+                .expect("valid token")
+                .0
+                .token(),
+            token
+        );
+    }
+
+    #[tokio::test]
+    async fn it_rejects_different_key() {
+        let key_id = "some-example-id".to_string();
+        let (_, decode_key) = create_key("CAFED00D");
+        let (bad_encode_key, _) = create_key("DEADC0DE");
+        let jwk = Jwk {
+            alg: KeyAlgorithm::HS512,
+            decoding_key: decode_key,
+        };
+
+        let audience = "test-audience".to_string();
+        let in_the_future = chrono::Utc::now().timestamp() + 1000;
+        let jwt = create_jwt(
+            key_id.clone(),
+            bad_encode_key,
+            audience.clone(),
+            in_the_future,
+        );
+
+        let server =
+            Url::from_str("https://auth.example.com").expect("should parse a valid example server");
+
+        let test_validator = TestTokenValidator {
+            audiences: vec![audience],
+            key_pair: (key_id, jwk),
+            servers: vec![server],
+        };
+
+        assert_eq!(test_validator.validate(jwt).await, None);
+    }
+
+    #[tokio::test]
+    async fn it_rejects_expired() {
+        let key_id = "some-example-id".to_string();
+        let (encode_key, decode_key) = create_key("F0CACC1A");
+        let jwk = Jwk {
+            alg: KeyAlgorithm::HS512,
+            decoding_key: decode_key,
+        };
+
+        let audience = "test-audience".to_string();
+        let in_the_past = chrono::Utc::now().timestamp() - 1000;
+        let jwt = create_jwt(key_id.clone(), encode_key, audience.clone(), in_the_past);
+
+        let server =
+            Url::from_str("https://auth.example.com").expect("should parse a valid example server");
+
+        let test_validator = TestTokenValidator {
+            audiences: vec![audience],
+            key_pair: (key_id, jwk),
+            servers: vec![server],
+        };
+
+        assert_eq!(test_validator.validate(jwt).await, None);
+    }
+
+    #[tokio::test]
+    async fn it_rejects_different_audience() {
+        let key_id = "some-example-id".to_string();
+        let (encode_key, decode_key) = create_key("F0CACC1A");
+        let jwk = Jwk {
+            alg: KeyAlgorithm::HS512,
+            decoding_key: decode_key,
+        };
+
+        let audience = "test-audience".to_string();
+        let bad_audience = "not-test-audience".to_string();
+        let in_the_past = chrono::Utc::now().timestamp() - 1000;
+        let jwt = create_jwt(key_id.clone(), encode_key, bad_audience, in_the_past);
+
+        let server =
+            Url::from_str("https://auth.example.com").expect("should parse a valid example server");
+
+        let test_validator = TestTokenValidator {
+            audiences: vec![audience],
+            key_pair: (key_id, jwk),
+            servers: vec![server],
+        };
+
+        assert_eq!(test_validator.validate(jwt).await, None);
     }
 }

--- a/crates/apollo-mcp-server/src/auth/valid_token.rs
+++ b/crates/apollo-mcp-server/src/auth/valid_token.rs
@@ -1,10 +1,18 @@
-/// A validated token string
-#[derive(Clone)]
-pub(crate) struct ValidToken(pub(super) String);
+use std::ops::Deref;
 
-impl ValidToken {
-    /// Read the contents of the token, consuming it.
-    pub fn read(self) -> String {
-        self.0
+use headers::{Authorization, authorization::Bearer};
+
+/// A validated authentication token
+///
+/// Note: This is used as a marker to ensure that we have validated this
+/// separately from just reading the header itself.
+#[derive(Clone)]
+pub(crate) struct ValidToken(pub(super) Authorization<Bearer>);
+
+impl Deref for ValidToken {
+    type Target = Authorization<Bearer>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/crates/apollo-mcp-server/src/auth/valid_token.rs
+++ b/crates/apollo-mcp-server/src/auth/valid_token.rs
@@ -1,0 +1,10 @@
+/// A validated token string
+#[derive(Clone)]
+pub(crate) struct ValidToken(pub(super) String);
+
+impl ValidToken {
+    /// Read the contents of the token, consuming it.
+    pub fn read(self) -> String {
+        self.0
+    }
+}

--- a/crates/apollo-mcp-server/src/auth/www_authenticate.rs
+++ b/crates/apollo-mcp-server/src/auth/www_authenticate.rs
@@ -1,0 +1,42 @@
+//! WWW Authenticate header definition.
+//!
+//! TODO: This might be nice to upstream to hyper.
+
+use headers::{Header, HeaderValue};
+use http::header::WWW_AUTHENTICATE;
+use tracing::warn;
+use url::Url;
+
+pub(super) enum WwwAuthenticate {
+    Bearer { resource_metadata: Url },
+}
+
+impl Header for WwwAuthenticate {
+    fn name() -> &'static http::HeaderName {
+        &WWW_AUTHENTICATE
+    }
+
+    fn decode<'i, I>(values: &mut I) -> Result<Self, headers::Error>
+    where
+        Self: Sized,
+        I: Iterator<Item = &'i http::HeaderValue>,
+    {
+        // We don't care about decoding, so we do nothing here.
+        Err(headers::Error::invalid())
+    }
+
+    fn encode<E: Extend<http::HeaderValue>>(&self, values: &mut E) {
+        let encoded = match &self {
+            WwwAuthenticate::Bearer { resource_metadata } => format!(
+                r#"Bearer resource_metadata="{}""#,
+                resource_metadata.as_str()
+            ),
+        };
+
+        // TODO: This shouldn't error, but it can so we might need to do something else here
+        match HeaderValue::from_str(&encoded) {
+            Ok(value) => values.extend(std::iter::once(value)),
+            Err(e) => warn!("could not construct WWW-AUTHENTICATE header: {e}"),
+        }
+    }
+}

--- a/crates/apollo-mcp-server/src/auth/www_authenticate.rs
+++ b/crates/apollo-mcp-server/src/auth/www_authenticate.rs
@@ -16,7 +16,7 @@ impl Header for WwwAuthenticate {
         &WWW_AUTHENTICATE
     }
 
-    fn decode<'i, I>(values: &mut I) -> Result<Self, headers::Error>
+    fn decode<'i, I>(_values: &mut I) -> Result<Self, headers::Error>
     where
         Self: Sized,
         I: Iterator<Item = &'i http::HeaderValue>,

--- a/crates/apollo-mcp-server/src/lib.rs
+++ b/crates/apollo-mcp-server/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod custom_scalar_map;
 pub mod errors;
 pub mod event;

--- a/crates/apollo-mcp-server/src/server.rs
+++ b/crates/apollo-mcp-server/src/server.rs
@@ -7,6 +7,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use url::Url;
 
+use crate::auth;
 use crate::custom_scalar_map::CustomScalarMap;
 use crate::errors::ServerError;
 use crate::event::Event as ServerEvent;
@@ -52,6 +53,10 @@ pub enum Transport {
     /// Note: This is deprecated in favor of HTTP streams.
     #[serde(rename = "sse")]
     SSE {
+        /// Authentication configuration
+        #[serde(default)]
+        auth: auth::Config,
+
         /// The IP address to bind to
         #[serde(default = "Transport::default_address")]
         address: IpAddr,
@@ -63,6 +68,10 @@ pub enum Transport {
 
     /// Host the MCP server on the configuration, using streamable HTTP messages.
     StreamableHttp {
+        /// Authentication configuration
+        #[serde(default)]
+        auth: auth::Config,
+
         /// The IP address to bind to
         #[serde(default = "Transport::default_address")]
         address: IpAddr,

--- a/crates/apollo-mcp-server/src/server.rs
+++ b/crates/apollo-mcp-server/src/server.rs
@@ -55,7 +55,7 @@ pub enum Transport {
     SSE {
         /// Authentication configuration
         #[serde(default)]
-        auth: auth::Config,
+        auth: Option<auth::Config>,
 
         /// The IP address to bind to
         #[serde(default = "Transport::default_address")]
@@ -70,7 +70,7 @@ pub enum Transport {
     StreamableHttp {
         /// Authentication configuration
         #[serde(default)]
-        auth: auth::Config,
+        auth: Option<auth::Config>,
 
         /// The IP address to bind to
         #[serde(default = "Transport::default_address")]

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
 use apollo_compiler::{Schema, validation::Valid};
+use http::HeaderValue;
+use http::header::AUTHORIZATION;
 use reqwest::header::HeaderMap;
 use rmcp::model::Implementation;
 use rmcp::{
@@ -18,6 +20,7 @@ use tracing::{debug, error};
 use url::Url;
 
 use crate::{
+    auth::ValidToken,
     custom_scalar_map::CustomScalarMap,
     errors::{McpError, ServerError},
     explorer::{EXPLORER_TOOL_NAME, Explorer},
@@ -180,7 +183,7 @@ impl ServerHandler for Running {
     async fn call_tool(
         &self,
         request: CallToolRequestParam,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         let result = match request.name.as_ref() {
             INTROSPECT_TOOL_NAME => {
@@ -223,10 +226,27 @@ impl ServerHandler for Running {
                     .await
             }
             _ => {
+                // Optionally extract the validated token and propagate it to upstream servers
+                // if found
+                let mut headers = self.headers.clone();
+                if let Some(token) = context.extensions.get::<ValidToken>() {
+                    headers.insert(
+                        AUTHORIZATION,
+                        HeaderValue::try_from(token.clone().read()).map_err(|e| {
+                            error!("Could not create auth token from validated token: {e}");
+                            McpError::new(
+                                ErrorCode::INTERNAL_ERROR,
+                                "could not extract validated token. This should not happen",
+                                None,
+                            )
+                        })?,
+                    );
+                }
+
                 let graphql_request = graphql::Request {
                     input: Value::from(request.arguments.clone()),
                     endpoint: &self.endpoint,
-                    headers: self.headers.clone(),
+                    headers,
                 };
                 self.operations
                     .lock()

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -1,8 +1,8 @@
+use std::ops::Deref;
 use std::sync::Arc;
 
 use apollo_compiler::{Schema, validation::Valid};
-use http::HeaderValue;
-use http::header::AUTHORIZATION;
+use headers::HeaderMapExt as _;
 use reqwest::header::HeaderMap;
 use rmcp::model::Implementation;
 use rmcp::{
@@ -230,17 +230,7 @@ impl ServerHandler for Running {
                 // if found
                 let mut headers = self.headers.clone();
                 if let Some(token) = context.extensions.get::<ValidToken>() {
-                    headers.insert(
-                        AUTHORIZATION,
-                        HeaderValue::try_from(token.clone().read()).map_err(|e| {
-                            error!("Could not create auth token from validated token: {e}");
-                            McpError::new(
-                                ErrorCode::INTERNAL_ERROR,
-                                "could not extract validated token. This should not happen",
-                                None,
-                            )
-                        })?,
-                    );
+                    headers.typed_insert(token.deref().clone());
                 }
 
                 let graphql_request = graphql::Request {

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::ops::Deref as _;
 use std::sync::Arc;
 
 use apollo_compiler::{Schema, validation::Valid};

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -11,7 +11,7 @@ use rmcp::{
 use serde_json::json;
 use tokio::sync::{Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, trace};
+use tracing::{Instrument as _, debug, error, info, trace};
 
 use crate::{
     errors::ServerError,
@@ -123,6 +123,7 @@ impl Starting {
         let health_check = match (&self.config.transport, self.config.health_check.enabled) {
             (
                 Transport::StreamableHttp {
+                    auth: _,
                     address: _,
                     port: _,
                 },
@@ -150,8 +151,23 @@ impl Starting {
             health_check: health_check.clone(),
         };
 
+        // Helper to enable auth
+        macro_rules! with_auth {
+            ($router:expr, $auth:ident) => {{
+                let mut router = $router;
+                if !$auth.disable {
+                    router = $auth.enable_middleware(router);
+                }
+
+                router
+            }};
+        }
         match self.config.transport {
-            Transport::StreamableHttp { address, port } => {
+            Transport::StreamableHttp {
+                auth,
+                address,
+                port,
+            } => {
                 info!(port = ?port, address = ?address, "Starting MCP server in Streamable HTTP mode");
                 let running = running.clone();
                 let listen_address = SocketAddr::new(address, port);
@@ -160,7 +176,8 @@ impl Starting {
                     LocalSessionManager::default().into(),
                     Default::default(),
                 );
-                let mut router = axum::Router::new().nest_service("/mcp", service);
+                let mut router =
+                    with_auth!(axum::Router::new().nest_service("/mcp", service), auth);
 
                 // Add health check endpoint if configured
                 if let Some(health_check) = health_check.filter(|h| h.config().enabled) {
@@ -182,19 +199,49 @@ impl Starting {
                     }
                 });
             }
-            Transport::SSE { address, port } => {
+            Transport::SSE {
+                auth,
+                address,
+                port,
+            } => {
                 info!(port = ?port, address = ?address, "Starting MCP server in SSE mode");
                 let running = running.clone();
                 let listen_address = SocketAddr::new(address, port);
-                SseServer::serve_with_config(SseServerConfig {
+
+                let (server, router) = SseServer::new(SseServerConfig {
                     bind: listen_address,
                     sse_path: "/sse".to_string(),
                     post_path: "/message".to_string(),
                     ct: cancellation_token,
                     sse_keep_alive: None,
-                })
-                .await?
-                .with_service(move || running.clone());
+                });
+
+                // Optionally wrap the router with auth, if enabled
+                let router = with_auth!(router, auth);
+
+                // Start up the SSE server
+                // Note: Until RMCP consolidates SSE with the same tower system as StreamableHTTP,
+                // we need to basically copy the implementation of `SseServer::serve_with_config` here.
+                let listener = tokio::net::TcpListener::bind(server.config.bind).await?;
+                let ct = server.config.ct.child_token();
+                let axum_server =
+                    axum::serve(listener, router).with_graceful_shutdown(async move {
+                        ct.cancelled().await;
+                        tracing::info!("mcp server cancelled");
+                    });
+
+                tokio::spawn(
+                    async move {
+                        if let Err(e) = axum_server.await {
+                            tracing::error!(error = %e, "mcp shutdown with error");
+                        }
+                    }
+                    .instrument(
+                        tracing::info_span!("mcp-server", bind_address = %server.config.bind),
+                    ),
+                );
+
+                server.with_service(move || running.clone());
             }
             Transport::Stdio => {
                 info!("Starting MCP server in stdio mode");

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -155,8 +155,8 @@ impl Starting {
         macro_rules! with_auth {
             ($router:expr, $auth:ident) => {{
                 let mut router = $router;
-                if !$auth.disable {
-                    router = $auth.enable_middleware(router);
+                if let Some(auth) = $auth {
+                    router = auth.enable_middleware(router);
                 }
 
                 router


### PR DESCRIPTION
This commit adds support for OAuth authn/z flows at the MCP protocol level. This follows the [official specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) and makes no other assumptions.