### PR TITLE
release: v0.7.3

### DIFF
--- a/.changesets/fix_openai_incompatibility.md
+++ b/.changesets/fix_openai_incompatibility.md
@@ -1,5 +1,0 @@
-### fix: generate openAI-compatible json schemas for list types - @DaleSeo PR #272
-
-The MCP server is generating JSON schemas that don't match OpenAI's function calling specification. It puts `oneOf` at the array level instead of using `items` to define the JSON schemas for the GraphQL list types. While some other LLMs are more flexible about this, it technically violates the [JSON Schema specification](https://json-schema.org/understanding-json-schema/reference/array) that OpenAI strictly follows.
-
-This PR updates the list type handling logic to move `oneOf` inside `items` for GraphQL list types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [0.7.3] - 2025-08-25
+
+## 🐛 Fixes
+
+### fix: generate openAI-compatible json schemas for list types - @DaleSeo PR #272
+
+The MCP server is generating JSON schemas that don't match OpenAI's function calling specification. It puts `oneOf` at the array level instead of using `items` to define the JSON schemas for the GraphQL list types. While some other LLMs are more flexible about this, it technically violates the [JSON Schema specification](https://json-schema.org/understanding-json-schema/reference/array) that OpenAI strictly follows.
+
+This PR updates the list type handling logic to move `oneOf` inside `items` for GraphQL list types.
+
 # [0.7.2] - 2025-08-19
 
 ## 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-mcp-registry"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "derive_more",
  "educe",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-mcp-server"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "apollo-compiler",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-schema-index"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "apollo-compiler",
  "enumset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [workspace.package]
 authors = ["Apollo <opensource@apollographql.com>"]
-version = "0.7.2"
+version = "0.7.3"
 
 [workspace.dependencies]
 apollo-compiler = "1.27.0"

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -187,7 +187,7 @@ mod test {
             "extensions": {
                 "clientLibrary": {
                     "name":"mcp",
-                    "version":"0.7.2"
+                    "version":"0.7.3"
                 }
             },
             "operationName":"mock_operation"
@@ -233,7 +233,7 @@ mod test {
                 },
                 "clientLibrary": {
                     "name":"mcp",
-                    "version":"0.7.2"
+                    "version":"0.7.3"
                 }
             },
         })

--- a/docs/source/install.mdx
+++ b/docs/source/install.mdx
@@ -26,14 +26,14 @@ To download a **specific version** of Apollo MCP Server (recommended for CI envi
 
 ```bash
 # Note the `v` prefixing the version number
-docker image pull ghcr.io/apollographql/apollo-mcp-server:v0.7.2
+docker image pull ghcr.io/apollographql/apollo-mcp-server:v0.7.3
 ```
 
 To download a specific version of Apollo MCP Server that is a release candidate:
 
 ```bash
 # Note the `v` prefixing the version number and the `-rc` suffix
-docker image pull ghcr.io/apollographql/apollo-mcp-server:v0.7.2-rc.1
+docker image pull ghcr.io/apollographql/apollo-mcp-server:v0.7.3-rc.1
 ```
 
 <Note>
@@ -65,7 +65,7 @@ To install or upgrade to a **specific version** of Apollo MCP Server (recommende
 
 ```bash
 # Note the `v` prefixing the version number
-curl -sSL https://mcp.apollo.dev/download/nix/v0.7.2 | sh
+curl -sSL https://mcp.apollo.dev/download/nix/v0.7.3 | sh
 ```
 
 If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
@@ -82,5 +82,5 @@ To install or upgrade to a **specific version** of Apollo MCP Server (recommende
 
 ```bash
 # Note the `v` prefixing the version number
-iwr 'https://mcp.apollo.dev/download/win/v0.7.2' | iex
+iwr 'https://mcp.apollo.dev/download/win/v0.7.3' | iex
 ```

--- a/scripts/nix/install.sh
+++ b/scripts/nix/install.sh
@@ -14,7 +14,7 @@ BINARY_DOWNLOAD_PREFIX="${APOLLO_MCP_SERVER_BINARY_DOWNLOAD_PREFIX:="https://git
 
 # Apollo MCP Server version defined in apollo-mcp-server's Cargo.toml
 # Note: Change this line manually during the release steps.
-PACKAGE_VERSION="v0.7.2"
+PACKAGE_VERSION="v0.7.3"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -8,7 +8,7 @@
 
 # Apollo MCP Server version defined in apollo-mcp-server's Cargo.toml
 # Note: Change this line manually during the release steps.
-$package_version = 'v0.7.2'
+$package_version = 'v0.7.3'
 
 function Install-Binary($apollo_mcp_server_install_args) {
   $old_erroractionpreference = $ErrorActionPreference


### PR DESCRIPTION
# [0.7.3] - 2025-08-25

## 🐛 Fixes

### fix: generate openAI-compatible json schemas for list types - @DaleSeo PR #272

The MCP server is generating JSON schemas that don't match OpenAI's function calling specification. It puts `oneOf` at the array level instead of using `items` to define the JSON schemas for the GraphQL list types. While some other LLMs are more flexible about this, it technically violates the [JSON Schema specification](https://json-schema.org/understanding-json-schema/reference/array) that OpenAI strictly follows.

This PR updates the list type handling logic to move `oneOf` inside `items` for GraphQL list types.