### PR TITLE
docs: updating define operation collections section with note on variables

### DIFF
--- a/docs/source/define-tools.mdx
+++ b/docs/source/define-tools.mdx
@@ -50,7 +50,7 @@ Files and directories specified with `operations` are hot reloaded. When you spe
 
 ### From operation collections
 
-For graphs managed by GraphOS, Apollo MCP Server can retrieve operations from an [operation collection](/graphos/platform/explorer/operation-collections). 
+For graphs managed by GraphOS, Apollo MCP Server can retrieve operations from an [operation collection](/graphos/platform/explorer/operation-collections).
 
 Use GraphOS Studio Explorer to create and manage operation collections.
 
@@ -58,7 +58,7 @@ Use GraphOS Studio Explorer to create and manage operation collections.
 
 To use a GraphOS operation collection, you must set your graph credentials (`APOLLO_GRAPH_REF` and `APOLLO_KEY`) when configuring the MCP Server.
 
-Each graph variant will have its own default MCP Tools Collection, but you can specify any shared collection by using `operations.source: collection`.
+Each graph variant has its own default MCP Tools Collection, but you can specify any shared collection by using `operations.source: collection`.
 
 Apollo MCP Server automatically fetches the default collection if no ID is specified.
 
@@ -68,15 +68,15 @@ operations:
   id: <collection-id>
 ```
 
-The MCP Server supports hot reloading of the GraphOS operation collection, so it can automatically pick up changes from GraphOS without restarting.
+The MCP Server supports hot reloading of the GraphOS operation collection, so it automatically picks up changes from GraphOS without restarting.
 
 #### Setting operation collection variables
 
-When saving operation collections, remove any dynamic variables from the **Variables** panel of Explorer. This will enable the LLM to modify the variables when calling the operation.
+When saving operation collections, remove any dynamic variables from the **Variables** panel of Explorer. This enables the LLM to modify the variables when calling the operation.
 
-Any variables set to any valid value (even `null`) in the Variables panel of a saved operation will be used as a hardcoded override for that operation's variable.
+Any variables set to any valid value (even `null`) in the Variables panel of a saved operation are used as a hardcoded override for that operation's variable.
 
-For example, if the following operation is created for an operation collection:
+For example, if you create the following operation for an operation collection:
 
 ```graphql
 query GetProduct($productId: ID!) {
@@ -95,7 +95,7 @@ And the Variables panel has `productId` set to `1234`:
 }
 ```
 
-Then every time the `GetProduct` operation is called by the LLM, the `productId` variable will always be set to `1234`. The same would be true if `productId` was set to `null`.
+Then, every time the LLM calls the `GetProduct` operation, the `productId` variable is always set to `1234`. The same is true if `productId` is set to `null`.
 
 If you want to use dynamic variables that the LLM can modify, remove any variables from the Variables panel and save that operation to the collection.
 

--- a/docs/source/define-tools.mdx
+++ b/docs/source/define-tools.mdx
@@ -67,6 +67,34 @@ operations:
 
 The MCP Server supports hot reloading of the GraphOS Operation Collection, so it can automatically pick up changes from GraphOS without restarting.
 
+#### A note on operation collection variables ####
+Operation collection variables are treated a bit differently than how they are treated from local file operations. In
+short, any variables set to any valid value (even `null`) in the Variables panel when saved will be used as a hardcoded 
+override for that operation’s variable. The LLM cannot modify or pass in these values and therefore are omitted from 
+the resulting input schema. 
+
+For example, let's say the following operation is created for an operation collection:
+```graphql
+query ProductQuery($productId: ID!) {
+    product(id: $productId) {
+        id
+        description
+    }
+}
+```
+The Variables panel has `productid` set to `1234`:
+```json
+{
+  "productId": "1234"
+}
+```
+then every time this operation is called by the LLM, the `productId` variable will always be this value. 
+The same would be true if `productId` was set to `null`.
+
+To get a similar to behavior to what is seen when using the local file operations source one can simply delete 
+`productId` from the Variables panel and then re-save the operation to update the collection. This will keep it from 
+being hard-coded and will be added to the resulting schema.
+
 ### From persisted query manifests
 
 Apollo MCP Server supports reading GraphQL operations from Apollo-formatted [persisted query manifest](/graphos/platform/security/persisted-queries#manifest-format) files.

--- a/docs/source/define-tools.mdx
+++ b/docs/source/define-tools.mdx
@@ -48,24 +48,27 @@ You can also use the `operations` option to specify a directory. The server then
 
 Files and directories specified with `operations` are hot reloaded. When you specify a file, the MCP tool is updated when the file contents are modified. When you specify a directory, operations exposed as MCP tools are updated when files are added, modified, or removed from the directory.
 
-### From Operation Collection
+### From operation collections
 
-For graphs managed by GraphOS, Apollo MCP Server can get operations from an [Operation Collection](https://www.apollographql.com/docs/graphos/platform/explorer/operation-collections).
+For graphs managed by GraphOS, Apollo MCP Server can retrieve operations from an [operation collection](/graphos/platform/explorer/operation-collections). 
 
-To use a GraphOS Operation Collection, you must:
+Use GraphOS Studio Explorer to create and manage operation collections.
 
-- Set `APOLLO_GRAPH_REF` and `APOLLO_KEY` environment variables for a GraphOS graph
+#### Configuring the MCP Server to use a GraphOS operation collection
 
-Each variant will have its own default MCP Tools Collection, but you can specify any shared collection by using `operations` with `operations.source: collection`.
+To use a GraphOS operation collection, you must set your graph credentials (`APOLLO_GRAPH_REF` and `APOLLO_KEY`) when configuring the MCP Server.
+
+Each graph variant will have its own default MCP Tools Collection, but you can specify any shared collection by using `operations.source: collection`.
+
 Apollo MCP Server automatically fetches the default collection if no ID is specified.
 
-```yaml title="Example config file for using a GraphOS Operation Collection"
+```yaml title="Example config file for using a GraphOS operation collection"
 operations:
   source: collection
   id: <collection-id>
 ```
 
