### PR TITLE
fix: Add custom deserializer to handle APOLLO_UPLINK_ENDPOINTS environment variable parsing

### DIFF
--- a/.changesets/fix_apollo_uplink_endpoints_env_var_parsing.md
+++ b/.changesets/fix_apollo_uplink_endpoints_env_var_parsing.md
@@ -1,0 +1,5 @@
+### fix: Add custom deserializer to handle APOLLO_UPLINK_ENDPOINTS environment variable parsing - @swcollard PR #220
+
+The APOLLO_UPLINK_ENDPOINTS environment variables has historically been a comma separated list of URL strings.
+The move to yaml configuration allows us to more directly define the endpoints as a Vec.
+This fix introduces a custom deserializer for the `apollo_uplink_endpoints` config field that can handle both the environment variable comma separated string, and the yaml-based list.

--- a/crates/apollo-mcp-server/src/runtime.rs
+++ b/crates/apollo-mcp-server/src/runtime.rs
@@ -142,16 +142,117 @@ mod test {
 
             let config = read_config(path)?;
 
-            assert_eq!(config.endpoint.as_str(), "http://from_file:4000/");
-            assert_eq!(config.graphos.apollo_uplink_endpoints.len(), 2);
-            assert_eq!(
-                config.graphos.apollo_uplink_endpoints[0].as_str(),
-                "http://from_env:4000/"
-            );
-            assert_eq!(
-                config.graphos.apollo_uplink_endpoints[1].as_str(),
-                "http://from_env2:4000/"
-            );
+            insta::assert_debug_snapshot!(config, @r#"
+            Config {
+                custom_scalars: None,
+                endpoint: Endpoint(
+                    Url {
+                        scheme: "http",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "from_file",
+                            ),
+                        ),
+                        port: Some(
+                            4000,
+                        ),
+                        path: "/",
+                        query: None,
+                        fragment: None,
+                    },
+                ),
+                graphos: GraphOSConfig {
+                    apollo_key: None,
+                    apollo_graph_ref: None,
+                    apollo_registry_url: None,
+                    apollo_uplink_endpoints: [
+                        Url {
+                            scheme: "http",
+                            cannot_be_a_base: false,
+                            username: "",
+                            password: None,
+                            host: Some(
+                                Domain(
+                                    "from_env",
+                                ),
+                            ),
+                            port: Some(
+                                4000,
+                            ),
+                            path: "/",
+                            query: None,
+                            fragment: None,
+                        },
+                        Url {
+                            scheme: "http",
+                            cannot_be_a_base: false,
+                            username: "",
+                            password: None,
+                            host: Some(
+                                Domain(
+                                    "from_env2",
+                                ),
+                            ),
+                            port: Some(
+                                4000,
+                            ),
+                            path: "/",
+                            query: None,
+                            fragment: None,
+                        },
+                    ],
+                },
+                headers: {},
+                health_check: HealthCheckConfig {
+                    enabled: false,
+                    path: "/health",
+                    readiness: ReadinessConfig {
+                        interval: ReadinessIntervalConfig {
+                            sampling: 5s,
+                            unready: None,
+                        },
+                        allowed: 100,
+                    },
+                },
+                introspection: Introspection {
+                    execute: ExecuteConfig {
+                        enabled: false,
+                    },
+                    introspect: IntrospectConfig {
+                        enabled: false,
+                        minify: false,
+                    },
+                    search: SearchConfig {
+                        enabled: false,
+                        index_memory_bytes: 50000000,
+                        leaf_depth: 1,
+                        minify: false,
+                    },
+                    validate: ValidateConfig {
+                        enabled: false,
+                    },
+                },
+                logging: Logging {
+                    level: Level(
+                        Info,
+                    ),
+                    path: None,
+                    rotation: Hourly,
+                },
+                operations: Infer,
+                overrides: Overrides {
+                    disable_type_description: false,
+                    disable_schema_description: false,
+                    enable_explorer: false,
+                    mutation_mode: None,
+                },
+                schema: Uplink,
+                transport: Stdio,
+            }
+            "#);
             Ok(())
         });
     }

--- a/crates/apollo-mcp-server/src/runtime.rs
+++ b/crates/apollo-mcp-server/src/runtime.rs
@@ -124,4 +124,35 @@ mod test {
             Ok(())
         });
     }
+
+    #[test]
+    fn it_merges_env_and_file_with_uplink_endpoints() {
+        let config = "
+            endpoint: http://from_file:4000/
+        ";
+
+        figment::Jail::expect_with(move |jail| {
+            let path = "config.yaml";
+
+            jail.create_file(path, config)?;
+            jail.set_env(
+                "APOLLO_UPLINK_ENDPOINTS",
+                "http://from_env:4000/,http://from_env2:4000/",
+            );
+
+            let config = read_config(path)?;
+
+            assert_eq!(config.endpoint.as_str(), "http://from_file:4000/");
+            assert_eq!(config.graphos.apollo_uplink_endpoints.len(), 2);
+            assert_eq!(
+                config.graphos.apollo_uplink_endpoints[0].as_str(),
+                "http://from_env:4000/"
+            );
+            assert_eq!(
+                config.graphos.apollo_uplink_endpoints[1].as_str(),
+                "http://from_env2:4000/"
+            );
+            Ok(())
+        });
+    }
 }

