### PR TITLE
fix: Validate ExecutableDocument in validate tool

### DIFF
--- a/.changesets/fix_fix_validate_exec_doc_validation.md
+++ b/.changesets/fix_fix_validate_exec_doc_validation.md
@@ -1,0 +1,7 @@
+### fix: Validate ExecutableDocument in validate tool - @swcollard PR #329
+
+Contains fixes for https://github.com/apollographql/apollo-mcp-server/issues/327
+
+The validate tool was parsing the operation passed in to it against the schema but it wasn't performing the validate function on the ExecutableDocument returned by the Parser. This led to cases where missing required arguments were not caught by the Tool.
+
+This change also updates the input schema to the execute tool to make it more clear to the LLM that it needs to provide a valid JSON object

--- a/crates/apollo-mcp-server/src/introspection/tools/execute.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/execute.rs
@@ -26,7 +26,8 @@ pub struct Input {
     /// The GraphQL operation
     query: String,
 
-    /// The variable values
+    /// The variable values represented as JSON
+    #[schemars(schema_with = "String::json_schema", default)]
     variables: Option<Value>,
 }
 

--- a/e2e/mcp-server-tester/local-operations/tool-tests.yaml
+++ b/e2e/mcp-server-tester/local-operations/tool-tests.yaml
@@ -63,3 +63,17 @@ tools:
         success: false
         error:
           contains: 'Error: type `Launch` does not have a field `invalid`'
+
+    - name: 'Validates a launches query with an missing argument'
+      tool: 'validate'
+      params:
+        operation: >
+          query Agency {
+            agency {
+              id
+            }
+          }
+      expect:
+        success: false
+        error:
+          contains: 'Error: the required argument `Query.agency(id:)` is not provided'

--- a/e2e/mcp-server-tester/pq-manifest/tool-tests.yaml
+++ b/e2e/mcp-server-tester/pq-manifest/tool-tests.yaml
@@ -63,3 +63,17 @@ tools:
         success: false
         error:
           contains: 'Error: type `Launch` does not have a field `invalid`'
+
+    - name: 'Validates a launches query with an missing argument'
+      tool: 'validate'
+      params:
+        operation: >
+          query Agency {
+            agency {
+              id
+            }
+          }
+      expect:
+        success: false
+        error:
+          contains: 'Error: the required argument `Query.agency(id:)` is not provided'


### PR DESCRIPTION
Contains fixes for : https://github.com/apollographql/apollo-mcp-server/issues/327

The validate tool was parsing the operation passed in to it against the schema but it wasn't performing the validate function on the ExecutableDocument returned by the Parser. This led to cases where missing required arguments were not caught by the Tool.

This change also updates the input schema to the execute tool to make it more clear to the LLM that it needs to provide a valid JSON object