### PR TITLE
Handle environment variables when no config file is provided

### DIFF
--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -38,11 +38,10 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let config: runtime::Config = Args::parse()
-        .config
-        .map(runtime::read_config)
-        .transpose()?
-        .unwrap_or_default();
+    let config: runtime::Config = match Args::parse().config {
+        Some(config_path) => runtime::read_config(config_path)?,
+        None => runtime::read_config_from_env().unwrap_or_default(),
+    };
 
     let mut env_filter = EnvFilter::from_default_env().add_directive(config.logging.level.into());
 

--- a/crates/apollo-mcp-server/src/runtime.rs
+++ b/crates/apollo-mcp-server/src/runtime.rs
@@ -26,6 +26,15 @@ pub use schema_source::SchemaSource;
 /// Separator to use when drilling down into nested options in the env figment
 const ENV_NESTED_SEPARATOR: &str = "__";
 
+/// Read configuration from environment variables only (when no config file is provided)
+#[allow(clippy::result_large_err)]
+pub fn read_config_from_env() -> Result<Config, figment::Error> {
+    Figment::new()
+        .join(apollo_common_env())
+        .join(Env::prefixed("APOLLO_MCP_").split(ENV_NESTED_SEPARATOR))
+        .extract()
+}
+
 /// Read in a config from a YAML file, filling in any missing values from the environment
 #[allow(clippy::result_large_err)]
 pub fn read_config(yaml_path: impl AsRef<Path>) -> Result<Config, figment::Error> {


### PR DESCRIPTION
When running the MCP server without a config file, environment variables like `APOLLO_GRAPH_REF` and `APOLLO_KEY` are ignored. This results in the server failing with the message "Missing environment variable: APOLLO_GRAPH_REF," even when the variables are properly set.

The root cause appears to be the configuration loading logic, which has two separate paths:
-  **With config file**: `read_config(path)` processes both the YAML file and environment variables.
-  **Without config file**: `Config::default()` only uses defaults, ignoring environment variables.

The processing of environment variables, including the mapping of `APOLLO_GRAPH_REF` to `GRAPHOS:APOLLO_GRAPH_REF`, occurs only in the `read_config()` function.

To resolve this issue, I added the `read_config_from_env()` function, which processes environment variables without requiring a config file. I then updated the `main` function to utilize environment variable processing regardless of the presence of a config file.

## Testing

Before:

```bash
$ APOLLO_GRAPH_REF=dale@demo APOLLO_KEY=🔑 cargo run
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.20s
     Running `target/debug/apollo-mcp-server`
2025-07-29T13:55:26.616148Z  INFO Apollo MCP Server v0.6.0 // (c) Apollo Graph, Inc. // Licensed under MIT
Error: Missing environment variable: APOLLO_GRAPH_REF
```

After:

```bash
$ APOLLO_GRAPH_REF=dale@demo APOLLO_KEY=🔑 cargo run
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.55s
     Running `target/debug/apollo-mcp-server`
2025-07-29T14:33:39.756760Z  INFO Apollo MCP Server v0.6.0 // (c) Apollo Graph, Inc. // Licensed under MIT
2025-07-29T14:33:39.756884Z  WARN No operations specified, falling back to the default collection in dale@demo
2025-07-29T14:33:40.131890Z  INFO Tool GoodQuery loaded with a character count of 188. Estimated tokens: 47
2025-07-29T14:33:40.134403Z  INFO Tool BadQuery loaded with a character count of 187. Estimated tokens: 46
2025-07-29T14:33:40.134492Z  INFO Starting MCP server in stdio mode
```