### PR TITLE
docs: updatings docs for rover 0.35 and fixing some issues

### DIFF
--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -217,7 +217,7 @@ You can use the [`rover dev`](/rover/commands/dev) command of Rover CLI v0.32 or
 
 Running `rover dev --mcp` starts an MCP Server.  An optional configuration file path can be provided to configure the MCP server via `rover dev --mcp <PATH/TO/CONFIG>`.
 
-The mapping of `rover dev` options to MCP Server options:
+The `rover dev` options for Apollo MCP Server:
 
 | `rover dev` option       | Equivalent MCP Server option | Description                                        |
 |:-------------------------| :--------------------------- |:---------------------------------------------------|

--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -41,7 +41,7 @@ docker image pull ghcr.io/apollographql/apollo-mcp-server:v0.6.1-rc.1
 The container sets a few defaults for ease of use:
 
 - **Working Directory is `/data`**: Make sure to mount static schemas / operations to this location
-  using the volume flag when running [(`-v` / `--version`)](https://docs.docker.com/reference/cli/docker/container/run/#volume).
+  using the volume flag when running [(`-v` / `--volume`)](https://docs.docker.com/reference/cli/docker/container/run/#volume).
 - **HTTP Streamable Transport on port 5000**: Make sure to export container port 5000 for HTTP Streamable connections to
   the MCP server using the port flag when running [(`-p` / `--port`)](https://docs.docker.com/reference/cli/docker/container/run/#publish)
 

--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -219,6 +219,6 @@ Running `rover dev --mcp` starts an MCP Server.  An optional configuration file 
 
 The `rover dev` options for Apollo MCP Server:
 
-| `rover dev` option       | Equivalent MCP Server option | Description                                        |
-|:-------------------------| :--------------------------- |:---------------------------------------------------|
-| `--mcp <PATH/TO/CONFIG>` | `<PATH/TO/CONFIG>`           | Optional path to the MCP server configuration file |
+| `rover dev` option       | Description                                        |
+|:-------------------------|:---------------------------------------------------|
+| `--mcp <PATH/TO/CONFIG>` | Optional path to the MCP server configuration file |

--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -215,10 +215,4 @@ The default value for `type` is `"stdio"`.
 
 You can use the [`rover dev`](/rover/commands/dev) command of Rover CLI v0.32 or later to run an Apollo MCP Server instance for local development.
 
-Running `rover dev --mcp` starts an MCP Server. Additional options, `--mcp*`, directly configure the MCP Server.
-
-The mapping of `rover dev` options to MCP Server options:
-
-| `rover dev` option              | Equivalent MCP Server option | Description                               |
-| :------------------------------ | :--------------------------- | :---------------------------------------- |
-| `--mcp-config <PATH/TO/CONFIG>` | `<PATH/TO/CONFIG>`           | Path to the MCP server configuration file |
+Running `rover dev --mcp` starts an MCP Server. An optional configuration file path can be provided to configure the MCP server via `rover dev --mcp <PATH/TO/CONFIG>`.

--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -216,9 +216,3 @@ The default value for `type` is `"stdio"`.
 You can use the [`rover dev`](/rover/commands/dev) command of Rover CLI v0.32 or later to run an Apollo MCP Server instance for local development.
 
 Running `rover dev --mcp` starts an MCP Server.  An optional configuration file path can be provided to configure the MCP server via `rover dev --mcp <PATH/TO/CONFIG>`.
-
-The `rover dev` options for Apollo MCP Server:
-
-| `rover dev` option       | Description                                        |
-|:-------------------------|:---------------------------------------------------|
-| `--mcp <PATH/TO/CONFIG>` | Optional path to the MCP server configuration file |

--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -215,4 +215,10 @@ The default value for `type` is `"stdio"`.
 
 You can use the [`rover dev`](/rover/commands/dev) command of Rover CLI v0.32 or later to run an Apollo MCP Server instance for local development.
 
-Running `rover dev --mcp` starts an MCP Server. An optional configuration file path can be provided to configure the MCP server via `rover dev --mcp <PATH/TO/CONFIG>`.
+Running `rover dev --mcp` starts an MCP Server.  An optional configuration file path can be provided to configure the MCP server via `rover dev --mcp <PATH/TO/CONFIG>`.
+
+The mapping of `rover dev` options to MCP Server options:
+
+| `rover dev` option       | Equivalent MCP Server option | Description                                        |
+|:-------------------------| :--------------------------- |:---------------------------------------------------|
+| `--mcp <PATH/TO/CONFIG>` | `<PATH/TO/CONFIG>`           | Optional path to the MCP server configuration file |

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -67,8 +67,7 @@ The example files located in `graphql/TheSpaceDevs/` include:
 
     ```sh showLineNumbers=false
     rover dev --supergraph-config ./graphql/TheSpaceDevs/supergraph.yaml \
-    --mcp \
-    --mcp-config <path to the preceding config>
+    --mcp <path to the preceding config>
     ```
 
     This command:

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -39,7 +39,7 @@ If you learn best with videos and exercises, this [interactive course](https://w
 ## Prerequisites
 
 - Clone the [Apollo MCP Server repo](https://github.com/apollographql/apollo-mcp-server)
-- Install [Apollo Rover CLI](/rover/getting-started) v0.32 or later
+- Install [Apollo Rover CLI](/rover/getting-started) v0.35 or later
 
 ## Step 1: Understand the Example
 


### PR DESCRIPTION
1. Setting rover min version needed to 0.35
2. Fixing typo with `--version` in docker section which should be `--volume`.
3. Fixed an issue with the `rover dev --mcp` command example in quickstart.