### PR TITLE
docs: adding logging.path and logging.rotation cmd reference docs

### DIFF
--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -192,9 +192,11 @@ These fields are under the top-level `introspection` key. Learn more about the M
 
 These fields are under the top-level `logging` key.
 
-| Option  | Type                                                | Default  | Description                     |
-| :------ | :-------------------------------------------------- | :------- | :------------------------------ |
-| `level` | `oneOf ["trace", "debug", "info", "warn", "error"]` | `"info"` | The minimum log level to record |
+| Option     | Type                                                | Default    | Description                                                                       |
+|:-----------|:----------------------------------------------------|:-----------|:----------------------------------------------------------------------------------|
+| `level`    | `oneOf ["trace", "debug", "info", "warn", "error"]` | `"info"`   | The minimum log level to record                                                   |
+| `path`     | `FilePath`                                          |            | An output file path for logging. If not provided logging outputs to stdio/stderr. |
+| `rotation` | `oneOf ["minutely", "hourly", "daily", "never"]`    | `"hourly"` | The log file rotation interval (if file logging is used)                          |
 
 #### Operation source configuration
 


### PR DESCRIPTION
Updating config reference docs for information on newly added `logging.path` and `logging.rotation` options.