### PR TITLE
docs: Provide example config file for documentation

### DIFF
--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -87,12 +87,13 @@ iwr 'https://mcp.apollo.dev/download/win/v0.6.1' | iex
 
 ## Usage
 
-Configure the Apollo MCP server with a YAML configuration file. The path to this file is the only argument.
-A configuration file is not required, but if one is not provided environment variables for your Apollo Graph Reference and Apollo Key are needed.
+Configure the Apollo MCP server with a YAML configuration file.
 
 ```sh showLineNumbers=false
 apollo-mcp-server [OPTIONS] <PATH/TO/CONFIG/FILE>
 ```
+
+A configuration file is optional. If the file is not provided, environment variables for your graph credentials (`APOLLO_GRAPH_REF` and `APOLLO_KEY`) are required for the server to run.
 
 ### CLI options
 
@@ -103,8 +104,7 @@ apollo-mcp-server [OPTIONS] <PATH/TO/CONFIG/FILE>
 
 ### Example config file
 
-Detailed options for your configuration file are below, but this is an example configuration file.
-This file sets your endpoint to `localhost:4001`, configures transport over Streamable HTTP, provides a GraphOS key and graph reference,
+The following example file sets your endpoint to `localhost:4001`, configures transport over Streamable HTTP, provides a GraphOS key and graph reference,
 enables introspection, and provides two local MCP operations for the server to expose.
 
 ```yaml config.yaml
@@ -112,8 +112,8 @@ endpoint: http://localhost:4001/
 transport:
   type: streamable_http
 graphos:
-  apollo_key: <YOUR_KEY>
-  apollo_graph_ref: <YOUR_GRAPH>
+  apollo_key: <YOUR_APOLLO_KEY>
+  apollo_graph_ref: <YOUR_APOLLO_GRAPH_REF>
 introspection:
   introspect:
     enabled: true
@@ -126,7 +126,7 @@ operations:
 
 ### Config options
 
-All fields are optional and have sensible default values.
+All fields are optional.
 
 | Option           | Type                  | Default                  | Description                                                   |
 | :--------------- | :-------------------- | :----------------------- | :------------------------------------------------------------ |
@@ -144,7 +144,7 @@ All fields are optional and have sensible default values.
 
 #### GraphOS configuration
 
-These fields are under the top-level `graphos` key and define credentials and other details related to GraphOS.
+These fields are under the top-level `graphos` key and define your GraphOS graph credentials and endpoints.
 
 | Option                    | Type     | Default | Description                                                                                                     |
 | :------------------------ | :------- | :------ | :-------------------------------------------------------------------------------------------------------------- |

--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -156,7 +156,7 @@ These fields are under the top-level `graphos` key and define your GraphOS graph
 
 #### Introspection configuration
 
-These fields are under the top-level `introspection` key. Learn more about the MCP [introspection tools](apollo-mcp-server/guides/introspection).
+These fields are under the top-level `introspection` key. Learn more about the MCP [introspection tools](/apollo-mcp-server/guides#introspection-tools).
 
 | Option               | Type     | Default | Description                                                           |
 | :------------------- | :------- | :------ | :-------------------------------------------------------------------- |

--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -87,7 +87,7 @@ iwr 'https://mcp.apollo.dev/download/win/v0.6.1' | iex
 
 ## Usage
 
-Configure the Apollo MCP server with a configuration file. The path to this file is the only argument.
+Configure the Apollo MCP server with a YAML configuration file. The path to this file is the only argument.
 
 ```sh showLineNumbers=false
 apollo-mcp-server [OPTIONS] <PATH/TO/CONFIG/FILE>
@@ -99,6 +99,25 @@ apollo-mcp-server [OPTIONS] <PATH/TO/CONFIG/FILE>
 | :-------------- | :------------------------ |
 | `-h, --help`    | Print help information    |
 | `-V, --version` | Print version information |
