### PR TITLE
docs: replace SSE with Streamable HTTP in the architecture diagram

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -40,7 +40,7 @@ graph LR
 
     %% Connections
     AI <-->|"Natural Language\nRequests"| MCPClient
-    MCPClient <-->|"MCP Protocol\n(stdio/SSE)"| MCPServer
+    MCPClient <-->|"MCP Protocol\n(stdio/Streamable HTTP)"| MCPServer
     MCPServer <-->|"GraphQL\nOperations"| GraphQL
     GraphQL <-->|"Data\nQueries"| Data
 


### PR DESCRIPTION
Updating the architecture diagram in the welcome docs to replace the old SSE transport with Streamable HTTP.

<img width="2574" height="1016" alt="2025-08-18 at 11 59 54" src="https://github.com/user-attachments/assets/93569f8d-c513-4206-b6d1-d5b4b79ec160" />
