### PR TITLE
Docs: Add cross links to the quickstart

### DIFF
--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -15,6 +15,8 @@ Let's run Apollo MCP Server for the first time! You will:
 - Run an MCP Server example
 - Connect an MCP client (Claude Desktop) to the MCP Server
 
+Want a quick overview of what we can do with Apollo MCP Server? Check out [this YouTube video](https://www.youtube.com/watch?v=QTvMYUP4E30) or [blog post](https://www.apollographql.com/blog/getting-started-with-apollo-mcp-server-for-any-graphql-api) about what we'll cover in more detail here.
+
 ## What You'll Build
 
 In this quickstart, you'll create a working AI integration where Claude Desktop can query space-related data through GraphQL. By the end, you'll be able to:


### PR DESCRIPTION
Provide some other options for getting to know Apollo MCP Server in case a developer doesn't want to run through the whole quickstart.
