### PR TITLE
feat: Pass `remote-mcp` mcp-session-id header along to GraphQL request

### DIFF
--- a/.changesets/feat_pass_session_id.md
+++ b/.changesets/feat_pass_session_id.md
@@ -1,0 +1,5 @@
+### feat: Pass `remote-mcp` mcp-session-id header along to GraphQL request - @damassi PR #236
+
+This adds support for passing the `mcp-session-id` header through from `remote-mcp` via the MCP client config. This header [originates from the underlying `@modelcontextprotocol/sdk` library](https://github.com/modelcontextprotocol/typescript-sdk/blob/a1608a6513d18eb965266286904760f830de96fe/src/client/streamableHttp.ts#L182), invoked from `remote-mcp`.
+
+With this change it is possible to correlate requests from MCP clients through to the final GraphQL server destination.

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -238,6 +238,7 @@ impl ServerHandler for Running {
                 // if found
                 let mut headers = self.headers.clone();
                 if let Some(axum_parts) = context.extensions.get::<axum::http::request::Parts>() {
+                    // Optionally extract the validated token and propagate it to upstream servers if present
                     if let Some(token) = axum_parts.extensions.get::<ValidToken>() {
                         headers.typed_insert(token.deref().clone());
                     }

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -215,7 +215,7 @@ impl ServerHandler for Running {
                         headers.insert("mcp-session-id", session_id.clone());
                     }
                 }
-                
+
                 self.execute_tool
                     .as_ref()
                     .ok_or(tool_not_found(&request.name))?
@@ -237,12 +237,11 @@ impl ServerHandler for Running {
                 // Optionally extract the validated token and propagate it to upstream servers
                 // if found
                 let mut headers = self.headers.clone();
-                if let Some(axum_parts) = context.extensions.get::<axum::http::request::Parts>()
-                {
+                if let Some(axum_parts) = context.extensions.get::<axum::http::request::Parts>() {
                     if let Some(token) = axum_parts.extensions.get::<ValidToken>() {
                         headers.typed_insert(token.deref().clone());
                     }
-                    
+
                     // Also forward the mcp-session-id header if present
                     if let Some(session_id) = axum_parts.headers.get("mcp-session-id") {
                         headers.insert("mcp-session-id", session_id.clone());

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -234,8 +234,6 @@ impl ServerHandler for Running {
                     .await
             }
             _ => {
-                // Optionally extract the validated token and propagate it to upstream servers
-                // if found
                 let mut headers = self.headers.clone();
                 if let Some(axum_parts) = context.extensions.get::<axum::http::request::Parts>() {
                     // Optionally extract the validated token and propagate it to upstream servers if present


### PR DESCRIPTION
We're attempting to embed the apollo-mcp-server within a proxy setup for more flexible OAuth support but are running into an issue where we cannot correlate requests issued from the MCP client with outbound requests, through apollo-mcp-server, to our graphql endpoint. 

Inspecting the headers passed in from `remote-mcp`, there's an `mcp-session-id` header [that originates from the underlying `@modelcontextprotocol/sdk` library](https://github.com/modelcontextprotocol/typescript-sdk/blob/a1608a6513d18eb965266286904760f830de96fe/src/client/streamableHttp.ts#L182). Allowing this header through would not only solve our correlation issue, but provide a level of observability at the graphql service level for which clients performed what, and when. This feels generally useful and correct. So this PR updates things to allow for that. 