### PR TITLE
Add git clone command to docs

### DIFF
--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -39,6 +39,9 @@ If you learn best with videos and exercises, this [interactive course](https://w
 ## Prerequisites
 
 - Clone the [Apollo MCP Server repo](https://github.com/apollographql/apollo-mcp-server)
+    ```sh showLineNumbers=false
+    git clone https://github.com/apollographql/apollo-mcp-server.git
+    ```
 - Install [Apollo Rover CLI](/rover/getting-started) v0.35 or later
 
 ## Step 1: Understand the Example


### PR DESCRIPTION
This will make it easier to get started with the Quickstart by keeping the reader in the Quickstart instead of sending them to GitHub to clone the MCP repo.