### PR TITLE
ci: using gh cli for PR creation and adding a fallback in case of merge conflicts

### DIFF
--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -48,6 +48,7 @@ jobs:
       HEAD_BRANCH: ${{ (github.event_name == 'workflow_dispatch' && inputs.head_branch) || 'main' }}
       BASE_BRANCH: ${{ (github.event_name == 'workflow_dispatch' && inputs.base_branch) || 'develop' }}
       SOURCE_PR: ${{ (github.event_name == 'pull_request' && github.event.pull_request.number) || inputs.source_pr_number || '' }}
+      GH_TOKEN: ${{ secrets.GH_PAT }}
 
     steps:
       - uses: actions/checkout@v4
@@ -91,34 +92,94 @@ jobs:
           git push origin HEAD
           echo "merge_status=$rc" >> "$GITHUB_OUTPUT"
 
-      # Open the PR targeting develop
+      # If no merge conflict, open the PR targeting develop
       - name: Open PR to develop
-        id: syncpr
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.GH_PAT }}
-          branch: ${{ steps.meta.outputs.branch }}
-          base: ${{ env.BASE_BRANCH }}
-          title: ${{ steps.meta.outputs.title }}
-          body:  |
-            ${{ steps.meta.outputs.body }}
+        id: sync_pr
+        if: ${{ steps.prep.outputs.merge_status == '0' }}
+        run: |
+          # Does sync branch actually differ from base?
+          read left right < <(git rev-list --left-right --count "origin/${BASE_BRANCH}...HEAD")
+          if [ "$right" -eq 0 ]; then
+            echo "No diff; skipping gh pr create"
+            exit 0
+          fi
 
-            Merge status: ${{ steps.prep.outputs.merge_status == '0' && 'clean ✅' || 'conflicts ❗' }}
-          labels: ${{ steps.prep.outputs.merge_status == '0' && 'back-merge,automation' || 'back-merge,automation,conflicts' }}
+          # Avoid duplicate PRs
+          existing=$(gh pr list --base "${BASE_BRANCH}" --head "${{ steps.meta.outputs.branch }}" --state open --json number --jq '.[0].number' || true)
+          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+            echo "pr_number=$existing" >> "$GITHUB_OUTPUT"
+            url=$(gh pr view "$existing" --json url --jq .url)
+            echo "pr_url=$url" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          gh pr create \
+            --base "${BASE_BRANCH}" \
+            --head "${{ steps.meta.outputs.branch }}" \
+            --title "${{ steps.meta.outputs.title }}" \
+            --body  "${{ steps.meta.outputs.body }} (created via gh CLI)"
+            --label back-merge --label automation
+
+          # Emit outputs for later steps
+          gh pr view --base "${BASE_BRANCH}" --head "${{ steps.meta.outputs.branch }}" \
+            --json number,url | jq -r '"pr_number=\(.number)\npr_url=\(.url)"' >> "$GITHUB_OUTPUT"
+
+      # If the merge hit conflicts, open a DIRECT PR: HEAD_BRANCH -> BASE_BRANCH so conflicts can be resolved prior to merge
+      - name: Open direct PR via gh (conflicts fallback)
+        id: pr_fallback
+        if: ${{ steps.prep.outputs.merge_status != '0' }}
+        run: |
+          # Skip if no diff between head and base
+          read left right < <(git rev-list --left-right --count "origin/${BASE_BRANCH}...origin/${HEAD_BRANCH}")
+          if [ "$right" -eq 0 ]; then
+            echo "No diff between ${HEAD_BRANCH} and ${BASE_BRANCH}; nothing to open."
+            exit 0
+          fi
+          
+          # Reuse existing open PR if present
+          existing=$(gh pr list --base "${BASE_BRANCH}" --head "${HEAD_BRANCH}" --state open --json number --jq '.[0].number' || true)
+          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+            echo "pr_number=$existing" >> "$GITHUB_OUTPUT"
+            url=$(gh pr view "$existing" --json url --jq .url)
+            echo "pr_url=$url" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          
+          gh pr create \
+            --base "${BASE_BRANCH}" \
+            --head "${HEAD_BRANCH}" \
+            --title "Sync ${HEAD_BRANCH} → ${BASE_BRANCH} (resolve conflicts)" \
+            --body  "Auto-opened via gh CLI because the automatic merge into a sync branch hit conflicts."
+            --label back-merge --label automation --label conflicts
+          
+          gh pr view --base "${BASE_BRANCH}" --head "${HEAD_BRANCH}" \
+            --json number,url | jq -r '"pr_number=\(.number)\npr_url=\(.url)"' >> "$GITHUB_OUTPUT"
 
       # Comment back on the ORIGINAL merged PR with a link to the sync PR
       - name: Comment on source PR with sync PR link
-        if: steps.syncpr.outputs.pull-request-url != '' && env.SOURCE_PR != ''
+        if: ${{ env.SOURCE_PR != '' && (steps.sync_pr.outputs.pr_number != '' || steps.pr_fallback.outputs.pr_number != '') }}
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PAT }}
           script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
             const issue_number = Number(process.env.SOURCE_PR);
-            const syncUrl = `${{ toJson(steps.syncpr.outputs['pull-request-url']) }}`.replace(/^"|"$/g, '');
-            const body = `Opened sync PR **${process.env.HEAD_BRANCH} → ${process.env.BASE_BRANCH}**: ${syncUrl}`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number,
-              body,
-            });
+      
+            const hadConflicts = '${{ steps.prep.outputs.merge_status }}' !== '0';
+            const syncUrl = '${{ steps.sync_pr.outputs.pr_url || steps.pr_fallback.outputs.pr_url }}';
+            const head = process.env.HEAD_BRANCH;
+            const base = process.env.BASE_BRANCH;
+      
+            const status = hadConflicts ? 'conflicts ❗' : 'clean ✅';
+            const note = hadConflicts
+            ? 'This was opened as a **direct PR** so conflicts can be resolved in the GitHub UI.'
+            : 'This was opened from a **sync branch** and is ready for review.';
+      
+            const body = [
+            `Opened sync PR **${head} → ${base}**: ${url}`,
+            ``,
+            `Merge status: **${status}**`,
+            note
+            ].join('\n');
+      
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });


### PR DESCRIPTION
1. Using GH CLI for PR creation
2. Adding fallback in case of merge conflicts
3. Updating comment to include merge conflict status