### PR TITLE
docs: improve quickstart rover dev command text

### DIFF
--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -57,23 +57,17 @@ The example files located in `graphql/TheSpaceDevs/` include:
 ## Step 2: Run the MCP Server
 
 1. From the root directory of your local repo, run `rover dev` to start a local graph with an MCP Server:
-
-    ```yaml title="Config file"
-    operations:
-      source: local
-      paths:
-      - ./graphql/TheSpaceDevs/operations
-    ```
-
     ```sh showLineNumbers=false
     rover dev --supergraph-config ./graphql/TheSpaceDevs/supergraph.yaml \
-    --mcp <path to the preceding config>
+    --mcp ./graphql/TheSpaceDevs/config.yml
     ```
 
     This command:
     - Starts a local graph using the supergraph configuration
     - Starts an MCP Server with the `--mcp` flag
-    - Exposes the specified operations as MCP tools
+    - Provides a configuration file with MCP Server options
+
+    The [command reference](/apollo-mcp-server/command-reference#config-options) has a breakdown of available configuration options. 
 
 2. Start MCP Inspector to verify the server is running:
 

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -67,7 +67,7 @@ The example files located in `graphql/TheSpaceDevs/` include:
     - Starts an MCP Server with the `--mcp` flag
     - Provides a configuration file with MCP Server options
 
-    The [command reference](/apollo-mcp-server/command-reference#config-options) has a breakdown of available configuration options. 
+    See the [command reference](/apollo-mcp-server/command-reference#config-options) for a list of available configuration options. 
 
 2. Start MCP Inspector to verify the server is running:
 

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -59,7 +59,7 @@ The example files located in `graphql/TheSpaceDevs/` include:
 1. From the root directory of your local repo, run `rover dev` to start a local graph with an MCP Server:
     ```sh showLineNumbers=false
     rover dev --supergraph-config ./graphql/TheSpaceDevs/supergraph.yaml \
-    --mcp ./graphql/TheSpaceDevs/config.yml
+    --mcp ./graphql/TheSpaceDevs/config.yaml
     ```
 
     This command:


### PR DESCRIPTION
Updating text in quickstart around the command used to make things more clear