--- a/crates/apollo-mcp-server/src/runtime/graphos.rs
+++ b/crates/apollo-mcp-server/src/runtime/graphos.rs
@@ -7,7 +7,7 @@ use apollo_mcp_registry::{
 use apollo_mcp_server::errors::ServerError;
 use schemars::JsonSchema;
 use serde::de::Error;
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use url::Url;
 
 const APOLLO_GRAPH_REF_ENV: &str = "APOLLO_GRAPH_REF";
@@ -39,21 +39,23 @@ where
 
 /// Credentials to use with GraphOS
 #[derive(Debug, Deserialize, Default, JsonSchema)]
+#[cfg_attr(test, derive(Serialize))]
 #[serde(default)]
 pub struct GraphOSConfig {
     /// The apollo key
     #[schemars(with = "Option<String>")]
-    pub apollo_key: Option<SecretString>,
+    #[cfg_attr(test, serde(skip_serializing))]
+    apollo_key: Option<SecretString>,
 
     /// The graph reference
-    pub apollo_graph_ref: Option<String>,
+    apollo_graph_ref: Option<String>,
 
     /// The URL to use for Apollo's registry
-    pub apollo_registry_url: Option<Url>,
+    apollo_registry_url: Option<Url>,
 
     /// List of uplink URL overrides
     #[serde(deserialize_with = "apollo_uplink_endpoints_deserializer")]
-    pub apollo_uplink_endpoints: Vec<Url>,
+    apollo_uplink_endpoints: Vec<Url>,
 }
 
 impl GraphOSConfig {

--- a/crates/apollo-mcp-server/src/runtime/graphos.rs
+++ b/crates/apollo-mcp-server/src/runtime/graphos.rs
@@ -29,8 +29,9 @@ where
         UrlListOrString::String(s) => s
             .split(',')
             .map(|v| {
-                Url::parse(v.trim())
-                    .map_err(|e| D::Error::custom(format!("Could not parse uplink endpoint URL: {e}")))
+                Url::parse(v.trim()).map_err(|e| {
+                    D::Error::custom(format!("Could not parse uplink endpoint URL: {e}"))
+                })
             })
             .collect(),
     }

--- a/crates/apollo-mcp-server/src/runtime/graphos.rs
+++ b/crates/apollo-mcp-server/src/runtime/graphos.rs
@@ -7,8 +7,11 @@ use apollo_mcp_registry::{
 use apollo_mcp_server::errors::ServerError;
 use schemars::JsonSchema;
 use serde::de::Error;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer};
 use url::Url;
+
+#[cfg(test)]
+use serde::Serialize;
 
 const APOLLO_GRAPH_REF_ENV: &str = "APOLLO_GRAPH_REF";
 const APOLLO_KEY_ENV: &str = "APOLLO_KEY";

--- a/crates/apollo-mcp-server/src/runtime/graphos.rs
+++ b/crates/apollo-mcp-server/src/runtime/graphos.rs
@@ -28,7 +28,10 @@ where
         UrlListOrString::List(urls) => Ok(urls),
         UrlListOrString::String(s) => s
             .split(',')
-            .map(|v| Url::parse(v.trim()).map_err(D::Error::custom))
+            .map(|v| {
+                Url::parse(v.trim())
+                    .map_err(D::Error::custom("Could not parse uplink endpoint URL"))
+            })
             .collect(),
     }
 }

--- a/crates/apollo-mcp-server/src/runtime/graphos.rs
+++ b/crates/apollo-mcp-server/src/runtime/graphos.rs
@@ -30,7 +30,7 @@ where
             .split(',')
             .map(|v| {
                 Url::parse(v.trim())
-                    .map_err(D::Error::custom("Could not parse uplink endpoint URL"))
+                    .map_err(|e| D::Error::custom(format!("Could not parse uplink endpoint URL: {e}")))
             })
             .collect(),
     }


### PR DESCRIPTION
The APOLLO_UPLINK_ENDPOINTS environment variables [has historically been a comma separated list of URL strings.](https://github.com/apollographql/router/blob/5b4d688a2ce52e83e1ffe861e98e8ecb87141e9f/README.md?plain=1#L48-L49) The move to yaml configuration allows us to more directly define the endpoints as a Vec. This change introduces a custom deserializer for the `apollo_uplink_endpoints` config field that can handle both the environment variable comma separated string, and the yaml-based list.

