### PR TITLE
Implement metrics for mcp tool and operation counts and durations

### DIFF
--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use apollo_compiler::{Schema, validation::Valid};
 use headers::HeaderMapExt as _;
-use opentelemetry::Context;
 use opentelemetry::trace::FutureExt;
+use opentelemetry::{Context, KeyValue, global};
 use reqwest::header::HeaderMap;
 use rmcp::model::Implementation;
 use rmcp::{
@@ -177,6 +177,11 @@ impl ServerHandler for Running {
         _request: InitializeRequestParam,
         context: RequestContext<RoleServer>,
     ) -> Result<InitializeResult, McpError> {
+        let meter = global::meter("apollo.mcp");
+        meter
+            .u64_counter("apollo.mcp.initialize.count")
+            .build()
+            .add(1, &[]);
         // TODO: how to remove these?
         let mut peers = self.peers.write().await;
         peers.push(context.peer);
@@ -189,25 +194,28 @@ impl ServerHandler for Running {
         request: CallToolRequestParam,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
-        let result = match request.name.as_ref() {
+        let meter = global::meter("apollo.mcp");
+        let start = std::time::Instant::now();
+        let tool_name = request.name.clone();
+        let result = match tool_name.as_ref() {
             INTROSPECT_TOOL_NAME => {
                 self.introspect_tool
                     .as_ref()
-                    .ok_or(tool_not_found(&request.name))?
+                    .ok_or(tool_not_found(&tool_name))?
                     .execute(convert_arguments(request)?)
                     .await
             }
             SEARCH_TOOL_NAME => {
                 self.search_tool
                     .as_ref()
-                    .ok_or(tool_not_found(&request.name))?
+                    .ok_or(tool_not_found(&tool_name))?
                     .execute(convert_arguments(request)?)
                     .await
             }
             EXPLORER_TOOL_NAME => {
                 self.explorer_tool
                     .as_ref()
-                    .ok_or(tool_not_found(&request.name))?
+                    .ok_or(tool_not_found(&tool_name))?
                     .execute(convert_arguments(request)?)
                     .await
             }
@@ -222,7 +230,7 @@ impl ServerHandler for Running {
 
                 self.execute_tool
                     .as_ref()
-                    .ok_or(tool_not_found(&request.name))?
+                    .ok_or(tool_not_found(&tool_name))?
                     .execute(graphql::Request {
                         input: Value::from(request.arguments.clone()),
                         endpoint: &self.endpoint,
@@ -233,7 +241,7 @@ impl ServerHandler for Running {
             VALIDATE_TOOL_NAME => {
                 self.validate_tool
                     .as_ref()
-                    .ok_or(tool_not_found(&request.name))?
+                    .ok_or(tool_not_found(&tool_name))?
                     .execute(convert_arguments(request)?)
                     .await
             }
@@ -260,8 +268,8 @@ impl ServerHandler for Running {
                     .lock()
                     .await
                     .iter()
-                    .find(|op| op.as_ref().name == request.name)
-                    .ok_or(tool_not_found(&request.name))?
+                    .find(|op| op.as_ref().name == tool_name)
+                    .ok_or(tool_not_found(&tool_name))?
                     .execute(graphql_request)
                     .with_context(Context::current())
                     .await
@@ -273,6 +281,28 @@ impl ServerHandler for Running {
             health_check.record_rejection();
         }
 
+        let attributes = vec![
+            KeyValue::new(
+                "success",
+                result.is_ok()
+                    && result
+                        .as_ref()
+                        .ok()
+                        .map(|r| r.is_error != Some(true))
+                        .unwrap_or(false),
+            ),
+            KeyValue::new("tool_name", tool_name),
+        ];
+        // Record response time and status
+        meter
+            .f64_histogram("apollo.mcp.tool.duration")
+            .build()
+            .record(start.elapsed().as_millis() as f64, &attributes);
+        meter
+            .u64_counter("apollo.mcp.tool.count")
+            .build()
+            .add(1, &attributes);
+
         result
     }
 
@@ -282,6 +312,11 @@ impl ServerHandler for Running {
         _request: Option<PaginatedRequestParam>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
+        let meter = global::meter("apollo.mcp");
+        meter
+            .u64_counter("apollo.mcp.list_tools.count")
+            .build()
+            .add(1, &[]);
         Ok(ListToolsResult {
             next_cursor: None,
             tools: self
@@ -300,6 +335,11 @@ impl ServerHandler for Running {
     }
 
     fn get_info(&self) -> ServerInfo {
+        let meter = global::meter("apollo.mcp");
+        meter
+            .u64_counter("apollo.mcp.get_info.count")
+            .build()
+            .add(1, &[]);
         ServerInfo {
             server_info: Implementation {
                 name: "Apollo MCP Server".to_string(),


### PR DESCRIPTION
## Apollo MCP Server Metrics

This PR adds metrics to count and measure request duration throughout the MCP server

* All metrics use the OpenTelemetry meter with scop `apollo.mcp`
* Duration metrics are recorded in milliseconds
* Metrics are recorded after operation completion to capture final success/error state

Metric Name | Metric Type | Attributes | Description | Location
-- | -- | -- | -- | --
apollo.mcp.operation.duration | f64_histogram | success (bool), operation.id (string), operation.type (string) | Records the duration of GraphQL operations in milliseconds | graphql.rs
apollo.mcp.operation.count | u64_counter | success (bool), operation.id (string), operation.type (string) | Counts the number of GraphQL operations executed | graphql.rs
apollo.mcp.tool.duration | f64_histogram | success (bool), tool_name (string) | Records the duration of MCP tool calls in milliseconds | server/states/running.rs
apollo.mcp.tool.count | u64_counter | success (bool), tool_name (string) | Counts the number of MCP tool calls | server/states/running.rs
apollo.mcp.initialize.count | u64_counter | None | Counts server initialization events | server/states/running.rs
apollo.mcp.list_tools.count | u64_counter | None | Counts list tools requests | server/states/running.rs
apollo.mcp.get_info.count | u64_counter | None | Counts get info requests | server/states/running.rs


### Operation-Specific Attributes
* `operation.id`: String containing the operation identifier (persisted query ID or operation name, defaults to "unknown")</li>
* `operation.type`: String indicating the type of operation:
  * `persisted_query` for operations using persisted query IDs
  * the operation name, or `unknown` for regular GraphQL operations

### Tool-Specific Attributes

* `tool_name`: String containing the name of the MCP tool being called (e.g., "introspect", "search", "explorer", "execute", "validate", or custom operation names)