### PR TITLE
Update SDL handling in sdl_to_api_schema function

### DIFF
--- a/.changesets/fix_lb_supergraph_new_specs.md
+++ b/.changesets/fix_lb_supergraph_new_specs.md
@@ -1,0 +1,3 @@
+### Update SDL handling in sdl_to_api_schema function - @lennyburdette PR #365
+
+Loads supergraph schemas using a function that supports various features, including Apollo Connectors. When supergraph loading failed, it would load it as a standard GraphQL schema, which reveals Federation query planning directives in when using the `search` and `introspection` tools.

--- a/crates/apollo-mcp-server/src/server/states.rs
+++ b/crates/apollo-mcp-server/src/server/states.rs
@@ -153,7 +153,7 @@ impl StateMachine {
 
     #[allow(clippy::result_large_err)]
     fn sdl_to_api_schema(schema_state: SchemaState) -> Result<Valid<Schema>, ServerError> {
-        match Supergraph::new(&schema_state.sdl) {
+        match Supergraph::new_with_router_specs(&schema_state.sdl) {
             Ok(supergraph) => Ok(supergraph
                 .to_api_schema(ApiSchemaOptions::default())
                 .map_err(|e| ServerError::Federation(Box::new(e)))?


### PR DESCRIPTION
`::new` uses "default" supergraph specs, which does not include Connectors, so all connector supergraph result in an error and are parsed as standard GraphQL. This ends up exposing join directives, which is a huge waste of tokens.