### PR TITLE
fix: Add missing token propagation for execute tool

### DIFF
--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -210,6 +210,11 @@ impl ServerHandler for Running {
             EXECUTE_TOOL_NAME => {
                 let mut headers = self.headers.clone();
                 if let Some(axum_parts) = context.extensions.get::<axum::http::request::Parts>() {
+                    // Optionally extract the validated token and propagate it to upstream servers if present
+                    if let Some(token) = axum_parts.extensions.get::<ValidToken>() {
+                        headers.typed_insert(token.deref().clone());
+                    }
+
                     // Forward the mcp-session-id header if present
                     if let Some(session_id) = axum_parts.headers.get("mcp-session-id") {
                         headers.insert("mcp-session-id", session_id.clone());


### PR DESCRIPTION
The execute tool is not forwarding JWT authentication tokens to upstream GraphQL endpoints, causing authentication failures when using this tool with protected APIs.