### PR TITLE
Update snapshots in custom_scalar_map.rs

### DIFF
--- a/crates/apollo-mcp-server/src/custom_scalar_map.rs
+++ b/crates/apollo-mcp-server/src/custom_scalar_map.rs
@@ -94,33 +94,33 @@ mod tests {
     fn empty_file() {
         let result = CustomScalarMap::from_str("").err().unwrap();
 
-        insta::assert_debug_snapshot!(result, @r###"
-            CustomScalarConfig(
-                Error("EOF while parsing a value", line: 1, column: 0),
-            )
-        "###)
+        insta::assert_debug_snapshot!(result, @r#"
+        CustomScalarConfig(
+            Error("EOF while parsing a value", line: 1, column: 0),
+        )
+        "#)
     }
 
     #[test]
     fn only_spaces() {
         let result = CustomScalarMap::from_str("    ").err().unwrap();
 
-        insta::assert_debug_snapshot!(result, @r###"
-            CustomScalarConfig(
-                Error("EOF while parsing a value", line: 1, column: 4),
-            )
-        "###)
+        insta::assert_debug_snapshot!(result, @r#"
+        CustomScalarConfig(
+            Error("EOF while parsing a value", line: 1, column: 4),
+        )
+        "#)
     }
 
     #[test]
     fn invalid_json() {
         let result = CustomScalarMap::from_str("Hello: }").err().unwrap();
 
-        insta::assert_debug_snapshot!(result, @r###"
-            CustomScalarConfig(
-                Error("expected value", line: 1, column: 1),
-            )
-        "###)
+        insta::assert_debug_snapshot!(result, @r#"
+        CustomScalarConfig(
+            Error("expected value", line: 1, column: 1),
+        )
+        "#)
     }
 
     #[test]
@@ -135,13 +135,13 @@ mod tests {
         .err()
         .unwrap();
 
-        insta::assert_debug_snapshot!(result, @r###"
-            CustomScalarJsonSchema(
-                Object {
-                    "test": Bool(true),
-                },
-            )
-        "###)
+        insta::assert_debug_snapshot!(result, @r#"
+        CustomScalarJsonSchema(
+            Object {
+                "test": Bool(true),
+            },
+        )
+        "#)
     }
 
     #[test]
@@ -161,7 +161,7 @@ mod tests {
         .err()
         .unwrap();
 
-        insta::assert_debug_snapshot!(result, @r###"
+        insta::assert_debug_snapshot!(result, @r#"
         CustomScalarJsonSchema(
             Object {
                 "type": String("object"),
@@ -172,7 +172,7 @@ mod tests {
                 },
             },
         )
-        "###)
+        "#)
     }
 
     #[test]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -39,4 +39,4 @@ tokio = { version = "1.36.0", features = ["full"] }
 which = "7.0.0"
 
 [dev-dependencies]
-insta = { version = "1.35.1", features = ["json", "redactions", "yaml"] }
+insta = { version = "1.43.1", features = ["json", "redactions", "yaml"] }


### PR DESCRIPTION
This PR follows up on https://github.com/apollographql/apollo-mcp-server/pull/272#discussion_r2294333085 and updates all inline snapshots to ensure they are consistent with the latest insta format. The insta crate in the xtask crate has also been bumped to 1.43.1.

<img width="1582" height="182" alt="image" src="https://github.com/user-attachments/assets/c086a0fe-bc14-4ee5-8e6b-d4e1d7fc6f7b" />

https://insta.rs/changelog/#1-40-0