+
+### Example config file
+
+Detailed options for your configuration file are below, but this is an example configuration file:
+
+```yaml config.yaml
+endpoint: http://localhost:4001/
+graphos:
+  apollo_key: <YOUR_KEY>
+  apollo_graph_ref: <YOUR_GRAPH>
+introspection:
+  introspect:
+    enabled: true
+operations:
+  source: local
+  paths:
+    - relative/path/to/your/operations/userDetails.graphql
+    - relative/path/to/your/operations/listing.graphql
+```
 
 ### Config options
 
@@ -164,7 +183,7 @@ The default value for `source` is `"infer"`.
 | GraphOS Collection | `id`     | `string`         |         | The collection ID to use in GraphOS. Use `default` for the default collection. [Learn more](/apollo-mcp-server/guides/#from-operation-collection) |
 | Introspection      | `source` | `"introspect"`   |         | Load operations by introspecting the schema. Note: You must enable introspection to use this source                                               |
 | Local              | `source` | `"local"`        |         | Load operations from local GraphQL files or directories                                                                                           |
-| Local              | `paths`  | `List<FilePath>` |         | Paths to GraphQL files or directories to search                                                                                                   |
+| Local              | `paths`  | `List<FilePath>` |         | Paths to GraphQL files or directories to search. Note: These paths are relative to the location from which you are running Apollo MCP Server.     |
 | Manifest           | `source` | `"manifest"`     |         | Load operations from a persisted queries manifest file                                                                                            |
 | Manifest           | `path`   | `FilePath`       |         | The path to the persisted query manifest                                                                                                          |
 | Uplink             | `source` | `"uplink"`       |         | Load operations from an uplink manifest. Note: This source requires an Apollo key and graph reference                                             |

--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -102,10 +102,14 @@ apollo-mcp-server [OPTIONS] <PATH/TO/CONFIG/FILE>
 
 ### Example config file
 
-Detailed options for your configuration file are below, but this is an example configuration file:
+Detailed options for your configuration file are below, but this is an example configuration file.
+This file sets your endpoint to `localhost:4001`, configures transport over Streamable HTTP, provides a GraphOS key and graph reference,
+enables introspection, and provides two local MCP operations for the server to expose.
 
 ```yaml config.yaml
 endpoint: http://localhost:4001/
+transport:
+  type: streamable_http
 graphos:
   apollo_key: <YOUR_KEY>
   apollo_graph_ref: <YOUR_GRAPH>

--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -143,7 +143,7 @@ All fields are optional and have sensible default values.
 
 #### GraphOS configuration
 
-These fields are under the top-level `graphos` key.
+These fields are under the top-level `graphos` key and define credentials and other details related to GraphOS.
 
 | Option                    | Type     | Default | Description                                                                                                     |
 | :------------------------ | :------- | :------ | :-------------------------------------------------------------------------------------------------------------- |

--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -156,7 +156,7 @@ These fields are under the top-level `graphos` key and define credentials and ot
 
 #### Introspection configuration
 
-These fields are under the top-level `introspection` key.
+These fields are under the top-level `introspection` key. Learn more about the MCP [introspection tools](apollo-mcp-server/guides/introspection).
 
 | Option               | Type     | Default | Description                                                           |
 | :------------------- | :------- | :------ | :-------------------------------------------------------------------- |

--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -88,6 +88,7 @@ iwr 'https://mcp.apollo.dev/download/win/v0.6.1' | iex
 ## Usage
 
 Configure the Apollo MCP server with a YAML configuration file. The path to this file is the only argument.
+A configuration file is not required, but if one is not provided environment variables for your Apollo Graph Reference and Apollo Key are needed.
 
 ```sh showLineNumbers=false
 apollo-mcp-server [OPTIONS] <PATH/TO/CONFIG/FILE>


### PR DESCRIPTION
In order to make usage of the new configuration file options easier, this commit adds an example configuration file. It also adds a few notes about proper usage of some options.