### PR TITLE
docs: rover does not support `--mcp-config` flag

### DIFF
--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -215,10 +215,10 @@ The default value for `type` is `"stdio"`.
 
 You can use the [`rover dev`](/rover/commands/dev) command of Rover CLI v0.32 or later to run an Apollo MCP Server instance for local development.
 
-Running `rover dev --mcp` starts an MCP Server. Additional options, `--mcp*`, directly configure the MCP Server.
+Running `rover dev --mcp` starts an MCP Server.
 
 The mapping of `rover dev` options to MCP Server options:
 
 | `rover dev` option              | Equivalent MCP Server option | Description                               |
 | :------------------------------ | :--------------------------- | :---------------------------------------- |
-| `--mcp-config <PATH/TO/CONFIG>` | `<PATH/TO/CONFIG>`           | Path to the MCP server configuration file |
+| `--mcp <PATH/TO/CONFIG>` | `<PATH/TO/CONFIG>`           | Path to the MCP server configuration file |

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -67,8 +67,7 @@ The example files located in `graphql/TheSpaceDevs/` include:
 
     ```sh showLineNumbers=false
     rover dev --supergraph-config ./graphql/TheSpaceDevs/supergraph.yaml \
-    --mcp \
-    --mcp-config <path to the preceding config>
+    --mcp <path to the preceding config>
     ```
 
     This command:


### PR DESCRIPTION
We've settled on a single flag, `--mcp`, but the documentation doesn't reflect this latest decision.