### PR TITLE
test: hardcoded version strings in tests

### DIFF
--- a/.changesets/maint_hardcoded_versions.md
+++ b/.changesets/maint_hardcoded_versions.md
@@ -1,0 +1,3 @@
+### Hardcoded version strings in tests - @DaleSeo PR #305
+
+The GraphQL tests have hardcoded version strings that we need to update manually each time we release a new version. Since this isn't included in the release checklist, it's easy to miss it and only notice the test failures later.

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -187,7 +187,7 @@ mod test {
             "extensions": {
                 "clientLibrary": {
                     "name":"mcp",
-                    "version":"0.7.4"
+                    "version": std::env!("CARGO_PKG_VERSION")
                 }
             },
             "operationName":"mock_operation"
@@ -233,7 +233,7 @@ mod test {
                 },
                 "clientLibrary": {
                     "name":"mcp",
-                    "version":"0.7.4"
+                    "version": std::env!("CARGO_PKG_VERSION")
                 }
             },
         })


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/GT-375 -->

The GraphQL tests have hardcoded version strings that we need to update manually each time we release a new version. Since this isn't included in the release checklist, it's easy to miss it and only notice the test failures later.