### PR TITLE
ci: fixes to the canary generation workflow

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -32,6 +32,11 @@ jobs:
 
   release_canary_container:
     needs: compute_canary_version
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     uses: ./.github/workflows/release-container.yml
     with:
       version: ${{ needs.compute_canary_version.outputs.version }}


### PR DESCRIPTION
Adding missing permissions to the canary generation workflow