-The MCP Server supports hot reloading of the GraphOS Operation Collection, so it can automatically pick up changes from GraphOS without restarting.
+The MCP Server supports hot reloading of the GraphOS operation collection, so it can automatically pick up changes from GraphOS without restarting.
 
 #### Setting operation collection variables
 

--- a/docs/source/define-tools.mdx
+++ b/docs/source/define-tools.mdx
@@ -67,33 +67,34 @@ operations:
 
 The MCP Server supports hot reloading of the GraphOS Operation Collection, so it can automatically pick up changes from GraphOS without restarting.
 
-#### A note on operation collection variables ####
-Operation collection variables are treated a bit differently than how they are treated from local file operations. In
-short, any variables set to any valid value (even `null`) in the Variables panel when saved will be used as a hardcoded 
-override for that operation’s variable. The LLM cannot modify or pass in these values and therefore are omitted from 
-the resulting input schema. 
+#### Setting operation collection variables
 
-For example, let's say the following operation is created for an operation collection:
+When saving operation collections, remove any dynamic variables from the **Variables** panel of Explorer. This will enable the LLM to modify the variables when calling the operation.
+
+Any variables set to any valid value (even `null`) in the Variables panel of a saved operation will be used as a hardcoded override for that operation's variable.
+
+For example, if the following operation is created for an operation collection:
+
 ```graphql
-query ProductQuery($productId: ID!) {
-    product(id: $productId) {
-        id
-        description
-    }
+query GetProduct($productId: ID!) {
+  product(id: $productId) {
+    id
+    description
+  }
 }
 ```
-The Variables panel has `productid` set to `1234`:
+
+And the Variables panel has `productId` set to `1234`:
+
 ```json
 {
   "productId": "1234"
 }
 ```
-then every time this operation is called by the LLM, the `productId` variable will always be this value. 
-The same would be true if `productId` was set to `null`.
 
-To get a similar to behavior to what is seen when using the local file operations source one can simply delete 
-`productId` from the Variables panel and then re-save the operation to update the collection. This will keep it from 
-being hard-coded and will be added to the resulting schema.
+Then every time the `GetProduct` operation is called by the LLM, the `productId` variable will always be set to `1234`. The same would be true if `productId` was set to `null`.
+
+If you want to use dynamic variables that the LLM can modify, remove any variables from the Variables panel and save that operation to the collection.
 
 ### From persisted query manifests
 


### PR DESCRIPTION
Updating the docs for defining operation collections with some extra information on how variables are treated for operation collections specifically. This came up since it seems to be missing from the docs and there have been questions around how this functionality works (since it is a bit confusing at first).