### PR TITLE
test: adding a basic manual e2e test for mcp server

### DIFF
--- a/.changesets/feat_alocay_add_basic_e2e_test.md
+++ b/.changesets/feat_alocay_add_basic_e2e_test.md
@@ -1,0 +1,15 @@
+### test: adding a basic manual e2e test for mcp server - @alocay PR #320
+
+Adding some basic e2e tests using [mcp-server-tester](https://github.com/steviec/mcp-server-tester). Currently, the tool does not always exit (ctrl+c is sometimes needed) so this should be run manually.
+
+### How to run tests?
+Added a script `run_tests.sh` (may need to run `chmod +x` to run it) to run tests. Basic usage found via `./run_tests.sh -h`. The script does the following:
+
+1. Builds test/config yaml paths and verifies the files exist.
+2. Checks if release `apollo-mcp-server` binary exists. If not, it builds the binary via `cargo build --release`.
+3. Reads in the template file (used by `mcp-server-tester`) and replaces all `<test-dir>` placeholders with the test directory value. Generates this test server config file and places it in a temp location.
+4. Invokes the `mcp-server-tester` via `npx`.
+5. On script exit the generated config is cleaned up.
+
+### Example run: 
+To run the tests for `local-operations` simply run `./run_tests.sh local-operations`

--- a/e2e/mcp-server-tester/local-operations/api.graphql
+++ b/e2e/mcp-server-tester/local-operations/api.graphql
@@ -1,0 +1,525 @@
+type Agency {
+  id: ID!
+  name: String
+  abbrev: String
+  type: String
+  featured: Boolean
+  country: [Country]
+  description: String
+  administrator: String
+  foundingYear: Int
+  spacecraft: String
+  image: Image
+  logo: Image
+  socialLogo: Image
+  totalLaunchCount: Int
+  consecutiveSuccessfulLaunches: Int
+  successfulLaunches: Int
+  failedLaunches: Int
+  pendingLaunches: Int
+  consecutiveSuccessfulLandings: Int
+  successfulLandings: Int
+  failedLandings: Int
+  attemptedLandings: Int
+  successfulLandingsSpacecraft: Int
+  failedLandingsSpacecraft: Int
+  attemptedLandingsSpacecraft: Int
+  successfulLandingsPayload: Int
+  failedLandingsPayload: Int
+  attemptedLandingsPayload: Int
+  infoUrl: String
+  wikiUrl: String
+  socialMediaLinks: [SocialMediaLink]
+}
+
+type AgencyConnection {
+  pageInfo: PageInfo
+  results: [Agency]
+}
+
+type ApiThrottle {
+  yourRequestLimit: Int
+  limitFrequencySecs: Int
+  currentUse: Int
+  nextUseSecs: Int
+  ident: String
+}
+
+type Astronaut {
+  id: ID!
+  name: String
+  status: String
+  agency: Agency
+  image: Image
+  type: String
+  inSpace: Boolean
+  timeInSpace: String
+  evaTime: String
+  age: Int
+  dateOfBirth: String
+  dateOfDeath: String
+  nationality: Country
+  bio: String
+  wiki: String
+  lastFlight: String
+  firstFlight: String
+  socialMediaLinks: [SocialMediaLink]
+}
+
+type AstronautConnection {
+  pageInfo: PageInfo
+  results: [Astronaut]
+}
+
+input AstronautFilters {
+  search: String
+  inSpace: Boolean
+}
+
+type CelestialBody {
+  id: ID!
+  name: String
+  type: CelestialType
+  diameter: Float
+  mass: Float
+  gravity: Float
+  lengthOfDay: String
+  atmosphere: Boolean
+  image: Image
+  description: String
+  wikiUrl: String
+}
+
+type CelestialBodyConnection {
+  pageInfo: PageInfo
+  results: [CelestialBody]
+}
+
+type CelestialType {
+  id: ID!
+  name: String
+}
+
+type Country {
+  id: ID!
+  name: String
+  alpha2Code: String
+  alpha3Code: String
+  nationalityName: String
+  nationalityNameComposed: String
+}
+
+type DockingEvent {
+  id: ID!
+  docking: String
+  departure: String
+  dockingLocation: DockingLocation
+  spaceStationTarget: SpaceStationTarget
+  flightVehicleTarget: FlightVehicleTarget
+  payloadFlightTarget: PayloadFlightTarget
+  flightVehicleChaser: FlightVehicleChaser
+  spaceStationChaser: SpaceStationChaser
+  payloadFlightChaser: PayloadFlightChaser
+}
+
+type DockingEventConnection {
+  pageInfo: PageInfo
+  results: [DockingEvent]
+}
+
+type DockingLocation {
+  id: ID!
+  name: String
+  spacestation: SpaceStation
+  spacecraft: Spacecraft
+  payload: Payload
+}
+
+type FlightVehicleChaser {
+  id: ID!
+  destination: String
+  missionEnd: String
+  spacecraft: Spacecraft
+  launch: Launch
+  landing: Landing
+}
+
+type FlightVehicleTarget {
+  id: ID!
+  destination: String
+  missionEnd: String
+  spacecraft: Spacecraft
+}
+
+type Image {
+  id: ID!
+  name: String
+  url: String
+  thumbnail: String
+  credit: String
+  singleUse: Boolean
+  license: ImageLicense
+}
+
+type ImageLicense {
+  name: String
+  link: String
+}
+
+type InfoUrl {
+  priority: Int
+  source: String
+  title: String
+  description: String
+  featureImage: String
+  url: String
+  type: String
+  language: Language
+}
+
+type Landing {
+  id: ID!
+  type: LandingType
+  attempt: Boolean
+  success: Boolean
+  description: String
+  downrangeDistance: String
+  landingLocation: LandingLocation
+}
+
+type LandingLocation {
+  id: ID!
+  name: String
+  active: Boolean
+  abbrev: String
+  description: String
+  location: Location
+  longitude: String
+  latitude: String
+  image: Image
+  landings: SuccessCount
+  celestialBody: CelestialBody
+}
+
+type LandingType {
+  id: ID!
+  name: String
+  abbrev: String
+  description: String
+}
+
+type Language {
+  id: ID!
+  name: String
+  code: String
+}
+
+type Launch {
+  id: ID!
+  name: String
+  launchDesignator: String
+  status: LaunchStatus
+  lastUpdated: String
+  net: String
+  netPrecision: String
+  window: LaunchWindow
+  image: Image
+  infographic: String
+  probability: Float
+  weatherConcerns: String
+  failreason: String
+  hashtag: String
+  provider: Agency
+  rocket: Rocket
+  mission: Mission
+  pad: Pad
+  webcastLive: Boolean
+  program: Program
+  orbitalLaunchAttemps: Int
+  locationLaunchAttemps: Int
+  padLaunchAttemps: Int
+  agencyLaunchAttemps: Int
+  orbitalLaunchAttempsYear: Int
+  locationLaunchAttempsYear: Int
+  padLaunchAttempsYear: Int
+  agencyLaunchAttempsYear: Int
+}
+
+type LaunchConnection {
+  pageInfo: PageInfo
+  results: [Launch]
+}
+
+type LaunchStatus {
+  id: ID!
+  name: String
+  abbrev: String
+  description: String
+}
+
+type LaunchWindow {
+  start: String
+  end: String
+}
+
+type Location {
+  id: ID!
+  name: String
+  active: Boolean
+  country: Country
+  image: Image
+  mapImage: String
+  longitude: String
+  latitude: String
+  totalLaunchCount: Int
+  totalLandingCount: Int
+  description: String
+  timezone: String
+}
+
+type Manufacturer {
+  id: ID!
+  name: String
+  abbrev: String
+  type: String
+  featured: Boolean
+  country: Country
+  description: String
+  administrator: String
+  foundingYear: Int
+  spacecraft: String
+  image: Image
+  logo: Image
+  socialLogo: Image
+}
+
+type Mission {
+  id: ID!
+  name: String
+  type: String
+  description: String
+  image: Image
+  orbit: Orbit
+  agencies: [Agency]
+  infoUrls: [InfoUrl]
+  vidUrls: [VideoUrl]
+}
+
+type MissionPatch {
+  id: ID!
+  name: String
+  priority: Int
+  imageUrl: String
+  agency: Agency
+}
+
+type Orbit {
+  id: ID!
+  name: String
+  abbrev: String
+  celestialBody: CelestialBody
+}
+
+type Pad {
+  id: ID!
+  active: Boolean
+  agencies: [Agency]
+  name: String
+  image: Image
+  description: String
+  infoUrl: String
+  wikiUrl: String
+  mapUrl: String
+  latitude: Float
+  longitude: Float
+  country: Country
+  mapImage: String
+  launchTotalCount: Int
+  orbitalLaunchAttemptCount: Int
+  fastestTurnaround: String
+  location: Location
+}
+
+type PageInfo {
+  count: Int
+  next: String
+  previous: String
+}
+
+type Payload {
+  id: ID!
+  name: String
+  type: String
+  manufacturer: Manufacturer
+  operator: Agency
+  image: Image
+  wikiLink: String
+  infoLink: String
+  program: Program
+  cost: Float
+  mass: Float
+  description: String
+}
+
+type PayloadFlightChaser {
+  id: ID!
+  url: String
+  destination: String
+  amount: String
+  payload: Payload
+  launch: Launch
+  landing: Landing
+}
+
+type PayloadFlightTarget {
+  id: ID!
+  destination: String
+  amount: String
+  payload: Payload
+  launch: Launch
+  landing: Landing
+}
+
+type Program {
+  id: ID!
+  name: String
+  image: Image
+  infoUrl: String
+  wikiUrl: String
+  description: String
+  agencies: [Agency]
+  startDate: String
+  endDate: String
+  missionPatches: [MissionPatch]
+}
+
+type Query {
+  agency(id: ID!): Agency
+  agencies(search: String, offset: Int = 0, limit: Int = 20): AgencyConnection
+  apiThrottle: ApiThrottle
+  astronaut(id: ID!): Astronaut
+  astronauts(filters: AstronautFilters, offset: Int = 0, limit: Int = 20): AstronautConnection
+  celestialBody(id: ID!): CelestialBody
+  celestialBodies(search: String, offset: Int = 0, limit: Int = 20): CelestialBodyConnection
+  dockingEvent(id: ID!): DockingEvent
+  dockingEvents(search: String, offset: Int = 0, limit: Int = 20): DockingEventConnection
+  launch(id: ID!): Launch
+  launches(search: String, limit: Int = 5, offset: Int = 0): LaunchConnection
+  previousLaunces(search: String, limit: Int = 5, offset: Int = 0): LaunchConnection
+  upcomingLaunches(search: String, limit: Int = 5, offset: Int = 0): LaunchConnection
+}
+
+type Rocket {
+  id: ID!
+  configuration: RocketLaunchConfigurations
+}
+
+type RocketFamily {
+  id: ID!
+  name: String
+}
+
+type RocketLaunchConfigurations {
+  id: ID!
+  name: String
+  fullName: String
+  variant: String
+  families: [RocketFamily]
+}
+
+type SocialMedia {
+  id: ID!
+  name: String
+  url: String
+  logo: Image
+}
+
+type SocialMediaLink {
+  id: ID!
+  url: String
+  socialMedia: SocialMedia
+}
+
+type Spacecraft {
+  id: ID!
+  name: String
+  type: String
+  agency: Agency
+  family: SpacecraftFamily
+  inUse: Boolean
+  serialNumber: String
+  isPlaceholder: Boolean
+  image: Image
+  inSpace: Boolean
+  timeInSpace: String
+  timeDocked: String
+  flightsCount: Int
+  missionEndsCount: Int
+  status: String
+  description: String
+  spacecraftConfig: SpacecraftConfig
+  fastestTurnaround: String
+}
+
+type SpacecraftConfig {
+  id: ID!
+  name: String
+  type: String
+  agency: Agency
+  family: SpacecraftFamily
+  inUse: Boolean
+  image: Image
+}
+
+type SpacecraftFamily {
+  id: ID!
+  name: String
+  description: String
+  manufacturer: Manufacturer
+  maidenFlight: String
+}
+
+type SpaceStation {
+  id: ID!
+  name: String
+  image: Image
+}
+
+type SpaceStationChaser {
+  id: ID!
+  name: String
+  image: Image
+  status: String
+  founded: String
+  deorbited: String
+  description: String
+  orbit: String
+  type: String
+}
+
+type SpaceStationTarget {
+  id: ID!
+  name: String
+  image: Image
+}
+
+type SuccessCount {
+  total: Int
+  successful: Int
+  failed: Int
+}
+
+type VideoUrl {
+  priority: Int
+  source: String
+  publisher: String
+  title: String
+  description: String
+  featureImage: String
+  url: String
+  type: String
+  language: Language
+  startTime: String
+  endTime: String
+  live: Boolean
+}

--- a/e2e/mcp-server-tester/local-operations/config.yaml
+++ b/e2e/mcp-server-tester/local-operations/config.yaml
@@ -1,0 +1,21 @@
+endpoint: https://thespacedevs-production.up.railway.app/
+transport:
+  type: stdio
+operations:
+  source: local
+  paths:
+    - ./local-operations/operations
+schema:
+  source: local
+  path: ./local-operations/api.graphql
+overrides:
+  mutation_mode: all
+introspection:
+  execute:
+    enabled: true
+  introspect:
+    enabled: true
+  search:
+    enabled: true
+  validate:
+    enabled: true

--- a/e2e/mcp-server-tester/local-operations/operations/ExploreCelestialBodies.graphql
+++ b/e2e/mcp-server-tester/local-operations/operations/ExploreCelestialBodies.graphql
@@ -1,0 +1,35 @@
+query ExploreCelestialBodies($search: String, $limit: Int = 10, $offset: Int = 0) {
+  celestialBodies(search: $search, limit: $limit, offset: $offset) {
+    pageInfo {
+      count
+      next
+      previous
+    }
+    results {
+      id
+      name
+      
+      # Physical characteristics
+      diameter  # in kilometers
+      mass     # in kilograms
+      gravity  # in m/s²
+      lengthOfDay
+      atmosphere
+      
+      # Classification
+      type {
+        id
+        name
+      }
+      
+      # Visual and descriptive content
+      image {
+        url
+        thumbnail
+        credit
+      }
+      description
+      wikiUrl
+    }
+  }
+}

--- a/e2e/mcp-server-tester/local-operations/operations/GetAstronautDetails.graphql
+++ b/e2e/mcp-server-tester/local-operations/operations/GetAstronautDetails.graphql
@@ -1,0 +1,57 @@
+query GetAstronautDetails($astronautId: ID!) {
+  astronaut(id: $astronautId) {
+    id
+    name
+    status
+    inSpace
+    age
+
+    # Birth and career dates
+    dateOfBirth
+    dateOfDeath
+    firstFlight
+    lastFlight
+
+    # Space experience metrics
+    timeInSpace
+    evaTime # Extravehicular Activity time
+    
+    # Agency information
+    agency {
+      id
+      name
+      abbrev
+      country {
+        name
+        nationalityName
+      }
+    }
+
+    # Nationality
+    nationality {
+      name
+      nationalityName
+      alpha2Code
+    }
+
+    # Media
+    image {
+      url
+      thumbnail
+      credit
+    }
+
+    # Bio and links
+    bio
+    wiki
+
+    # Social media
+    socialMediaLinks {
+      url
+      socialMedia {
+        name
+        url
+      }
+    }
+  }
+}

--- a/e2e/mcp-server-tester/local-operations/operations/GetAstronautsCurrentlyInSpace.graphql
+++ b/e2e/mcp-server-tester/local-operations/operations/GetAstronautsCurrentlyInSpace.graphql
@@ -1,0 +1,24 @@
+query GetAstronautsCurrentlyInSpace {
+  astronauts(filters: { inSpace: true, search: "" }) {
+    results {
+      id
+      name
+      timeInSpace
+      lastFlight
+      agency {
+        name
+        abbrev
+        country {
+          name
+        }
+      }
+      nationality {
+        name
+        nationalityName
+      }
+      image {
+        thumbnail
+      }
+    }
+  }
+}

--- a/e2e/mcp-server-tester/local-operations/operations/SearchUpcomingLaunches.graphql
+++ b/e2e/mcp-server-tester/local-operations/operations/SearchUpcomingLaunches.graphql
@@ -1,0 +1,27 @@
+# Fields searched - launch_designator, launch_service_provider__name, mission__name, name, pad__location__name, pad__name, rocket__configuration__manufacturer__abbrev, rocket__configuration__manufacturer__name, rocket__configuration__name, rocket__spacecraftflight__spacecraft__name. Codes are the best search terms to use. Single words are the next best alternative when you cannot use a code to search
+query SearchUpcomingLaunches($query: String!) {
+  upcomingLaunches(limit: 20, search: $query){
+    pageInfo {
+      count
+    }
+    results {
+      id
+      name
+      weatherConcerns
+      rocket {
+        id
+        configuration {
+          fullName
+        }
+      }
+      mission {
+        name
+        description
+      }
+      webcastLive
+      provider {
+        name
+      }
+    }
+  }
+}

--- a/e2e/mcp-server-tester/local-operations/tool-tests.yaml
+++ b/e2e/mcp-server-tester/local-operations/tool-tests.yaml
@@ -1,0 +1,65 @@
+tools:
+  expected_tool_list: ['introspect', 'execute', 'search', 'validate', 'SearchUpcomingLaunches', 'ExploreCelestialBodies', 'GetAstronautDetails', 'GetAstronautsCurrentlyInSpace']
+
+  tests:
+    - name: 'Introspection of launches query'
+      tool: 'introspect'
+      params: 
+        type_name: launches
+        depth: 1
+      expect: 
+        success: true
+
+    - name: 'Search for launches query'
+      tool: 'search'
+      params:
+        terms: ['launches']
+      expect:
+        success: true
+        result:
+          contains: 'launches(search: String, limit: Int = 5, offset: Int = 0): LaunchConnection'
+
+    - name: 'Validate a valid launches query'
+      tool: 'validate'
+      params:
+        operation: >
+          query GetLaunches {
+            launches {
+              results {
+                id
+                name
+                launchDesignator
+              }
+            }
+          }
+      expect:
+        success: true
+        result:
+          contains: 'Operation is valid'
+
+    - name: 'Validates an invalid query'
+      tool: 'validate'
+      params:
+        operation: >
+          query { invalidField }
+      expect:
+        success: false
+        error:
+          contains: 'Error: type `Query` does not have a field `invalidField`'
+
+    - name: 'Validates a launches query with an invalid field'
+      tool: 'validate'
+      params:
+        operation: >
+          query GetLaunches {
+            launches {
+              results {
+                id
+                invalid
+              }
+            }
+          }
+      expect:
+        success: false
+        error:
+          contains: 'Error: type `Launch` does not have a field `invalid`'

--- a/e2e/mcp-server-tester/pq-manifest/api.graphql
+++ b/e2e/mcp-server-tester/pq-manifest/api.graphql
@@ -1,0 +1,525 @@
+type Agency {
+  id: ID!
+  name: String
+  abbrev: String
+  type: String
+  featured: Boolean
+  country: [Country]
+  description: String
+  administrator: String
+  foundingYear: Int
+  spacecraft: String
+  image: Image
+  logo: Image
+  socialLogo: Image
+  totalLaunchCount: Int
+  consecutiveSuccessfulLaunches: Int
+  successfulLaunches: Int
+  failedLaunches: Int
+  pendingLaunches: Int
+  consecutiveSuccessfulLandings: Int
+  successfulLandings: Int
+  failedLandings: Int
+  attemptedLandings: Int
+  successfulLandingsSpacecraft: Int
+  failedLandingsSpacecraft: Int
+  attemptedLandingsSpacecraft: Int
+  successfulLandingsPayload: Int
+  failedLandingsPayload: Int
+  attemptedLandingsPayload: Int
+  infoUrl: String
+  wikiUrl: String
+  socialMediaLinks: [SocialMediaLink]
+}
+
+type AgencyConnection {
+  pageInfo: PageInfo
+  results: [Agency]
+}
+
+type ApiThrottle {
+  yourRequestLimit: Int
+  limitFrequencySecs: Int
+  currentUse: Int
+  nextUseSecs: Int
+  ident: String
+}
+
+type Astronaut {
+  id: ID!
+  name: String
+  status: String
+  agency: Agency
+  image: Image
+  type: String
+  inSpace: Boolean
+  timeInSpace: String
+  evaTime: String
+  age: Int
+  dateOfBirth: String
+  dateOfDeath: String
+  nationality: Country
+  bio: String
+  wiki: String
+  lastFlight: String
+  firstFlight: String
+  socialMediaLinks: [SocialMediaLink]
+}
+
+type AstronautConnection {
+  pageInfo: PageInfo
+  results: [Astronaut]
+}
+
+input AstronautFilters {
+  search: String
+  inSpace: Boolean
+}
+
+type CelestialBody {
+  id: ID!
+  name: String
+  type: CelestialType
+  diameter: Float
+  mass: Float
+  gravity: Float
+  lengthOfDay: String
+  atmosphere: Boolean
+  image: Image
+  description: String
+  wikiUrl: String
+}
+
+type CelestialBodyConnection {
+  pageInfo: PageInfo
+  results: [CelestialBody]
+}
+
+type CelestialType {
+  id: ID!
+  name: String
+}
+
+type Country {
+  id: ID!
+  name: String
+  alpha2Code: String
+  alpha3Code: String
+  nationalityName: String
+  nationalityNameComposed: String
+}
+
+type DockingEvent {
+  id: ID!
+  docking: String
+  departure: String
+  dockingLocation: DockingLocation
+  spaceStationTarget: SpaceStationTarget
+  flightVehicleTarget: FlightVehicleTarget
+  payloadFlightTarget: PayloadFlightTarget
+  flightVehicleChaser: FlightVehicleChaser
+  spaceStationChaser: SpaceStationChaser
+  payloadFlightChaser: PayloadFlightChaser
+}
+
+type DockingEventConnection {
+  pageInfo: PageInfo
+  results: [DockingEvent]
+}
+
+type DockingLocation {
+  id: ID!
+  name: String
+  spacestation: SpaceStation
+  spacecraft: Spacecraft
+  payload: Payload
+}
+
+type FlightVehicleChaser {
+  id: ID!
+  destination: String
+  missionEnd: String
+  spacecraft: Spacecraft
+  launch: Launch
+  landing: Landing
+}
+
+type FlightVehicleTarget {
+  id: ID!
+  destination: String
+  missionEnd: String
+  spacecraft: Spacecraft
+}
+
+type Image {
+  id: ID!
+  name: String
+  url: String
+  thumbnail: String
+  credit: String
+  singleUse: Boolean
+  license: ImageLicense
+}
+
+type ImageLicense {
+  name: String
+  link: String
+}
+
+type InfoUrl {
+  priority: Int
+  source: String
+  title: String
+  description: String
+  featureImage: String
+  url: String
+  type: String
+  language: Language
+}
+
+type Landing {
+  id: ID!
+  type: LandingType
+  attempt: Boolean
+  success: Boolean
+  description: String
+  downrangeDistance: String
+  landingLocation: LandingLocation
+}
+
+type LandingLocation {
+  id: ID!
+  name: String
+  active: Boolean
+  abbrev: String
+  description: String
+  location: Location
+  longitude: String
+  latitude: String
+  image: Image
+  landings: SuccessCount
+  celestialBody: CelestialBody
+}
+
+type LandingType {
+  id: ID!
+  name: String
+  abbrev: String
+  description: String
+}
+
+type Language {
+  id: ID!
+  name: String
+  code: String
+}
+
+type Launch {
+  id: ID!
+  name: String
+  launchDesignator: String
+  status: LaunchStatus
+  lastUpdated: String
+  net: String
+  netPrecision: String
+  window: LaunchWindow
+  image: Image
+  infographic: String
+  probability: Float
+  weatherConcerns: String
+  failreason: String
+  hashtag: String
+  provider: Agency
+  rocket: Rocket
+  mission: Mission
+  pad: Pad
+  webcastLive: Boolean
+  program: Program
+  orbitalLaunchAttemps: Int
+  locationLaunchAttemps: Int
+  padLaunchAttemps: Int
+  agencyLaunchAttemps: Int
+  orbitalLaunchAttempsYear: Int
+  locationLaunchAttempsYear: Int
+  padLaunchAttempsYear: Int
+  agencyLaunchAttempsYear: Int
+}
+
+type LaunchConnection {
+  pageInfo: PageInfo
+  results: [Launch]
+}
+
+type LaunchStatus {
+  id: ID!
+  name: String
+  abbrev: String
+  description: String
+}
+
+type LaunchWindow {
+  start: String
+  end: String
+}
+
+type Location {
+  id: ID!
+  name: String
+  active: Boolean
+  country: Country
+  image: Image
+  mapImage: String
+  longitude: String
+  latitude: String
+  totalLaunchCount: Int
+  totalLandingCount: Int
+  description: String
+  timezone: String
+}
+
+type Manufacturer {
+  id: ID!
+  name: String
+  abbrev: String
+  type: String
+  featured: Boolean
+  country: Country
+  description: String
+  administrator: String
+  foundingYear: Int
+  spacecraft: String
+  image: Image
+  logo: Image
+  socialLogo: Image
+}
+
+type Mission {
+  id: ID!
+  name: String
+  type: String
+  description: String
+  image: Image
+  orbit: Orbit
+  agencies: [Agency]
+  infoUrls: [InfoUrl]
+  vidUrls: [VideoUrl]
+}
+
+type MissionPatch {
+  id: ID!
+  name: String
+  priority: Int
+  imageUrl: String
+  agency: Agency
+}
+
+type Orbit {
+  id: ID!
+  name: String
+  abbrev: String
+  celestialBody: CelestialBody
+}
+
+type Pad {
+  id: ID!
+  active: Boolean
+  agencies: [Agency]
+  name: String
+  image: Image
+  description: String
+  infoUrl: String
+  wikiUrl: String
+  mapUrl: String
+  latitude: Float
+  longitude: Float
+  country: Country
+  mapImage: String
+  launchTotalCount: Int
+  orbitalLaunchAttemptCount: Int
+  fastestTurnaround: String
+  location: Location
+}
+
+type PageInfo {
+  count: Int
+  next: String
+  previous: String
+}
+
+type Payload {
+  id: ID!
+  name: String
+  type: String
+  manufacturer: Manufacturer
+  operator: Agency
+  image: Image
+  wikiLink: String
+  infoLink: String
+  program: Program
+  cost: Float
+  mass: Float
+  description: String
+}
+
+type PayloadFlightChaser {
+  id: ID!
+  url: String
+  destination: String
+  amount: String
+  payload: Payload
+  launch: Launch
+  landing: Landing
+}
+
+type PayloadFlightTarget {
+  id: ID!
+  destination: String
+  amount: String
+  payload: Payload
+  launch: Launch
+  landing: Landing
+}
+
+type Program {
+  id: ID!
+  name: String
+  image: Image
+  infoUrl: String
+  wikiUrl: String
+  description: String
+  agencies: [Agency]
+  startDate: String
+  endDate: String
+  missionPatches: [MissionPatch]
+}
+
+type Query {
+  agency(id: ID!): Agency
+  agencies(search: String, offset: Int = 0, limit: Int = 20): AgencyConnection
+  apiThrottle: ApiThrottle
+  astronaut(id: ID!): Astronaut
+  astronauts(filters: AstronautFilters, offset: Int = 0, limit: Int = 20): AstronautConnection
+  celestialBody(id: ID!): CelestialBody
+  celestialBodies(search: String, offset: Int = 0, limit: Int = 20): CelestialBodyConnection
+  dockingEvent(id: ID!): DockingEvent
+  dockingEvents(search: String, offset: Int = 0, limit: Int = 20): DockingEventConnection
+  launch(id: ID!): Launch
+  launches(search: String, limit: Int = 5, offset: Int = 0): LaunchConnection
+  previousLaunces(search: String, limit: Int = 5, offset: Int = 0): LaunchConnection
+  upcomingLaunches(search: String, limit: Int = 5, offset: Int = 0): LaunchConnection
+}
+
+type Rocket {
+  id: ID!
+  configuration: RocketLaunchConfigurations
+}
+
+type RocketFamily {
+  id: ID!
+  name: String
+}
+
+type RocketLaunchConfigurations {
+  id: ID!
+  name: String
+  fullName: String
+  variant: String
+  families: [RocketFamily]
+}
+
+type SocialMedia {
+  id: ID!
+  name: String
+  url: String
+  logo: Image
+}
+
+type SocialMediaLink {
+  id: ID!
+  url: String
+  socialMedia: SocialMedia
+}
+
+type Spacecraft {
+  id: ID!
+  name: String
+  type: String
+  agency: Agency
+  family: SpacecraftFamily
+  inUse: Boolean
+  serialNumber: String
+  isPlaceholder: Boolean
+  image: Image
+  inSpace: Boolean
+  timeInSpace: String
+  timeDocked: String
+  flightsCount: Int
+  missionEndsCount: Int
+  status: String
+  description: String
+  spacecraftConfig: SpacecraftConfig
+  fastestTurnaround: String
+}
+
+type SpacecraftConfig {
+  id: ID!
+  name: String
+  type: String
+  agency: Agency
+  family: SpacecraftFamily
+  inUse: Boolean
+  image: Image
+}
+
+type SpacecraftFamily {
+  id: ID!
+  name: String
+  description: String
+  manufacturer: Manufacturer
+  maidenFlight: String
+}
+
+type SpaceStation {
+  id: ID!
+  name: String
+  image: Image
+}
+
+type SpaceStationChaser {
+  id: ID!
+  name: String
+  image: Image
+  status: String
+  founded: String
+  deorbited: String
+  description: String
+  orbit: String
+  type: String
+}
+
+type SpaceStationTarget {
+  id: ID!
+  name: String
+  image: Image
+}
+
+type SuccessCount {
+  total: Int
+  successful: Int
+  failed: Int
+}
+
+type VideoUrl {
+  priority: Int
+  source: String
+  publisher: String
+  title: String
+  description: String
+  featureImage: String
+  url: String
+  type: String
+  language: Language
+  startTime: String
+  endTime: String
+  live: Boolean
+}

--- a/e2e/mcp-server-tester/pq-manifest/apollo.json
+++ b/e2e/mcp-server-tester/pq-manifest/apollo.json
@@ -1,0 +1,30 @@
+{
+  "format": "apollo-persisted-query-manifest",
+  "version": 1,
+  "operations": [
+    {
+      "id": "1417c051c5b1ba2fa41975fc02547c9c34c619c8694bf225df74e7b527575d5f",
+      "name": "ExploreCelestialBodies",
+      "type": "query",
+      "body": "query ExploreCelestialBodies($search: String, $limit: Int = 10, $offset: Int = 0) {\n  celestialBodies(search: $search, limit: $limit, offset: $offset) {\n    pageInfo {\n      count\n      next\n      previous\n      __typename\n    }\n    results {\n      id\n      name\n      diameter\n      mass\n      gravity\n      lengthOfDay\n      atmosphere\n      type {\n        id\n        name\n        __typename\n      }\n      image {\n        url\n        thumbnail\n        credit\n        __typename\n      }\n      description\n      wikiUrl\n      __typename\n    }\n    __typename\n  }\n}"
+    },
+    {
+      "id": "5cc5c30ad71bdf7d57e4fa5a8428c2d49ebc3e16a3d17f21efbd1ad22b4ba70b",
+      "name": "GetAstronautDetails",
+      "type": "query",
+      "body": "query GetAstronautDetails($astronautId: ID!) {\n  astronaut(id: $astronautId) {\n    id\n    name\n    status\n    inSpace\n    age\n    dateOfBirth\n    dateOfDeath\n    firstFlight\n    lastFlight\n    timeInSpace\n    evaTime\n    agency {\n      id\n      name\n      abbrev\n      country {\n        name\n        nationalityName\n        __typename\n      }\n      __typename\n    }\n    nationality {\n      name\n      nationalityName\n      alpha2Code\n      __typename\n    }\n    image {\n      url\n      thumbnail\n      credit\n      __typename\n    }\n    bio\n    wiki\n    socialMediaLinks {\n      url\n      socialMedia {\n        name\n        url\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+    },
+    {
+      "id": "83af5184f29c1eb5ce9b0d6da11285829f2f155d3815affbe66b56fa249f7603",
+      "name": "GetAstronautsCurrentlyInSpace",
+      "type": "query",
+      "body": "query GetAstronautsCurrentlyInSpace {\n  astronauts(filters: {inSpace: true, search: \"\"}) {\n    results {\n      id\n      name\n      timeInSpace\n      lastFlight\n      agency {\n        name\n        abbrev\n        country {\n          name\n          __typename\n        }\n        __typename\n      }\n      nationality {\n        name\n        nationalityName\n        __typename\n      }\n      image {\n        thumbnail\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+    },
+    {
+      "id": "824e3c8a1612c32a315450abbd5c7aedc0c402fdf6068583a54461f5b67d55be",
+      "name": "SearchUpcomingLaunches",
+      "type": "query",
+      "body": "query SearchUpcomingLaunches($query: String!) {\n  upcomingLaunches(limit: 20, search: $query) {\n    pageInfo {\n      count\n      __typename\n    }\n    results {\n      id\n      name\n      weatherConcerns\n      rocket {\n        id\n        configuration {\n          fullName\n          __typename\n        }\n        __typename\n      }\n      mission {\n        name\n        description\n        __typename\n      }\n      webcastLive\n      provider {\n        name\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+    }
+  ]
+}

--- a/e2e/mcp-server-tester/pq-manifest/config.yaml
+++ b/e2e/mcp-server-tester/pq-manifest/config.yaml
@@ -1,0 +1,20 @@
+endpoint: https://thespacedevs-production.up.railway.app/
+transport:
+  type: stdio
+operations:
+  source: manifest
+  path: ./pq-manifest/apollo.json
+schema:
+  source: local
+  path: ./pq-manifest/api.graphql
+overrides:
+  mutation_mode: all
+introspection:
+  execute:
+    enabled: true
+  introspect:
+    enabled: true
+  search:
+    enabled: true
+  validate:
+    enabled: true

--- a/e2e/mcp-server-tester/pq-manifest/tool-tests.yaml
+++ b/e2e/mcp-server-tester/pq-manifest/tool-tests.yaml
@@ -1,0 +1,65 @@
+tools:
+  expected_tool_list: ['introspect', 'execute', 'search', 'validate', 'SearchUpcomingLaunches', 'ExploreCelestialBodies', 'GetAstronautDetails', 'GetAstronautsCurrentlyInSpace']
+
+  tests:
+    - name: 'Introspection of launches query'
+      tool: 'introspect'
+      params: 
+        type_name: launches
+        depth: 1
+      expect: 
+        success: true
+
+    - name: 'Search for launches query'
+      tool: 'search'
+      params:
+        terms: ['launches']
+      expect:
+        success: true
+        result:
+          contains: 'launches(search: String, limit: Int = 5, offset: Int = 0): LaunchConnection'
+
+    - name: 'Validate a valid launches query'
+      tool: 'validate'
+      params:
+        operation: >
+          query GetLaunches {
+            launches {
+              results {
+                id
+                name
+                launchDesignator
+              }
+            }
+          }
+      expect:
+        success: true
+        result:
+          contains: 'Operation is valid'
+
+    - name: 'Validates an invalid query'
+      tool: 'validate'
+      params:
+        operation: >
+          query { invalidField }
+      expect:
+        success: false
+        error:
+          contains: 'Error: type `Query` does not have a field `invalidField`'
+
+    - name: 'Validates a launches query with an invalid field'
+      tool: 'validate'
+      params:
+        operation: >
+          query GetLaunches {
+            launches {
+              results {
+                id
+                invalid
+              }
+            }
+          }
+      expect:
+        success: false
+        error:
+          contains: 'Error: type `Launch` does not have a field `invalid`'

--- a/e2e/mcp-server-tester/run_tests.sh
+++ b/e2e/mcp-server-tester/run_tests.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: run-tools.sh <test-dir>
+
+Runs:
+  npx mcp-server-tester tools <test-dir>/tool-tests.yaml --server-config <test-dir>/apollo-mcp-server-config.json
+
+Notes:
+  - <test-dir> is resolved relative to this script's directory (not the caller's cwd),
+    so calling: foo/bar/run-tools.sh local-directory
+    uses:       foo/bar/local-directory/tool-tests.yaml
+  - If ../../target/release/apollo-mcp-server (relative to this script) doesn't exist,
+    it is built from the repo root (../../) with: cargo build --release
+USAGE
+  exit 1
+}
+
+[[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -eq 0 ]] && usage
+
+RAW_DIR_ARG="${1%/}"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# If absolute path, use it as-is; otherwise, resolve relative to the script dir.
+if [[ "$RAW_DIR_ARG" = /* ]]; then
+  TEST_DIR="$RAW_DIR_ARG"
+else
+  TEST_DIR="$(cd -P -- "$SCRIPT_DIR/$RAW_DIR_ARG" && pwd)"
+fi
+
+TEST_DIR="${1%/}"  # strip trailing slash if present
+TESTS="$TEST_DIR/tool-tests.yaml"
+MCP_CONFIG="$TEST_DIR/config.yaml"
+
+# Sanity checks
+[[ -f "$TESTS" ]]  || { echo "✗ Missing file: $TESTS";  exit 2; }
+[[ -f "$MCP_CONFIG" ]] || { echo "✗ Missing file: $MCP_CONFIG"; exit 2; }
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BIN_PATH="$REPO_ROOT/target/release/apollo-mcp-server"
+
+if [[ ! -x "$BIN_PATH" ]]; then
+  echo "ℹ️  Binary not found at: $BIN_PATH"
+  echo "➡️  Building release binary from: $REPO_ROOT"
+  (cd "$REPO_ROOT" && cargo build --release)
+
+  # Re-check after build
+  if [[ ! -x "$BIN_PATH" ]]; then
+    echo "✗ Build succeeded but binary not found/executable at: $BIN_PATH"
+    exit 3
+  fi
+fi
+
+# Template → generated server-config
+TEMPLATE_PATH="${SERVER_CONFIG_TEMPLATE:-"$SCRIPT_DIR/server-config.template.json"}"
+[[ -f "$TEMPLATE_PATH" ]] || { echo "✗ Missing server-config template: $TEMPLATE_PATH"; exit 4; }
+
+TMP_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT INT TERM # cleanup before exiting
+GEN_CONFIG="$TMP_DIR/server-config.generated.json"
+
+# Safe replacement for <test-dir> with absolute path (handles /, &, and |)
+safe_dir="${TEST_DIR//\\/\\\\}"
+safe_dir="${safe_dir//&/\\&}"
+safe_dir="${safe_dir//|/\\|}"
+
+# Replace the literal token "<test-dir>" everywhere
+sed "s|<test-dir>|$safe_dir|g" "$TEMPLATE_PATH" > "$GEN_CONFIG"
+
+# Run the command
+exec npx -y mcp-server-tester tools "$TESTS" --server-config "$GEN_CONFIG"

--- a/e2e/mcp-server-tester/run_tests.sh
+++ b/e2e/mcp-server-tester/run_tests.sh
@@ -71,4 +71,4 @@ safe_dir="${safe_dir//|/\\|}"
 sed "s|<test-dir>|$safe_dir|g" "$TEMPLATE_PATH" > "$GEN_CONFIG"
 
 # Run the command
-exec npx -y mcp-server-tester tools "$TESTS" --server-config "$GEN_CONFIG"
+npx -y mcp-server-tester tools "$TESTS" --server-config "$GEN_CONFIG"

--- a/e2e/mcp-server-tester/server-config.template.json
+++ b/e2e/mcp-server-tester/server-config.template.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "mcp-server": {
+      "command": "../../target/release/apollo-mcp-server",
+      "args": ["./<test-dir>/config.yaml"]
+    }
+  }
+}


### PR DESCRIPTION
Adding some basic e2e tests using [mcp-server-tester](https://github.com/steviec/mcp-server-tester). Currently the tool does not always exit (ctrl+c is sometimes needed) so this should be run manually.

### How to run tests?
Added a script `run_tests.sh` (may need to run `chmod +x` to run it) to run tests. Basic usage found via `./run_tests.sh -h`. The script does the following:

1. Builds test/config yaml paths and verifies the files exist.
2. Checks if release `apollo-mcp-server` binary exists. If not, it builds the binary via `cargo build --release`.
3. Reads in the template file (used by `mcp-server-tester`) and replaces all `<test-dir>` placeholders with the test directory value. Generates this test server config file and places it in a temp location.
4. Invokes the `mcp-server-tester` via `npx`.
5. On script exit the generated config is cleaned up.

### Example run: 
To run the tests for `local-operations` simply run `./run_tests.sh local-operations` 