### PR TITLE
Add CORS support

### DIFF
--- a/.changesets/feat_cors.md
+++ b/.changesets/feat_cors.md
@@ -1,0 +1,3 @@
+### Add CORS support - @DaleSeo PR #362
+
+This PR implements comprehensive CORS support for Apollo MCP Server to enable web-based MCP clients to connect without CORS errors. The implementation and configuration draw heavily from the Router's approach. Similar to other features like health checks and telemetry, CORS is supported only for the StreamableHttp transport, making it a top-level configuration.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,75 +1,86 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Run apollo-mcp-server [Weather][Streamable HTTP]",
-            "runtimeExecutable": "cargo",
-            "runtimeArgs": [
-                "run",
-                "--bin",
-                "apollo-mcp-server",
-                "--",
-                "graphql/weather/config.yaml",
-            ],
-            "cwd": "${workspaceFolder}",
-            "console": "integratedTerminal",
-            "env": {
-                "RUST_BACKTRACE": "1"
-            }
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Debug apollo-mcp-server [Weather][Streamable HTTP]",
-            "cargo": {
-                "args": [
-                    "build",
-                    "--bin=apollo-mcp-server",
-                    "--lib"
-                ],
-                "filter": {
-                    "name": "apollo-mcp-server",
-                    "kind": "bin"
-                }
-            },
-            "args": [
-                "graphql/weather/config.yaml",
-            ],
-            "cwd": "${workspaceFolder}",
-            "env": {
-                "RUST_BACKTRACE": "1"
-            }
-        },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Run apollo-mcp-server [TheSpaceDevs][Streamable HTTP]",
-            "runtimeExecutable": "cargo",
-            "runtimeArgs": [
-                "run",
-                "--bin",
-                "apollo-mcp-server",
-                "--",
-                "graphql/TheSpaceDevs/config.yaml",
-            ],
-            "cwd": "${workspaceFolder}",
-            "console": "integratedTerminal",
-            "env": {
-                "RUST_BACKTRACE": "1"
-            }
-        },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Run mcp-inspector",
-            "runtimeExecutable": "npx",
-            "runtimeArgs": [
-                "@modelcontextprotocol/inspector"
-            ],
-            "cwd": "${workspaceFolder}",
-            "console": "integratedTerminal"
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Run apollo-mcp-server [Weather][Streamable HTTP]",
+      "runtimeExecutable": "cargo",
+      "runtimeArgs": [
+        "run",
+        "--bin",
+        "apollo-mcp-server",
+        "--",
+        "graphql/weather/config.yaml"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "env": {
+        "RUST_BACKTRACE": "1"
+      }
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug apollo-mcp-server [Weather][Streamable HTTP]",
+      "cargo": {
+        "args": ["build", "--bin=apollo-mcp-server", "--lib"],
+        "filter": {
+          "name": "apollo-mcp-server",
+          "kind": "bin"
         }
-    ]
+      },
+      "args": ["graphql/weather/config.yaml"],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "RUST_BACKTRACE": "1",
+        "APOLLO_MCP_LOGGING__LEVEL": "debug"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Run apollo-mcp-server [TheSpaceDevs][Streamable HTTP]",
+      "runtimeExecutable": "cargo",
+      "runtimeArgs": [
+        "run",
+        "--bin",
+        "apollo-mcp-server",
+        "--",
+        "graphql/TheSpaceDevs/config.yaml"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "env": {
+        "RUST_BACKTRACE": "1"
+      }
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug apollo-mcp-server [TheSpaceDevs][Streamable HTTP]",
+      "cargo": {
+        "args": ["build", "--bin=apollo-mcp-server", "--lib"],
+        "filter": {
+          "name": "apollo-mcp-server",
+          "kind": "bin"
+        }
+      },
+      "args": ["graphql/TheSpaceDevs/config.yaml"],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "RUST_BACKTRACE": "1",
+        "APOLLO_MCP_LOGGING__LEVEL": "debug"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Run mcp-inspector",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["@modelcontextprotocol/inspector"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal"
+    }
+  ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,7 @@ dependencies = [
  "thiserror 2.0.14",
  "tokio",
  "tokio-util",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-appender",
@@ -645,7 +646,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1817,7 +1818,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3027,7 +3028,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3596,7 +3597,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4259,7 +4260,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -55,6 +55,7 @@ insta.workspace = true
 mockito = "1.7.0"
 rstest.workspace = true
 tokio.workspace = true
+tower = "0.5.2"
 tracing-test = "0.2.5"
 
 [lints]

--- a/crates/apollo-mcp-server/src/cors.rs
+++ b/crates/apollo-mcp-server/src/cors.rs
@@ -1,0 +1,327 @@
+use http::Method;
+use regex::Regex;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_http::cors::{AllowOrigin, Any, CorsLayer};
+use url::Url;
+
+use crate::errors::ServerError;
+
+/// CORS configuration options
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(default)]
+pub struct CorsConfig {
+    /// Enable CORS support
+    pub enabled: bool,
+
+    /// List of allowed origins (exact match)
+    pub origins: Vec<String>,
+
+    /// List of origin patterns (regex matching)
+    pub match_origins: Vec<String>,
+
+    /// Allow any origin (use with caution)
+    pub allow_any_origin: bool,
+
+    /// Allow credentials in CORS requests
+    pub allow_credentials: bool,
+
+    /// Allowed HTTP methods
+    pub allow_methods: Vec<String>,
+
+    /// Allowed request headers
+    pub allow_headers: Vec<String>,
+
+    /// Headers exposed to the browser
+    pub expose_headers: Vec<String>,
+
+    /// Max age for preflight cache (in seconds)
+    pub max_age: Option<u64>,
+}
+
+impl Default for CorsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            origins: Vec::new(),
+            match_origins: Vec::new(),
+            allow_any_origin: false,
+            allow_credentials: false,
+            allow_methods: default_methods(),
+            allow_headers: default_headers(),
+            expose_headers: Vec::new(),
+            max_age: Some(default_max_age()),
+        }
+    }
+}
+
+/// Default allowed HTTP methods
+fn default_methods() -> Vec<String> {
+    vec!["GET".to_string(), "POST".to_string(), "OPTIONS".to_string()]
+}
+
+/// Default allowed headers
+fn default_headers() -> Vec<String> {
+    vec![
+        "content-type".to_string(),
+        "authorization".to_string(),
+        "mcp-session-id".to_string(),
+    ]
+}
+
+/// Default max age for preflight cache (2 hours)
+fn default_max_age() -> u64 {
+    7200
+}
+
+impl CorsConfig {
+    /// Build a CorsLayer from this configuration
+    pub fn build_cors_layer(&self) -> Result<CorsLayer, ServerError> {
+        if !self.enabled {
+            return Err(ServerError::Cors("CORS is not enabled".to_string()));
+        }
+
+        // Validate configuration
+        self.validate()?;
+
+        let mut cors = CorsLayer::new();
+
+        // Configure origins
+        if self.allow_any_origin {
+            cors = cors.allow_origin(Any);
+        } else {
+            // Collect all origins (exact and regex patterns)
+            let mut origin_list = Vec::new();
+
+            // Parse exact origins
+            for origin_str in &self.origins {
+                let origin = origin_str.parse::<http::HeaderValue>().map_err(|e| {
+                    ServerError::Cors(format!("Invalid origin '{}': {}", origin_str, e))
+                })?;
+                origin_list.push(origin);
+            }
+
+            // For regex patterns, we need to use a predicate function
+            if !self.match_origins.is_empty() {
+                // Parse regex patterns to validate them
+                let mut regex_patterns = Vec::new();
+                for pattern in &self.match_origins {
+                    let regex = Regex::new(pattern).map_err(|e| {
+                        ServerError::Cors(format!("Invalid origin pattern '{}': {}", pattern, e))
+                    })?;
+                    regex_patterns.push(regex);
+                }
+
+                // Use predicate function that combines exact origins and regex patterns
+                let exact_origins = origin_list;
+                cors = cors.allow_origin(AllowOrigin::predicate(move |origin, _| {
+                    let origin_str = origin.to_str().unwrap_or("");
+
+                    // Check exact origins
+                    if exact_origins
+                        .iter()
+                        .any(|exact| exact.as_bytes() == origin.as_bytes())
+                    {
+                        return true;
+                    }
+
+                    // Check regex patterns
+                    regex_patterns
+                        .iter()
+                        .any(|regex| regex.is_match(origin_str))
+                }));
+            } else if !origin_list.is_empty() {
+                // Only exact origins, no regex
+                cors = cors.allow_origin(origin_list);
+            }
+        }
+
+        // Configure credentials
+        cors = cors.allow_credentials(self.allow_credentials);
+
+        // Configure methods
+        let methods: Result<Vec<Method>, _> = self
+            .allow_methods
+            .iter()
+            .map(|m| m.parse::<Method>())
+            .collect();
+        let methods =
+            methods.map_err(|e| ServerError::Cors(format!("Invalid HTTP method: {}", e)))?;
+        cors = cors.allow_methods(methods);
+
+        // Configure headers
+        if !self.allow_headers.is_empty() {
+            let headers: Result<Vec<http::HeaderName>, _> = self
+                .allow_headers
+                .iter()
+                .map(|h| h.parse::<http::HeaderName>())
+                .collect();
+            let headers =
+                headers.map_err(|e| ServerError::Cors(format!("Invalid header name: {}", e)))?;
+            cors = cors.allow_headers(headers);
+        }
+
+        // Configure exposed headers
+        if !self.expose_headers.is_empty() {
+            let headers: Result<Vec<http::HeaderName>, _> = self
+                .expose_headers
+                .iter()
+                .map(|h| h.parse::<http::HeaderName>())
+                .collect();
+            let headers = headers
+                .map_err(|e| ServerError::Cors(format!("Invalid exposed header name: {}", e)))?;
+            cors = cors.expose_headers(headers);
+        }
+
+        // Configure max age
+        if let Some(max_age) = self.max_age {
+            cors = cors.max_age(std::time::Duration::from_secs(max_age));
+        }
+
+        Ok(cors)
+    }
+
+    /// Validate the configuration for consistency
+    fn validate(&self) -> Result<(), ServerError> {
+        // Cannot use credentials with any origin
+        if self.allow_credentials && self.allow_any_origin {
+            return Err(ServerError::Cors(
+                "Cannot use allow_credentials with allow_any_origin for security reasons"
+                    .to_string(),
+            ));
+        }
+
+        // Must have at least some origin configuration if not allowing any origin
+        if !self.allow_any_origin && self.origins.is_empty() && self.match_origins.is_empty() {
+            return Err(ServerError::Cors(
+                "Must specify origins, match_origins, or allow_any_origin when CORS is enabled"
+                    .to_string(),
+            ));
+        }
+
+        // Validate that origin strings are valid URLs
+        for origin in &self.origins {
+            Url::parse(origin).map_err(|e| {
+                ServerError::Cors(format!("Invalid origin URL '{}': {}", origin, e))
+            })?;
+        }
+
+        // Validate regex patterns
+        for pattern in &self.match_origins {
+            Regex::new(pattern).map_err(|e| {
+                ServerError::Cors(format!("Invalid regex pattern '{}': {}", pattern, e))
+            })?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = CorsConfig::default();
+        assert!(!config.enabled);
+        assert!(!config.allow_any_origin);
+        assert!(!config.allow_credentials);
+        assert_eq!(config.allow_methods, default_methods());
+        assert_eq!(config.allow_headers, default_headers());
+        assert_eq!(config.max_age, Some(default_max_age()));
+    }
+
+    #[test]
+    fn test_disabled_cors_fails_to_build() {
+        let config = CorsConfig::default();
+        assert!(config.build_cors_layer().is_err());
+    }
+
+    #[test]
+    fn test_allow_any_origin_builds() {
+        let config = CorsConfig {
+            enabled: true,
+            allow_any_origin: true,
+            ..Default::default()
+        };
+        assert!(config.build_cors_layer().is_ok());
+    }
+
+    #[test]
+    fn test_specific_origins_build() {
+        let config = CorsConfig {
+            enabled: true,
+            origins: vec![
+                "https://localhost:3000".to_string(),
+                "https://studio.apollographql.com".to_string(),
+            ],
+            ..Default::default()
+        };
+        assert!(config.build_cors_layer().is_ok());
+    }
+
+    #[test]
+    fn test_regex_origins_build() {
+        let config = CorsConfig {
+            enabled: true,
+            match_origins: vec!["^https://localhost:[0-9]+$".to_string()],
+            ..Default::default()
+        };
+        assert!(config.build_cors_layer().is_ok());
+    }
+
+    #[test]
+    fn test_credentials_with_any_origin_fails() {
+        let config = CorsConfig {
+            enabled: true,
+            allow_any_origin: true,
+            allow_credentials: true,
+            ..Default::default()
+        };
+        assert!(config.build_cors_layer().is_err());
+    }
+
+    #[test]
+    fn test_no_origins_fails() {
+        let config = CorsConfig {
+            enabled: true,
+            allow_any_origin: false,
+            origins: vec![],
+            match_origins: vec![],
+            ..Default::default()
+        };
+        assert!(config.build_cors_layer().is_err());
+    }
+
+    #[test]
+    fn test_invalid_origin_fails() {
+        let config = CorsConfig {
+            enabled: true,
+            origins: vec!["not-a-valid-url".to_string()],
+            ..Default::default()
+        };
+        assert!(config.build_cors_layer().is_err());
+    }
+
+    #[test]
+    fn test_invalid_regex_fails() {
+        let config = CorsConfig {
+            enabled: true,
+            match_origins: vec!["[invalid regex".to_string()],
+            ..Default::default()
+        };
+        assert!(config.build_cors_layer().is_err());
+    }
+
+    #[test]
+    fn test_invalid_method_fails() {
+        let config = CorsConfig {
+            enabled: true,
+            origins: vec!["https://localhost:3000".to_string()],
+            allow_methods: vec!["invalid method with spaces".to_string()],
+            ..Default::default()
+        };
+        assert!(config.build_cors_layer().is_err());
+    }
+}

--- a/crates/apollo-mcp-server/src/cors.rs
+++ b/crates/apollo-mcp-server/src/cors.rs
@@ -47,7 +47,11 @@ impl Default for CorsConfig {
             match_origins: Vec::new(),
             allow_any_origin: false,
             allow_credentials: false,
-            allow_methods: vec!["GET".to_string(), "POST".to_string()],
+            allow_methods: vec![
+                "GET".to_string(),
+                "POST".to_string(),
+                "DELETE".to_string(), // Clients that no longer need a particular session SHOULD send an HTTP DELETE to explicitly terminate the session
+            ],
             allow_headers: vec![
                 "content-type".to_string(),
                 "mcp-protocol-version".to_string(), // https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#protocol-version-header
@@ -223,7 +227,7 @@ mod tests {
         assert!(!config.allow_credentials);
         assert_eq!(
             config.allow_methods,
-            vec!["GET".to_string(), "POST".to_string()]
+            vec!["GET".to_string(), "POST".to_string(), "DELETE".to_string()]
         );
         assert_eq!(
             config.allow_headers,

--- a/crates/apollo-mcp-server/src/cors.rs
+++ b/crates/apollo-mcp-server/src/cors.rs
@@ -181,7 +181,7 @@ impl CorsConfig {
         // Cannot use credentials with any origin
         if self.allow_credentials && self.allow_any_origin {
             return Err(ServerError::Cors(
-                "Cannot use allow_credentials with allow_any_origin for security reasons"
+                "Cannot use allow_credentials with allow_any_origin for security reasons. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS#requests_with_credentials"
                     .to_string(),
             ));
         }

--- a/crates/apollo-mcp-server/src/cors.rs
+++ b/crates/apollo-mcp-server/src/cors.rs
@@ -52,9 +52,15 @@ impl Default for CorsConfig {
                 "content-type".to_string(),
                 "mcp-protocol-version".to_string(), // https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#protocol-version-header
                 "mcp-session-id".to_string(), // https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management
+                "traceparent".to_string(), // https://www.w3.org/TR/trace-context/#traceparent-header
+                "tracestate".to_string(),  // https://www.w3.org/TR/trace-context/#tracestate-header
             ],
-            expose_headers: vec!["mcp-session-id".to_string()], // https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management
-            max_age: Some(7200),                                // 2 hours
+            expose_headers: vec![
+                "mcp-session-id".to_string(), // https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management
+                "traceparent".to_string(), // https://www.w3.org/TR/trace-context/#traceparent-header
+                "tracestate".to_string(),  // https://www.w3.org/TR/trace-context/#tracestate-header
+            ],
+            max_age: Some(7200), // 2 hours
         }
     }
 }
@@ -225,6 +231,16 @@ mod tests {
                 "content-type".to_string(),
                 "mcp-protocol-version".to_string(),
                 "mcp-session-id".to_string(),
+                "traceparent".to_string(),
+                "tracestate".to_string(),
+            ]
+        );
+        assert_eq!(
+            config.expose_headers,
+            vec![
+                "mcp-session-id".to_string(),
+                "traceparent".to_string(),
+                "tracestate".to_string(),
             ]
         );
         assert_eq!(config.max_age, Some(7200));

--- a/crates/apollo-mcp-server/src/errors.rs
+++ b/crates/apollo-mcp-server/src/errors.rs
@@ -100,6 +100,9 @@ pub enum ServerError {
 
     #[error("Failed to index schema: {0}")]
     Indexing(#[from] IndexingError),
+
+    #[error("CORS configuration error: {0}")]
+    Cors(String),
 }
 
 /// An MCP tool error

--- a/crates/apollo-mcp-server/src/lib.rs
+++ b/crates/apollo-mcp-server/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod cors;
 pub mod custom_scalar_map;
 pub mod errors;
 pub mod event;

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -145,6 +145,7 @@ async fn main() -> anyhow::Result<()> {
         .search_leaf_depth(config.introspection.search.leaf_depth)
         .index_memory_bytes(config.introspection.search.index_memory_bytes)
         .health_check(config.health_check)
+        .cors(config.cors)
         .build()
         .start()
         .await?)

--- a/crates/apollo-mcp-server/src/runtime.rs
+++ b/crates/apollo-mcp-server/src/runtime.rs
@@ -158,9 +158,13 @@ mod test {
                         "content-type",
                         "mcp-protocol-version",
                         "mcp-session-id",
+                        "traceparent",
+                        "tracestate",
                     ],
                     expose_headers: [
                         "mcp-session-id",
+                        "traceparent",
+                        "tracestate",
                     ],
                     max_age: Some(
                         7200,

--- a/crates/apollo-mcp-server/src/runtime.rs
+++ b/crates/apollo-mcp-server/src/runtime.rs
@@ -144,6 +144,27 @@ mod test {
 
             insta::assert_debug_snapshot!(config, @r#"
             Config {
+                cors: CorsConfig {
+                    enabled: false,
+                    origins: [],
+                    match_origins: [],
+                    allow_any_origin: false,
+                    allow_credentials: false,
+                    allow_methods: [
+                        "GET",
+                        "POST",
+                        "OPTIONS",
+                    ],
+                    allow_headers: [
+                        "content-type",
+                        "authorization",
+                        "mcp-session-id",
+                    ],
+                    expose_headers: [],
+                    max_age: Some(
+                        7200,
+                    ),
+                },
                 custom_scalars: None,
                 endpoint: Endpoint(
                     Url {

--- a/crates/apollo-mcp-server/src/runtime.rs
+++ b/crates/apollo-mcp-server/src/runtime.rs
@@ -153,14 +153,15 @@ mod test {
                     allow_methods: [
                         "GET",
                         "POST",
-                        "OPTIONS",
                     ],
                     allow_headers: [
                         "content-type",
-                        "authorization",
+                        "mcp-protocol-version",
                         "mcp-session-id",
                     ],
-                    expose_headers: [],
+                    expose_headers: [
+                        "mcp-session-id",
+                    ],
                     max_age: Some(
                         7200,
                     ),

--- a/crates/apollo-mcp-server/src/runtime.rs
+++ b/crates/apollo-mcp-server/src/runtime.rs
@@ -153,6 +153,7 @@ mod test {
                     allow_methods: [
                         "GET",
                         "POST",
+                        "DELETE",
                     ],
                     allow_headers: [
                         "content-type",

--- a/crates/apollo-mcp-server/src/runtime/config.rs
+++ b/crates/apollo-mcp-server/src/runtime/config.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use apollo_mcp_server::{health::HealthCheckConfig, server::Transport};
+use apollo_mcp_server::{cors::CorsConfig, health::HealthCheckConfig, server::Transport};
 use reqwest::header::HeaderMap;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -15,6 +15,9 @@ use super::{
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(default)]
 pub struct Config {
+    /// CORS configuration
+    pub cors: CorsConfig,
+
     /// Path to a custom scalar map
     pub custom_scalars: Option<PathBuf>,
 

--- a/crates/apollo-mcp-server/src/server.rs
+++ b/crates/apollo-mcp-server/src/server.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 use url::Url;
 
 use crate::auth;
+use crate::cors::CorsConfig;
 use crate::custom_scalar_map::CustomScalarMap;
 use crate::errors::ServerError;
 use crate::event::Event as ServerEvent;
@@ -40,6 +41,7 @@ pub struct Server {
     search_leaf_depth: usize,
     index_memory_bytes: usize,
     health_check: HealthCheckConfig,
+    cors: CorsConfig,
 }
 
 #[derive(Debug, Clone, Deserialize, Default, JsonSchema)]
@@ -124,6 +126,7 @@ impl Server {
         search_leaf_depth: usize,
         index_memory_bytes: usize,
         health_check: HealthCheckConfig,
+        cors: CorsConfig,
     ) -> Self {
         let headers = {
             let mut headers = headers.clone();
@@ -151,6 +154,7 @@ impl Server {
             search_leaf_depth,
             index_memory_bytes,
             health_check,
+            cors,
         }
     }
 

--- a/crates/apollo-mcp-server/src/server/states.rs
+++ b/crates/apollo-mcp-server/src/server/states.rs
@@ -6,6 +6,7 @@ use reqwest::header::HeaderMap;
 use url::Url;
 
 use crate::{
+    cors::CorsConfig,
     custom_scalar_map::CustomScalarMap,
     errors::{OperationError, ServerError},
     health::HealthCheckConfig,
@@ -48,6 +49,7 @@ struct Config {
     search_leaf_depth: usize,
     index_memory_bytes: usize,
     health_check: HealthCheckConfig,
+    cors: CorsConfig,
 }
 
 impl StateMachine {
@@ -81,6 +83,7 @@ impl StateMachine {
                 search_leaf_depth: server.search_leaf_depth,
                 index_memory_bytes: server.index_memory_bytes,
                 health_check: server.health_check,
+                cors: server.cors,
             },
         });
 

--- a/docs/source/_sidebar.yaml
+++ b/docs/source/_sidebar.yaml
@@ -28,7 +28,7 @@ items:
         href: "./deploy"
       - label: "Health Checks"
         href: "./health-checks"
-      - label: "CORS Support"
+      - label: "CORS"
         href: "./cors"
   - label: "Authorization"
     href: "./auth"

--- a/docs/source/_sidebar.yaml
+++ b/docs/source/_sidebar.yaml
@@ -28,6 +28,8 @@ items:
         href: "./deploy"
       - label: "Health Checks"
         href: "./health-checks"
+      - label: "CORS Support"
+        href: "./cors"
   - label: "Authorization"
     href: "./auth"
   - label: "Best Practices"

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -45,17 +45,17 @@ These fields are under the top-level `graphos` key and define your GraphOS graph
 
 These fields are under the top-level `cors` key and configure Cross-Origin Resource Sharing (CORS) for browser-based MCP clients.
 
-| Option              | Type           | Default                             | Description                                                                                              |
-| :------------------ | :------------- | :---------------------------------- | :------------------------------------------------------------------------------------------------------- |
-| `enabled`           | `bool`         | `false`                             | Enable CORS support                                                                                      |
-| `origins`           | `List<string>` | `[]`                                | List of allowed origins (exact matches). Use `["*"]` to allow any origin (not recommended in production) |
-| `match_origins`     | `List<string>` | `[]`                                | List of regex patterns to match allowed origins (e.g., `"^https://localhost:[0-9]+$"`)                   |
-| `allow_any_origin`  | `bool`         | `false`                             | Allow requests from any origin. Cannot be used with `allow_credentials: true`                            |
-| `allow_credentials` | `bool`         | `false`                             | Allow credentials (cookies, authorization headers) in CORS requests                                      |
-| `allow_methods`     | `List<string>` | `["GET", "POST", "OPTIONS"]`        | List of allowed HTTP methods                                                                             |
-| `allow_headers`     | `List<string>` | `["content-type", "authorization"]` | List of allowed request headers                                                                          |
-| `expose_headers`    | `List<string>` | `[]`                                | List of response headers exposed to the browser (e.g., `["mcp-session-id"]`)                             |
-| `max_age`           | `number`       | `86400`                             | Maximum age (in seconds) for preflight cache                                                             |
+| Option              | Type           | Default                                                                                   | Description                                                                                              |
+| :------------------ | :------------- | :---------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------- |
+| `enabled`           | `bool`         | `false`                                                                                   | Enable CORS support                                                                                      |
+| `origins`           | `List<string>` | `[]`                                                                                      | List of allowed origins (exact matches). Use `["*"]` to allow any origin (not recommended in production) |
+| `match_origins`     | `List<string>` | `[]`                                                                                      | List of regex patterns to match allowed origins (e.g., `"^https://localhost:[0-9]+$"`)                   |
+| `allow_any_origin`  | `bool`         | `false`                                                                                   | Allow requests from any origin. Cannot be used with `allow_credentials: true`                            |
+| `allow_credentials` | `bool`         | `false`                                                                                   | Allow credentials (cookies, authorization headers) in CORS requests                                      |
+| `allow_methods`     | `List<string>` | `["GET", "POST", "OPTIONS"]`                                                              | List of allowed HTTP methods                                                                             |
+| `allow_headers`     | `List<string>` | `["content-type", "mcp-protocol-version", "mcp-session-id", "traceparent", "tracestate"]` | List of allowed request headers                                                                          |
+| `expose_headers`    | `List<string>` | `["mcp-session-id", "traceparent", "tracestate"]`                                         | List of response headers exposed to the browser (includes MCP and W3C Trace Context headers)             |
+| `max_age`           | `number`       | `86400`                                                                                   | Maximum age (in seconds) for preflight cache                                                             |
 
 ### Health checks
 

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -17,6 +17,7 @@ All fields are optional.
 
 | Option           | Type                  | Default                  | Description                                                      |
 | :--------------- | :-------------------- | :----------------------- | :--------------------------------------------------------------- |
+| `cors`           | `Cors`                |                          | CORS configuration                                               |
 | `custom_scalars` | `FilePath`            |                          | Path to a [custom scalar map](/apollo-mcp-server/custom-scalars) |
 | `endpoint`       | `URL`                 | `http://localhost:4000/` | The target GraphQL endpoint                                      |
 | `graphos`        | `GraphOS`             |                          | Apollo-specific credential overrides                             |
@@ -39,6 +40,22 @@ These fields are under the top-level `graphos` key and define your GraphOS graph
 | `apollo_graph_ref`        | `string` |         | The Apollo GraphOS graph reference. You can also provide this with the `APOLLO_GRAPH_REF` environment variable  |
 | `apollo_registry_url`     | `URL`    |         | The URL to use for Apollo's registry                                                                            |
 | `apollo_uplink_endpoints` | `URL`    |         | List of uplink URL overrides. You can also provide this with the `APOLLO_UPLINK_ENDPOINTS` environment variable |
+
+### CORS
+
+These fields are under the top-level `cors` key and configure Cross-Origin Resource Sharing (CORS) for browser-based MCP clients.
+
+| Option              | Type           | Default                             | Description                                                                                              |
+| :------------------ | :------------- | :---------------------------------- | :------------------------------------------------------------------------------------------------------- |
+| `enabled`           | `bool`         | `false`                             | Enable CORS support                                                                                      |
+| `origins`           | `List<string>` | `[]`                                | List of allowed origins (exact matches). Use `["*"]` to allow any origin (not recommended in production) |
+| `match_origins`     | `List<string>` | `[]`                                | List of regex patterns to match allowed origins (e.g., `"^https://localhost:[0-9]+$"`)                   |
+| `allow_any_origin`  | `bool`         | `false`                             | Allow requests from any origin. Cannot be used with `allow_credentials: true`                            |
+| `allow_credentials` | `bool`         | `false`                             | Allow credentials (cookies, authorization headers) in CORS requests                                      |
+| `allow_methods`     | `List<string>` | `["GET", "POST", "OPTIONS"]`        | List of allowed HTTP methods                                                                             |
+| `allow_headers`     | `List<string>` | `["content-type", "authorization"]` | List of allowed request headers                                                                          |
+| `expose_headers`    | `List<string>` | `[]`                                | List of response headers exposed to the browser (e.g., `["mcp-session-id"]`)                             |
+| `max_age`           | `number`       | `86400`                             | Maximum age (in seconds) for preflight cache                                                             |
 
 ### Health checks
 
@@ -154,7 +171,6 @@ The available fields depend on the value of the nested `type` key:
 | `port`          | `5000` (default)      | `u16`      | The port to bind to                                                       |
 | `stateful_mode` | `true` (default)      | `bool`     | Flag to enable or disable stateful mode and session management.           |
 
-
 ##### SSE (Deprecated, use StreamableHTTP)
 
 | Option    | Value                 | Value Type | Description                                                                                                      |
@@ -167,14 +183,14 @@ The available fields depend on the value of the nested `type` key:
 
 These fields are under the top-level `transport` key, nested under the `auth` key. Learn more about [authorization and authentication](/apollo-mcp-server/auth).
 
-| Option                            | Type           | Default | Description                                                                                        |
-| :-------------------------------- | :------------- | :------ | :------------------------------------------------------------------------------------------------- |
-| `servers`                         | `List<URL>`    |         | List of upstream delegated OAuth servers (must support OIDC metadata discovery endpoint)           |
-| `audiences`                       | `List<string>` |         | List of accepted audiences from upstream signed JWTs                                               |
-| `resource`                        | `string`       |         | The externally available URL pointing to this MCP server. Can be `localhost` when testing locally. |
-| `resource_documentation`          | `string`       |         | Optional link to more documentation relating to this MCP server                                    |
-| `scopes`                          | `List<string>` |         | List of queryable OAuth scopes from the upstream OAuth servers                                     |
-| `disable_auth_token_passthrough`  | `bool`         | `false` | Optional flag to disable passing validated Authorization header to downstream API                  |
+| Option                           | Type           | Default | Description                                                                                        |
+| :------------------------------- | :------------- | :------ | :------------------------------------------------------------------------------------------------- |
+| `servers`                        | `List<URL>`    |         | List of upstream delegated OAuth servers (must support OIDC metadata discovery endpoint)           |
+| `audiences`                      | `List<string>` |         | List of accepted audiences from upstream signed JWTs                                               |
+| `resource`                       | `string`       |         | The externally available URL pointing to this MCP server. Can be `localhost` when testing locally. |
+| `resource_documentation`         | `string`       |         | Optional link to more documentation relating to this MCP server                                    |
+| `scopes`                         | `List<string>` |         | List of queryable OAuth scopes from the upstream OAuth servers                                     |
+| `disable_auth_token_passthrough` | `bool`         | `false` | Optional flag to disable passing validated Authorization header to downstream API                  |
 
 Below is an example configuration using `StreamableHTTP` transport with authentication:
 

--- a/docs/source/cors.mdx
+++ b/docs/source/cors.mdx
@@ -1,0 +1,243 @@
+---
+title: Configuring CORS
+---
+
+# Configuring CORS
+
+Control browser access to your MCP server
+
+---
+
+**This article describes CORS configuration that's specific to Apollo MCP Server**. For a more general introduction to CORS and common considerations, see [MDN's CORS documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS).
+
+By default, Apollo MCP Server has CORS disabled. If your MCP server serves tools to browser-based applications, you need to enable CORS and configure one of the following in the `cors` section of your server's YAML config file:
+
+- Add the origins of those web applications to the server's list of allowed `origins`.
+  - Use this option if there is a known, finite list of web applications that consume your MCP server.
+- Add a regex that matches the origins of those web applications to the server's list of allowed `match_origins`.
+  - This option comes in handy if you want to match origins against a pattern, see the example below that matches subdomains of a specific namespace.
+- Enable the `allow_any_origin` option.
+  - Use this option if your MCP server is a public API with arbitrarily many web app consumers.
+  - With this option enabled, the server sends the wildcard (\*) value for the `Access-Control-Allow-Origin` header. This enables _any_ website to initiate browser connections to it (but they can't provide cookies or other credentials).
+- If clients need to authenticate their requests with cookies, you _must_ use either `origins`, `match_origins`, or the combination of both options. When using both options, note that `origins` is evaluated before `match_origins`.
+
+The following snippet includes an example of each option (use either `allow_any_origin`, or `origins` and/or `match_origins`):
+
+```yaml title="mcp.yaml"
+transport:
+  type: streamable_http
+  port: 5000
+
+cors:
+  # Enable CORS support
+  enabled: true
+
+  # Set to true to allow any origin
+  # (Defaults to false)
+  allow_any_origin: true
+
+  # List of accepted origins
+  # (Ignored if allow_any_origin is true)
+  #
+  # An origin is a combination of scheme, hostname and port.
+  # It does not have any path section, so no trailing slash.
+  origins:
+    - https://www.your-app.example.com
+    - https://studio.apollographql.com # Keep this so GraphOS Studio can run queries against your server
+
+  # List of origin patterns (regex matching)
+  match_origins:
+    - "^https://([a-z0-9]+[.])*api[.]example[.]com$" # any host that uses https and ends with .api.example.com
+```
+
+You can also disable CORS entirely by setting `enabled` to `false` or omitting the `cors` section:
+
+```yaml title="mcp.yaml"
+cors:
+  enabled: false
+```
+
+If your MCP server serves exclusively _non_-browser-based clients, you probably don't need to enable CORS configuration.
+
+## Passing credentials
+
+If your MCP server requires requests to include a user's credentials (e.g., via cookies), you need to modify your CORS configuration to tell the browser those credentials are allowed.
+
+You can enable credentials with CORS by setting the Access-Control-Allow-Credentials HTTP header to `true`.
+
+To allow browsers to pass credentials to the server, set `allow_credentials` to `true`, like so:
+
+```yaml title="mcp.yaml"
+cors:
+  enabled: true
+  origins:
+    - https://www.your-app.example.com
+    - https://studio.apollographql.com
+  allow_credentials: true
+```
+
+**To support credentialed requests, your server's config file must specify individual `origins` or `match_origins`**. If your server enables `allow_any_origin`, your browser will refuse to send credentials.
+
+## All `cors` options
+
+The following snippet shows all CORS configuration defaults for Apollo MCP Server:
+
+```yaml title="mcp.yaml"
+#
+# CORS (Cross Origin Resource Sharing)
+#
+cors:
+  # Enable CORS support
+  enabled: false
+
+  # Set to true to allow any origin
+  allow_any_origin: false
+
+  # List of accepted origins
+  # (Ignored if allow_any_origin is set to true)
+  #
+  # An origin is a combination of scheme, hostname and port.
+  # It does not have any path section, so no trailing slash.
+  origins: []
+
+  # List of origin patterns (regex matching)
+  # Useful for matching dynamic ports or subdomains
+  match_origins: []
+
+  # Set to true to add the `Access-Control-Allow-Credentials` header
+  allow_credentials: false
+
+  # Allowed request methods
+  allow_methods:
+    - GET
+    - POST
+
+  # The headers to allow.
+  # These are the default headers required for MCP protocol
+  allow_headers:
+    - accept
+    - content-type
+    - mcp-protocol-version
+    - mcp-session-id
+
+  # Which response headers are available to scripts running in the
+  # browser in response to a cross-origin request.
+  # The mcp-session-id header should be exposed for MCP session management.
+  expose_headers:
+    - mcp-session-id
+
+  # Adds the Access-Control-Max-Age header
+  # Maximum age (in seconds) for preflight cache
+  max_age: 7200 # 2 hours
+```
+
+## Origin matching
+
+Apollo MCP Server supports two types of origin matching:
+
+### Exact origins
+
+Use the `origins` array for exact origin matches:
+
+```yaml
+cors:
+  enabled: true
+  origins:
+    - http://localhost:3000
+    - https://myapp.example.com
+    - https://studio.apollographql.com
+```
+
+### Pattern matching
+
+Use the `match_origins` array for regex pattern matching:
+
+```yaml
+cors:
+  enabled: true
+  match_origins:
+    - "^https://localhost:[0-9]+$" # Any localhost HTTPS port
+    - "^http://localhost:[0-9]+$" # Any localhost HTTP port
+    - "^https://.*\\.example\\.com$" # Any subdomain of example.com
+```
+
+## Common configurations
+
+### Development setup
+
+For local development with hot reloading and various ports:
+
+```yaml title="mcp.yaml"
+cors:
+  enabled: true
+  match_origins:
+    - "^http://localhost:[0-9]+$"
+  allow_credentials: true
+```
+
+### Production setup
+
+For production with specific known origins:
+
+```yaml title="mcp.yaml"
+cors:
+  enabled: true
+  origins:
+    - https://myapp.example.com
+    - https://studio.apollographql.com
+  allow_credentials: true
+  max_age: 86400 # 24 hours
+```
+
+### Public API setup
+
+For public APIs that don't require credentials:
+
+```yaml title="mcp.yaml"
+cors:
+  enabled: true
+  allow_any_origin: true
+  allow_credentials: false # Cannot use credentials with any origin
+```
+
+## Browser integration example
+
+Here's a simple example of connecting to Apollo MCP Server from a browser:
+
+```javascript
+async function connectToMCP() {
+  const response = await fetch("http://127.0.0.1:5000/mcp", {
+    method: "POST",
+    headers: {
+      Accept: "application/json, text/event-stream",
+      "Content-Type": "application/json",
+      "MCP-Protocol-Version": "2025-06-18",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "Browser Client", version: "1.0" },
+      },
+      id: 1,
+    }),
+  });
+
+  // Extract session ID from response headers (automatically exposed)
+  const sessionId = response.headers.get("mcp-session-id");
+
+  // Handle SSE format response (starts with "data: ")
+  const responseText = await response.text();
+  const jsonData = responseText.startsWith("data: ")
+    ? responseText.slice(6) // Remove "data: " prefix
+    : responseText;
+
+  const result = JSON.parse(jsonData);
+  console.log("Connected:", result);
+  console.log("Session ID:", sessionId);
+}
+
+connectToMCP();
+```

--- a/docs/source/cors.mdx
+++ b/docs/source/cors.mdx
@@ -43,7 +43,6 @@ cors:
   # It does not have any path section, so no trailing slash.
   origins:
     - https://www.your-app.example.com
-    - https://studio.apollographql.com # Keep this so GraphOS Studio can run queries against your server
 
   # List of origin patterns (regex matching)
   match_origins:
@@ -72,7 +71,6 @@ cors:
   enabled: true
   origins:
     - https://www.your-app.example.com
-    - https://studio.apollographql.com
   allow_credentials: true
 ```
 
@@ -150,7 +148,6 @@ cors:
   origins:
     - http://localhost:3000
     - https://myapp.example.com
-    - https://studio.apollographql.com
 ```
 
 ### Pattern matching
@@ -189,7 +186,6 @@ cors:
   enabled: true
   origins:
     - https://myapp.example.com
-    - https://studio.apollographql.com
   allow_credentials: true
   max_age: 86400 # 24 hours
 ```

--- a/docs/source/cors.mdx
+++ b/docs/source/cors.mdx
@@ -113,18 +113,23 @@ cors:
     - POST
 
   # The headers to allow.
-  # These are the default headers required for MCP protocol
+  # These are the default headers required for MCP protocol and trace context
   allow_headers:
     - accept
     - content-type
     - mcp-protocol-version
     - mcp-session-id
+    - traceparent # W3C Trace Context
+    - tracestate # W3C Trace Context
 
   # Which response headers are available to scripts running in the
   # browser in response to a cross-origin request.
   # The mcp-session-id header should be exposed for MCP session management.
+  # Trace context headers are exposed for distributed tracing.
   expose_headers:
     - mcp-session-id
+    - traceparent # W3C Trace Context
+    - tracestate # W3C Trace Context
 
   # Adds the Access-Control-Max-Age header
   # Maximum age (in seconds) for preflight cache

--- a/docs/source/cors.mdx
+++ b/docs/source/cors.mdx
@@ -2,7 +2,7 @@
 title: Configuring CORS
 ---
 
-# Configuring CORS
+## Configuring CORS
 
 Control browser access to your MCP server
 
@@ -58,7 +58,7 @@ cors:
 
 If your MCP server serves exclusively _non_-browser-based clients, you probably don't need to enable CORS configuration.
 
-## Passing credentials
+### Passing credentials
 
 If your MCP server requires requests to include a user's credentials (e.g., via cookies), you need to modify your CORS configuration to tell the browser those credentials are allowed.
 
@@ -76,7 +76,7 @@ cors:
 
 **To support credentialed requests, your server's config file must specify individual `origins` or `match_origins`**. If your server enables `allow_any_origin`, your browser will refuse to send credentials.
 
-## All `cors` options
+### All `cors` options
 
 The following snippet shows all CORS configuration defaults for Apollo MCP Server:
 
@@ -134,11 +134,11 @@ cors:
   max_age: 7200 # 2 hours
 ```
 
-## Origin matching
+### Origin matching
 
 Apollo MCP Server supports two types of origin matching:
 
-### Exact origins
+#### Exact origins
 
 Use the `origins` array for exact origin matches:
 
@@ -150,7 +150,7 @@ cors:
     - https://myapp.example.com
 ```
 
-### Pattern matching
+#### Pattern matching
 
 Use the `match_origins` array for regex pattern matching:
 
@@ -163,9 +163,9 @@ cors:
     - "^https://.*\\.example\\.com$" # Any subdomain of example.com
 ```
 
-## Common configurations
+### Common configurations
 
-### Development setup
+#### Development setup
 
 For local development with hot reloading and various ports:
 
@@ -177,7 +177,7 @@ cors:
   allow_credentials: true
 ```
 
-### Production setup
+#### Production setup
 
 For production with specific known origins:
 
@@ -190,7 +190,7 @@ cors:
   max_age: 86400 # 24 hours
 ```
 
-### Public API setup
+#### Public API setup
 
 For public APIs that don't require credentials:
 
@@ -201,7 +201,7 @@ cors:
   allow_credentials: false # Cannot use credentials with any origin
 ```
 
-## Browser integration example
+### Browser integration example
 
 Here's a simple example of connecting to Apollo MCP Server from a browser:
 


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/GT-271 -->

This PR implements comprehensive CORS support for Apollo MCP Server to enable web-based MCP clients to connect without CORS errors. The implementation and configuration draw heavily from the Router's approach. Similar to other features like health checks and telemetry, CORS is supported only for the StreamableHttp transport, making it a top-level configuration.

### Configuration

You can configure it like this:

```yaml
cors:
  enabled: true
  origins:
    - https://example.com
    - https://studio.apollographql.com
  match_origins:
    - "^http://localhost:[0-9]+$"
    - "^http://127.0.0.1:[0-9]+$"
  allow_credentials: true
  allow_methods:
    - GET
    - POST
  allow_headers:
    - content-type
    - authorization
    - mcp-protocol-version
    - mcp-session-id
  expose_headers:
    - mcp-session-id
  max_age: 0
```

Minimum configuration:

```yaml
cors:
  enabled: true
  allow_any_origin: true
```

## Test

Allowed Pre-flight request with `access-control-allow-origin: http://localhost:3000`.

```sh
$ curl -i -X OPTIONS \
  -H "Origin: http://localhost:3000" \
  -H "Access-Control-Request-Method: POST" \
http://127.0.0.1:5000/mcp

HTTP/1.1 200 OK
access-control-allow-credentials: true
vary: origin, access-control-request-method, access-control-request-headers
access-control-allow-methods: GET,POST
access-control-allow-headers: content-type,authorization,mcp-protocol-version,mcp-session-id
access-control-max-age: 7200
access-control-allow-origin: http://localhost:3000
content-length: 0
date: Wed, 17 Sep 2025 20:45:21 GMT
```

Rejected Pre-flight request with no `access-control-allow-origin`

```sh
$ curl -i -X OPTIONS \
  -H "Origin: https://unauthorized.com" \
  -H "Access-Control-Request-Method: POST" \
http://127.0.0.1:5000/mcp

HTTP/1.1 200 OK
access-control-allow-credentials: true
vary: origin, access-control-request-method, access-control-request-headers
access-control-allow-methods: GET,POST
access-control-allow-headers: content-type,authorization,mcp-protocol-version,mcp-session-id
access-control-max-age: 7200
content-length: 0
date: Wed, 17 Sep 2025 20:53:15 GMT
```

MCP Initialize Call with `access-control-expose-headers: mcp-session-id`

```sh
$ curl -i -X POST \
  -H "Origin: http://localhost:3000" \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}},"id":1}' \
  http://127.0.0.1:5000/mcp

HTTP/1.1 200 OK
content-type: text/event-stream
cache-control: no-cache
mcp-session-id: 4063d7b8-9810-464d-b3f7-3a0414ac4abd
vary: origin, access-control-request-method, access-control-request-headers
access-control-allow-credentials: true
access-control-allow-origin: http://localhost:3000
access-control-expose-headers: mcp-session-id
transfer-encoding: chunked
date: Wed, 17 Sep 2025 21:06:40 GMT

data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{"listChanged":true}},"serverInfo":{"name":"Apollo MCP Server","title":"Apollo MCP Server","version":"0.8.0","websiteUrl":"https://www.apollographql.com/docs/apollo-mcp-server"}}}
```

## End-to-end

Open any website in your browser and run the following script in the console. Make sure to set up the MCP server to allow the website URL as the CORS origin.

```yml
cors:
  enabled: true
  origins:
    - https://your-website.com
```

```js
async function connectToMCP() {
  const response = await fetch("http://127.0.0.1:5000/mcp", {
    method: "POST",
    headers: {
      Accept: "application/json, text/event-stream",
      "Content-Type": "application/json",
      "MCP-Protocol-Version": "2025-06-18",
    },
    body: JSON.stringify({
      jsonrpc: "2.0",
      method: "initialize",
      params: {
        protocolVersion: "2025-06-18",
        capabilities: {},
        clientInfo: { name: "Browser Client", version: "1.0" },
      },
      id: 1,
    }),
  });

  // Extract session ID from response headers (automatically exposed)
  const sessionId = response.headers.get("mcp-session-id");

  // Handle SSE format response (starts with "data: ")
  const responseText = await response.text();
  const jsonData = responseText.startsWith("data: ")
    ? responseText.slice(6) // Remove "data: " prefix
    : responseText;

  const result = JSON.parse(jsonData);
  console.log("Connected:", result);
  console.log("Session ID:", sessionId);
}

connectToMCP();
```

<img width="2332" height="1630" alt="2025-09-23 at 09 45 01" src="https://github.com/user-attachments/assets/23bd1b33-2e7a-40e2-a876-51e7d0397f2d" />
