### PR TITLE
Add documentation for minify options in introspect and search tools

### DIFF
--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -177,16 +177,20 @@ Health checks are only available when using the `streamable_http` transport. The
 
 These fields are under the top-level `introspection` key. Learn more about the MCP [introspection tools](/apollo-mcp-server/guides#introspection-tools).
 
-| Option               | Type     | Default | Description                                                           |
-| :------------------- | :------- | :------ | :-------------------------------------------------------------------- |
-| `execute`            | `object` |         | Execution configuration for introspection                             |
-| `execute.enabled`    | `bool`   | `false` | Enable introspection for execution                                    |
-| `introspect`         | `object` |         | Introspection configuration for allowing clients to run introspection |
-| `introspect.enabled` | `bool`   | `false` | Enable introspection requests                                         |
-| `search`             | `object` |         | Search tool configuration                                             |
-| `search.enabled`     | `bool`   | `false` | Enable search tool                                                    |
-| `validate`           | `object` |         | Validation tool configuration                                         |
-| `validate.enabled`   | `bool`   | `false` | Enable validation tool                                                |
+| Option                      | Type     | Default    | Description                                                           |
+| :-------------------------- | :------- | :--------- | :-------------------------------------------------------------------- |
+| `execute`                   | `object` |            | Execution configuration for introspection                             |
+| `execute.enabled`           | `bool`   | `false`    | Enable introspection for execution                                    |
+| `introspect`                | `object` |            | Introspection configuration for allowing clients to run introspection |
+| `introspect.enabled`        | `bool`   | `false`    | Enable introspection requests                                         |
+| `introspect.minify`         | `bool`   | `false`    | Minify introspection results to reduce context window usage           |
+| `search`                    | `object` |            | Search tool configuration                                             |
+| `search.enabled`            | `bool`   | `false`    | Enable search tool                                                    |
+| `search.index_memory_bytes` | `number` | `50000000` | Amount of memory used for indexing (in bytes)                         |
+| `search.leaf_depth`         | `number` | `1`        | Depth of subtype information to include from matching types           |
+| `search.minify`             | `bool`   | `false`    | Minify search results to reduce context window usage                  |
+| `validate`                  | `object` |            | Validation tool configuration                                         |
+| `validate.enabled`          | `bool`   | `false`    | Enable validation tool                                                |
 
 ### Logging
 

--- a/docs/source/guides/index.mdx
+++ b/docs/source/guides/index.mdx
@@ -166,6 +166,40 @@ You can enable the following introspection tools:
 
 The MCP client can use these tools to provide schema information to the model and its context window, and allow the model to execute GraphQL operations based on that schema.
 
+### Minification
+
+Both the `introspect` and `search` tools support minification of their results through the `minify` option. These options help optimize context window usage for AI models.
+
+- **Reduces context window usage**: Minified GraphQL SDL takes up significantly less space in the AI model's context window, allowing for more complex schemas or additional context
+- **Uses compact notation**: Type definitions use prefixed compact syntax and common scalar types are shortened
+- **Preserves functionality**: All essential type information is retained, just in a more compact format
+- **Includes legend in tool descriptions**: When minify is enabled, the tool descriptions automatically include a legend explaining the notation
+
+**Minification format:**
+
+- **Type prefixes**: `T=type`, `I=input`, `E=enum`, `U=union`, `F=interface`
+- **Scalar abbreviations**: `s=String`, `i=Int`, `f=Float`, `b=Boolean`, `d=ID`
+- **Type modifiers**: `!=required`, `[]=list`, `<>=implements`
+
+Example comparison:
+
+**Regular output:**
+
+```graphql
+type User {
+  id: ID!
+  name: String
+  email: String!
+  posts: [Post]
+}
+```
+
+**Minified output:**
+
+```
+T:User:id:d!,name:s,email:s!,posts:[Post]
+```
+
 <Tip>
 
 Use a [contract variant](/graphos/platform/schema-management/delivery/contracts/overview) so you can control the parts of your graph that AI can introspect. [Learn more](/apollo-mcp-server/best-practices#use-contract-variants-to-control-ai-access-to-graphs)
@@ -178,6 +212,12 @@ introspection:
     enabled: true
   introspect:
     enabled: true
+    minify: true
+  search:
+    enabled: true
+    minify: true
+    index_memory_bytes: 50000000
+    leaf_depth: 1
   validate:
     enabled: true
 ```


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/GT-332 -->

We added the minifySDL feature in PR #178, but we didn't include any documentation for it. This PR adds documentation for the new minify options in the `introspect` and `search` tools.