### PR TITLE
Redirect `/docs/apollo-mcp-server/guides` to fix 404

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -3,6 +3,7 @@ title: Apollo MCP Server
 subtitle: Enable graph-based API orchestration with AI
 redirectFrom:
     - /apollo-mcp-server/user-guide
+    - /apollo-mcp-server/guides
 ---
 
 <PreviewFeature>


### PR DESCRIPTION
This page is currently 404'ing https://www.apollographql.com/docs/apollo-mcp-server/guides

Attempting to add a redirect to the mcp server docs homepage.

https://github.com/apollographql/apollo-mcp-server/issues/344