### PR TITLE
fix(ci): pin to specific stable rust version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,14 +1,43 @@
 {
+  // Allow for intellisense in editors
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
+
+  // List of rules to apply
+  extends: [
+    // Recommended best practices from renovate itself
+    // See: https://docs.renovatebot.com/upgrade-best-practices/#whats-in-the-configbest-practices-preset
+    "config:best-practices",
+
+    // Apply our own internal best practices
+    // See: https://github.com/apollographql/apollo-mcp-server/commits/main/.github/renovate.json5
+    "github>apollographql/renovate-config-apollo-open-source:default.json5",
+
+    // Update to the latest rust stable version as it releases.
+    // See: https://github.com/Turbo87/renovate-config/blob/master/rust/updateToolchain.json
+    "github>Turbo87/renovate-config//rust/updateToolchain",
+  ],
+
+  // Globally disable all automatic update PRs from renovate
   packageRules: [
     {
       enabled: false,
       matchPackageNames: ["*"],
     },
   ],
+
+  // Globally enable vulnerability alerts
+  //
+  // Note: This needs extra configuration at the repository level, which is described in the link
+  // below.
+  //
+  // See: https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts
   vulnerabilityAlerts: {
     enabled: true,
   },
+
+  // Disable automatically updating lock files to latest versions once a week.
+  //
+  // See: https://docs.renovatebot.com/configuration-options/#lockfilemaintenance
   lockFileMaintenance: {
     enabled: false,
   },

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ members = [
 
 [workspace.package]
 authors = ["Apollo <opensource@apollographql.com>"]
+edition = "2024"
+license-file = "LICENSE"
+repository = "https://github.com/apollographql/apollo-mcp-server"
+rust-version = "1.89.0"
 version = "0.7.2"
 
 [workspace.dependencies]

--- a/crates/apollo-mcp-registry/Cargo.toml
+++ b/crates/apollo-mcp-registry/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "apollo-mcp-registry"
-version.workspace = true
-edition = "2024"
 authors.workspace = true
-license-file = "../LICENSE"
-repository = "https://github.com/apollographql/apollo-mcp-server"
+edition.workspace = true
+license-file.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
 description = "Registry providing schema and operations to the MCP Server"
 
 [dependencies]

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "apollo-mcp-server"
-version.workspace = true
 authors.workspace = true
-edition = "2024"
-license-file = "../LICENSE"
+edition.workspace = true
+license-file.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
 default-run = "apollo-mcp-server"
 
 [dependencies]

--- a/crates/apollo-schema-index/Cargo.toml
+++ b/crates/apollo-schema-index/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "apollo-schema-index"
-edition = "2024"
 authors.workspace = true
+edition.workspace = true
+license-file.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 version.workspace = true
-license-file = "../LICENSE"
-repository = "https://github.com/apollographql/apollo-mcp-server"
+
 description = "GraphQL schema indexing"
 
 [dependencies]

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "cache-nix-action": {
       "flake": false,
       "locked": {
-        "lastModified": 1746350578,
-        "narHash": "sha256-66auSJUldF+QLnMZEvOR9y9+P6doadeHmYl5UDFqVic=",
+        "lastModified": 1754213534,
+        "narHash": "sha256-4QgmQ8UAecAuu84hh5dYni1ahlvXvu2UdCDme6Jnh68=",
         "owner": "nix-community",
         "repo": "cache-nix-action",
-        "rev": "76f6697d63b7378f7161d52f3d81784130ecd90d",
+        "rev": "e2cf51da82e145785f5db595f553f7cbc2ca54df",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1751562746,
-        "narHash": "sha256-smpugNIkmDeicNz301Ll1bD7nFOty97T79m4GUMUczA=",
+        "lastModified": 1755993354,
+        "narHash": "sha256-FCRRAzSaL/+umLIm3RU3O/+fJ2ssaPHseI2SSFL8yZU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "aed2020fd3dc26e1e857d4107a5a67a33ab6c1fd",
+        "rev": "25bd41b24426c7734278c2ff02e53258851db914",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751510438,
-        "narHash": "sha256-m8PjOoyyCR4nhqtHEBP1tB/jF+gJYYguSZmUmVTEAQE=",
+        "lastModified": 1756089517,
+        "narHash": "sha256-KGinVKturJFPrRebgvyUB1BUNqf1y9FN+tSJaTPlnFE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7f415261f298656f8164bd636c0dc05af4e95b6b",
+        "rev": "44774c8c83cd392c50914f86e1ff75ef8619f1cd",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "unstable": {
       "locked": {
-        "lastModified": 1751498133,
-        "narHash": "sha256-QWJ+NQbMU+NcU2xiyo7SNox1fAuwksGlQhpzBl76g1I=",
+        "lastModified": 1756128520,
+        "narHash": "sha256-R94HxJBi+RK1iCm8Y4Q9pdrHZl0GZoDPIaYwjxRNPh4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d55716bb59b91ae9d1ced4b1ccdea7a442ecbfdb",
+        "rev": "c53baa6685261e5253a1c355a1b322f82674a824",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.89.0"
 profile = "default"
 components = ["rust-analyzer", "rust-src"]


### PR DESCRIPTION
This PR pins the `rust-toolchain` to a specific rust version for compatibility guarantees. Renovate will handle warning on outdated versions of stable rust as they release.

A minimal supported rust version was also added to the underlying crates to account for future stable version bumps.