### PR TITLE
fix: Use the correct HEAD branch for the Prep Release workflow

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -232,7 +232,7 @@ jobs:
 
       - name: Open/Update draft PR to main
         env:
-          HEAD: ${{ github.ref_name }}
+          HEAD: release/${{ steps.bump.outputs.new_version }}
           TITLE: Releasing ${{ steps.bump.outputs.new_version }}
         shell: bash
         run: |


### PR DESCRIPTION
The Prep Release workflow was basing the Release PR off the `develop` branch rather than the release branch. This is incorrect and should use the `release/x.y.z` branch instead.