### PR TITLE
release: v0.7.1

### DIFF
--- a/.changesets/feat_pass_session_id.md
+++ b/.changesets/feat_pass_session_id.md
@@ -1,5 +1,0 @@
-### feat: Pass `remote-mcp` mcp-session-id header along to GraphQL request - @damassi PR #236
-
-This adds support for passing the `mcp-session-id` header through from `remote-mcp` via the MCP client config. This header [originates from the underlying `@modelcontextprotocol/sdk` library](https://github.com/modelcontextprotocol/typescript-sdk/blob/a1608a6513d18eb965266286904760f830de96fe/src/client/streamableHttp.ts#L182), invoked from `remote-mcp`.
-
-With this change it is possible to correlate requests from MCP clients through to the final GraphQL server destination.

--- a/.changesets/fix_apollo_uplink_endpoints_env_var_parsing.md
+++ b/.changesets/fix_apollo_uplink_endpoints_env_var_parsing.md
@@ -1,5 +1,0 @@
-### fix: Add custom deserializer to handle APOLLO_UPLINK_ENDPOINTS environment variable parsing - @swcollard PR #220
-
-The APOLLO_UPLINK_ENDPOINTS environment variables has historically been a comma separated list of URL strings.
-The move to yaml configuration allows us to more directly define the endpoints as a Vec.
-This fix introduces a custom deserializer for the `apollo_uplink_endpoints` config field that can handle both the environment variable comma separated string, and the yaml-based list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [0.7.1] - 2025-08-13
+
+## 🚀 Features
+
+### feat: Pass `remote-mcp` mcp-session-id header along to GraphQL request - @damassi PR #236
+
+This adds support for passing the `mcp-session-id` header through from `remote-mcp` via the MCP client config. This header [originates from the underlying `@modelcontextprotocol/sdk` library](https://github.com/modelcontextprotocol/typescript-sdk/blob/a1608a6513d18eb965266286904760f830de96fe/src/client/streamableHttp.ts#L182), invoked from `remote-mcp`.
+
+With this change it is possible to correlate requests from MCP clients through to the final GraphQL server destination.
+
+## 🐛 Fixes
+
+### fix: Valid token fails validation with multiple audiences - @DaleSeo PR #244
+
+Valid tokens are failing validation with the following error when the JWT tokens contain an audience claim as an array.
+
+```
+JSON error: invalid type: sequence, expected a string at line 1 column 97
+```
+
+According to [RFC 7519 Section 4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3), the audience claim can be either a single string or an array of strings. However, our implementation assumes it will always be a string, which is causing this JSON parsing error.
+This fix updates the `Claims` struct to use `Vec<String>` instead of `String` for the `aud` field, along with a custom deserializer to handle both string and array formats.
+
+### fix: Add custom deserializer to handle APOLLO_UPLINK_ENDPOINTS environment variable parsing - @swcollard PR #220
+
+The APOLLO_UPLINK_ENDPOINTS environment variables has historically been a comma separated list of URL strings.
+The move to yaml configuration allows us to more directly define the endpoints as a Vec.
+This fix introduces a custom deserializer for the `apollo_uplink_endpoints` config field that can handle both the environment variable comma separated string, and the yaml-based list.
+
 # [0.7.0] - 2025-08-04
 
 ## 🚀 Features
@@ -24,12 +53,12 @@ transport:
     # List of upstream delegated OAuth servers
     # Note: These need to support the OIDC metadata discovery endpoint
     servers:
-    - https://auth.example.com
+      - https://auth.example.com
 
     # List of accepted audiences from upstream signed JWTs
     # See: https://www.ory.sh/docs/hydra/guides/audiences
     audiences:
-    - mcp.example.audience
+      - mcp.example.audience
 
     # The externally available URL pointing to this MCP server. Can be `localhost`
     # when testing locally.
@@ -42,9 +71,9 @@ transport:
 
     # List of queryable OAuth scopes from the upstream OAuth servers
     scopes:
-    - read
-    - mcp
-    - profile
+      - read
+      - mcp
+      - profile
 ```
 
 ## 🐛 Fixes
@@ -53,8 +82,6 @@ transport:
 
 To support certain scenarios where a client fails on an omitted `properties` field within `input_schema`, setting the field to an empty map (`{}`) instead. While a missing `properties` field is allowed this will unblock
 certain users and allow them to use the MCP server.
-
-
 
 # [0.6.1] - 2025-07-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-mcp-registry"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "derivative",
  "derive_more 2.0.1",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-mcp-server"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "apollo-compiler",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-schema-index"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "apollo-compiler",
  "enumset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [workspace.package]
 authors = ["Apollo <opensource@apollographql.com>"]
-version = "0.7.0"
+version = "0.7.1"
 
 [workspace.dependencies]
 apollo-compiler = "1.27.0"

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -6,8 +6,8 @@ This document outlines the steps required to prepare and execute a new release o
 
 - [ ] Create a new branch "#.#.#" where "#.#.#" is this release's version
 - [ ] Update the change log by running `cargo xtask changeset changelog #.#.#` where `#.#.#` is the release version, and verify the results in [CHANGELOG.md](./CHANGELOG.md)
-- [ ] Ensure that any new command line arguments have been added to [the command reference doc page](./docs/source/command-reference.mdx)
-- [ ] Ensure any new command line arguments have an equivalent in `rover dev`, or there is an open task to add them if appropriate
+- [ ] Ensure that any new configuration options have been added to [the command reference doc page](./docs/source/command-reference.mdx)
+- [ ] Ensure any new configuration options have an equivalent in `rover dev`, or there is an open task to add them if appropriate
 - [ ] Update the version number in [Cargo.toml](./Cargo.toml)
 - [ ] Update the version number in [the \*nix install script](./scripts/nix/install.sh)
 - [ ] Update the version number in [the Windows install script](./scripts/windows/install.ps1)

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -187,7 +187,7 @@ mod test {
             "extensions": {
                 "clientLibrary": {
                     "name":"mcp",
-                    "version":"0.7.0"
+                    "version":"0.7.1"
                 }
             },
             "operationName":"mock_operation"
@@ -233,7 +233,7 @@ mod test {
                 },
                 "clientLibrary": {
                     "name":"mcp",
-                    "version":"0.7.0"
+                    "version":"0.7.1"
                 }
             },
         })

