### PR TITLE
Configure Codecov with coverage targets

### DIFF
--- a/.changesets/maint_codecov.md
+++ b/.changesets/maint_codecov.md
@@ -1,0 +1,3 @@
+### Configure Codecov with coverage targets - @DaleSeo PR #337
+
+This PR adds `codecov.yml` to set up Codecov with specific coverage targets and quality standards. It helps define clear expectations for code quality. It also includes some documentation about code coverage in `CONTRIBUTING.md` and adds the Codecov badge to `README.md`.

--- a/.github/workflows/verify-changeset.yml
+++ b/.github/workflows/verify-changeset.yml
@@ -1,6 +1,7 @@
 name: Verify Changeset
 on:
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     branches-ignore:
       - main
       - release/**

--- a/.github/workflows/verify-changeset.yml
+++ b/.github/workflows/verify-changeset.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   verify-changeset:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changeset') && !startsWith(github.head_ref, 'sync/') && !startsWith(github.head_ref, 'conflict/') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changeset') && !startsWith(github.head_ref, 'sync/') && !startsWith(github.head_ref, 'conflict/') && !github.event.pull_request.draft }}
     name: Verify
     runs-on: ubuntu-24.04
     permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,3 +58,20 @@ It’s important that every piece of code in Apollo packages is reviewed by at l
 3. Testing. Please make sure that the tests ensure that the code won’t break when other stuff change around it. The error messages in the test should help identify what is broken exactly and how. The tests should test every edge case if possible. Please make sure you get as much coverage as possible.
 4. No unnecessary or unrelated changes. PRs shouldn’t come with random formatting changes, especially in unrelated parts of the code. If there is some refactoring that needs to be done, it should be in a separate PR from a bug fix or feature, if possible.
 5. Please run `cargo test`, `cargo clippy`, and `cargo fmt` prior to creating a PR.
+
+### Code Coverage
+
+Apollo MCP Server uses comprehensive code coverage reporting to ensure code quality and test effectiveness. 
+The project uses [cargo-llvm-cov](https://crates.io/crates/cargo-llvm-cov) for generating code coverage reports and [Codecov](https://www.codecov.io/) for coverage analysis and reporting. Coverage is automatically generated and reported on every pull request through GitHub Actions.
+
+#### Coverage Targets
+
+The project maintains the following coverage targets, configured in `codecov.yml`:
+
+- **Project Coverage**: Automatically maintained - should increase overall coverage on each PR
+- **Patch Coverage**: 80% - requires 80% coverage on all new/modified code
+
+These targets help ensure that:
+
+- The overall codebase coverage doesn't decrease over time
+- New code is well-tested before being merged

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ![release binaries workflow status](https://img.shields.io/github/actions/workflow/status/apollographql/apollo-mcp-server/release-bins.yml?label=release%20binaries)
 ![release container workflow status](https://img.shields.io/github/actions/workflow/status/apollographql/apollo-mcp-server/release-container.yml?label=release%20container)
 ![license](https://img.shields.io/github/license/apollographql/apollo-mcp-server)
+[![codecov](https://codecov.io/github/apollographql/apollo-mcp-server/graph/badge.svg?token=6NHuvZQ8ak)](https://codecov.io/github/apollographql/apollo-mcp-server)
 
 # Apollo MCP Server
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        # Should increase overall coverage on each PR
+        target: auto
+    patch:
+      default:
+        # Require 80% coverage on all new/modified code
+        target: 80%

--- a/crates/apollo-mcp-registry/src/uplink/schema/event.rs
+++ b/crates/apollo-mcp-registry/src/uplink/schema/event.rs
@@ -1,6 +1,7 @@
-use crate::uplink::schema::SchemaState;
+use super::SchemaState;
 use std::fmt::Debug;
 use std::fmt::Formatter;
+use std::fmt::Result;
 
 /// Schema events
 pub enum Event {
@@ -12,7 +13,7 @@ pub enum Event {
 }
 
 impl Debug for Event {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         match self {
             Event::UpdateSchema(_) => {
                 write!(f, "UpdateSchema(<redacted>)")
@@ -21,5 +22,30 @@ impl Debug for Event {
                 write!(f, "NoMoreSchema")
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_debug_event_no_more_schema() {
+        let event = Event::NoMoreSchema;
+        let output = format!("{:?}", event);
+        assert_eq!(output, "NoMoreSchema");
+    }
+
+    #[test]
+    fn test_debug_redacts_update_schema() {
+        let event = Event::UpdateSchema(SchemaState {
+            sdl: "type Query { hello: String }".to_string(),
+            launch_id: Some("test-launch-123".to_string()),
+        });
+
+        let output = format!("{:?}", event);
+        assert_eq!(output, "UpdateSchema(<redacted>)");
+        assert!(!output.contains("type Query"));
+        assert!(!output.contains("test-launch-123"));
     }
 }


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/GT-370 -->

This PR adds `codecov.yml` to set up Codecov with specific coverage targets and quality standards. It helps define clear expectations for code quality. It also includes some documentation about code coverage in `CONTRIBUTING.md` and adds the Codecov badge to `README.md`.