### PR TITLE
docs: remove placeholder for rover dev flags

### DIFF
--- a/docs/source/run.mdx
+++ b/docs/source/run.mdx
@@ -135,7 +135,7 @@ The Rover CLI is a tool for working with GraphQL APIs locally.
 You can use the [`rover dev`](/rover/commands/dev) command of Rover CLI `v0.35` or later to run an Apollo MCP Server instance alongside your local graph. Use the `--mcp` flag to start an MCP server and provide an optional configuration file.
 
 ```sh
-rover dev --mcp <PATH/TO/CONFIG> [...other rover dev flags]
+rover dev --mcp <PATH/TO/CONFIG>
 ```
 
 For more information, see the [Rover CLI documentation](/rover).


### PR DESCRIPTION
`rover dev --mcp` takes only one argument now.

<img width="1352" height="366" alt="2025-09-10 at 10 59 20" src="https://github.com/user-attachments/assets/44845f11-08d5-4f4a-9e5f-f36a6a6f46e3" />