--- a/docs/source/command-reference.mdx
+++ b/docs/source/command-reference.mdx
@@ -26,14 +26,14 @@ To download a **specific version** of Apollo MCP Server (recommended for CI envi
 
 ```bash
 # Note the `v` prefixing the version number
-docker image pull ghcr.io/apollographql/apollo-mcp-server:v0.7.0
+docker image pull ghcr.io/apollographql/apollo-mcp-server:v0.7.1
 ```
 
 To download a specific version of Apollo MCP Server that is a release candidate:
 
 ```bash
 # Note the `v` prefixing the version number and the `-rc` suffix
-docker image pull ghcr.io/apollographql/apollo-mcp-server:v0.7.0-rc.1
+docker image pull ghcr.io/apollographql/apollo-mcp-server:v0.7.1-rc.1
 ```
 
 <Note>
@@ -65,7 +65,7 @@ To install or upgrade to a **specific version** of Apollo MCP Server (recommende
 
 ```bash
 # Note the `v` prefixing the version number
-curl -sSL https://mcp.apollo.dev/download/nix/v0.7.0 | sh
+curl -sSL https://mcp.apollo.dev/download/nix/v0.7.1 | sh
 ```
 
 If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
@@ -82,7 +82,7 @@ To install or upgrade to a **specific version** of Apollo MCP Server (recommende
 
 ```bash
 # Note the `v` prefixing the version number
-iwr 'https://mcp.apollo.dev/download/win/v0.7.0' | iex
+iwr 'https://mcp.apollo.dev/download/win/v0.7.1' | iex
 ```
 
 ## Usage
@@ -197,7 +197,7 @@ These fields are under the top-level `introspection` key. Learn more about the M
 These fields are under the top-level `logging` key.
 
 | Option     | Type                                                | Default    | Description                                                                       |
-|:-----------|:----------------------------------------------------|:-----------|:----------------------------------------------------------------------------------|
+| :--------- | :-------------------------------------------------- | :--------- | :-------------------------------------------------------------------------------- |
 | `level`    | `oneOf ["trace", "debug", "info", "warn", "error"]` | `"info"`   | The minimum log level to record                                                   |
 | `path`     | `FilePath`                                          |            | An output file path for logging. If not provided logging outputs to stdio/stderr. |
 | `rotation` | `oneOf ["minutely", "hourly", "daily", "never"]`    | `"hourly"` | The log file rotation interval (if file logging is used)                          |
@@ -256,7 +256,6 @@ The default value for `type` is `"stdio"`.
 | StreamableHTTP | `address` | `IpAddr`            | `127.0.0.1` | The IP address to bind to                                                                                                     |
 | StreamableHTTP | `port`    | `u16`               | `5000`      | The port to bind to                                                                                                           |
 
-
 ### Auth
 
 These fields are under the top-level `transport` key, nested under the `auth` key.
@@ -278,12 +277,12 @@ transport:
     # List of upstream delegated OAuth servers
     # Note: These need to support the OIDC metadata discovery endpoint
     servers:
-    - https://auth.example.com
+      - https://auth.example.com
 
     # List of accepted audiences from upstream signed JWTs
     # See: https://www.ory.sh/docs/hydra/guides/audiences
     audiences:
-    - mcp.example.audience
+      - mcp.example.audience
 
     # The externally available URL pointing to this MCP server. Can be `localhost`
     # when testing locally.
@@ -296,9 +295,9 @@ transport:
 
     # List of queryable OAuth scopes from the upstream OAuth servers
     scopes:
-    - read
-    - mcp
-    - profile
+      - read
+      - mcp
+      - profile
 ```
 
 ## Run a local graph with MCP server using `rover dev`

--- a/scripts/nix/install.sh
+++ b/scripts/nix/install.sh
@@ -14,7 +14,7 @@ BINARY_DOWNLOAD_PREFIX="${APOLLO_MCP_SERVER_BINARY_DOWNLOAD_PREFIX:="https://git
 
 # Apollo MCP Server version defined in apollo-mcp-server's Cargo.toml
 # Note: Change this line manually during the release steps.
-PACKAGE_VERSION="v0.7.0"
+PACKAGE_VERSION="v0.7.1"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -8,7 +8,7 @@
 
 # Apollo MCP Server version defined in apollo-mcp-server's Cargo.toml
 # Note: Change this line manually during the release steps.
-$package_version = 'v0.7.0'
+$package_version = 'v0.7.1'
 
 function Install-Binary($apollo_mcp_server_install_args) {
   $old_erroractionpreference = $ErrorActionPreference


### PR DESCRIPTION
# [0.7.1] - 2025-08-13

## 🚀 Features

### feat: Pass `remote-mcp` mcp-session-id header along to GraphQL request - @damassi PR #236

This adds support for passing the `mcp-session-id` header through from `remote-mcp` via the MCP client config. This header [originates from the underlying `@modelcontextprotocol/sdk` library](https://github.com/modelcontextprotocol/typescript-sdk/blob/a1608a6513d18eb965266286904760f830de96fe/src/client/streamableHttp.ts#L182), invoked from `remote-mcp`.

With this change it is possible to correlate requests from MCP clients through to the final GraphQL server destination.

## 🐛 Fixes

### fix: Valid token fails validation with multiple audiences - @DaleSeo PR #244

Valid tokens are failing validation with the following error when the JWT tokens contain an audience claim as an array.

```
JSON error: invalid type: sequence, expected a string at line 1 column 97
```

According to [RFC 7519 Section 4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3), the audience claim can be either a single string or an array of strings. However, our implementation assumes it will always be a string, which is causing this JSON parsing error.
This fix updates the `Claims` struct to use `Vec<String>` instead of `String` for the `aud` field, along with a custom deserializer to handle both string and array formats.

### fix: Add custom deserializer to handle APOLLO_UPLINK_ENDPOINTS environment variable parsing - @swcollard PR #220

The APOLLO_UPLINK_ENDPOINTS environment variables has historically been a comma separated list of URL strings.
The move to yaml configuration allows us to more directly define the endpoints as a Vec.
This fix introduces a custom deserializer for the `apollo_uplink_endpoints` config field that can handle both the environment variable comma separated string, and the yaml-based list.