### PR TITLE
Fix parsing headers from header file

### DIFF
--- a/crates/apollo-mcp-server/src/runtime/config.rs
+++ b/crates/apollo-mcp-server/src/runtime/config.rs
@@ -79,10 +79,10 @@ mod parsers {
 
                 // While there are entries remaining in the input, add them
                 // into our map.
-                while let Some((key, value)) = map.next_entry()? {
-                    let key = HeaderName::from_str(key)
+                while let Some((key, value)) = map.next_entry::<String, String>()? {
+                    let key = HeaderName::from_str(&key)
                         .map_err(|e| serde::de::Error::custom(e.to_string()))?;
-                    let value = HeaderValue::from_str(value)
+                    let value = HeaderValue::from_str(&value)
                         .map_err(|e| serde::de::Error::custom(e.to_string()))?;
 
                     parsed.insert(key, value);
@@ -92,7 +92,7 @@ mod parsers {
             }
         }
 
-        deserializer.deserialize_str(MapFromStrVisitor)
+        deserializer.deserialize_map(MapFromStrVisitor)
     }
 }
 


### PR DESCRIPTION
I'm seeing an error like: `Error: invalid type: found string "X-Header", expected a borrowed string for key "default.headers.X-Header" in config.yaml YAML file` when running the mcp server with a config file with the headers key:
```yaml
...
headers:
   X-Header: Foo
...
```

This updates the while loop to borrow the string, avoiding the error. I'm sure there is a better way to handle this, but I wanted to take a quick poke at fixing it. 