### PR TITLE
ci: update github checkout actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       actions: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: nixbuild/nix-quick-install-action@v30
@@ -55,7 +55,7 @@ jobs:
       actions: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: nixbuild/nix-quick-install-action@v30
@@ -81,7 +81,7 @@ jobs:
       actions: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: nixbuild/nix-quick-install-action@v30
@@ -107,7 +107,7 @@ jobs:
       actions: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: nixbuild/nix-quick-install-action@v30

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -47,7 +47,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_PAT }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -42,7 +42,7 @@ jobs:
       attestations: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
       - uses: nixbuild/nix-quick-install-action@v30

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -32,7 +32,7 @@ jobs:
       attestations: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -51,7 +51,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_PAT }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
Not sure why Renovate isn’t opening a PR like the one it created for Rover https://github.com/apollographql/rover/pull/2694 but this change applies the same update.