### PR TITLE
ci: stop verifying changeset on push

### DIFF
--- a/.github/workflows/verify-changeset.yml
+++ b/.github/workflows/verify-changeset.yml
@@ -1,12 +1,5 @@
 name: Verify Changeset
 on:
-  push:
-    # don't run on tags, run on commits
-    # https://github.com/orgs/community/discussions/25615
-    tags-ignore:
-      - "**"
-    branches:
-      - main
   pull_request:
     paths-ignore:
       - '.github/**'


### PR DESCRIPTION
<img width="1910" height="702" alt="2025-08-15 at 09 19 06" src="https://github.com/user-attachments/assets/75eb40bb-c24c-45b8-be23-3436a3fb4536" />

https://github.com/apollographql/apollo-mcp-server/actions/runs/16979482955/job/48136230667

The `verify-changeset.yml` workflow fails on every push to main. This happens because during the push event, there's no `pull_request` context available, so `context.payload.pull_request` is `undefined`. When the workflow tries to access `pr.number`, it results in an error since `pr` is undefined:

```
TypeError: Cannot read properties of undefined (reading 'number')
```

I removed the push trigger from the workflow configuration. Once a PR is merged and the code is pushed to main, we don't need to verify changesets anymore. That verification should have already taken place during the PR review process.