### PR TITLE
docs: Add quickstart variant for Docker

### DIFF
--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -105,7 +105,7 @@ You can run the MCP Server using the Rover CLI or Docker.
         enabled: true
     ```
 
-Then, from the root directory of your local repo, run this Docker command to start a local graph with an MCP Server:
+1. In a new terminal, from the root directory of your local repo, run this Docker command to start the MCP Server:
     ```sh showLineNumbers=false
     docker run \
       -it --rm \
@@ -121,22 +121,24 @@ Then, from the root directory of your local repo, run this Docker command to sta
     - Maps configuration files into the proper place for the Apollo MCP Server container
     - Forwards port 5000 for accessing the MCP Server
 
-2. Start MCP Inspector to verify the server is running:
+## Step 3: Verify the MCP Server with MCP Inspector
+
+1. Start MCP Inspector to verify the server is running:
 
     ```sh
     npx @modelcontextprotocol/inspector
     ```
 
-3. Open a browser and go to [`http://127.0.0.1:6274`](http://127.0.0.1:6274)
+1. Open a browser and go to [`http://127.0.0.1:6274`](http://127.0.0.1:6274)
 
-4. In Inspector:
+1. In Inspector:
     - Select `Streamable HTTP` as the Transport Type
     - Enter `http://127.0.0.1:5000/mcp` as the URL
     - Click **Connect**, then **List Tools**
 
     You should see the tools from your server listed.
 
-## Step 3: Connect Claude Desktop
+## Step 4: Connect Claude Desktop
 
 We're using [Claude](https://claude.ai/download) as our AI Assistant (acting as our MCP Client).
 
@@ -171,7 +173,7 @@ You need Node v18 or later installed for `mcp-remote` to work. If you have an ol
 
 2. Restart Claude.
 
-## Step 4: Test Your Setup
+## Step 5: Test Your Setup with Claude
 
 Let's verify everything is working:
 


### PR DESCRIPTION
This change provides an alternative method for running the Apollo MCP Server. Rather than using Rover CLI, these instructions allow running the MCP Server Docker container directly.