### PR TITLE
chore: Update CODEOWNERS to include ai-runtime

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @apollographql/graph-tooling
-docs @apollographql/docs @apollographql/graph-tooling
+* @apollographql/ai-runtime
+docs @apollographql/docs @apollographql/ai-runtime


### PR DESCRIPTION
Swapping the code owner from the broader graph tooling team to the more newly scoped ai-runtime team