### PR TITLE
ci: adding a skip for the changeset verification if a label is applied

### DIFF
--- a/.github/workflows/verify-changeset.yml
+++ b/.github/workflows/verify-changeset.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   verify-changeset:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changeset') }}
     name: Verify
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
Cherry picking from develop the verify changeset skip via label