### PR TITLE
Telemetry: Trace operations and auth

### DIFF
--- a/crates/apollo-mcp-registry/src/platform_api/operation_collections/collection_poller.rs
+++ b/crates/apollo-mcp-registry/src/platform_api/operation_collections/collection_poller.rs
@@ -248,7 +248,7 @@ impl From<&OperationCollectionDefaultEntry> for OperationData {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum CollectionSource {
     Id(String, PlatformApiConfig),
     Default(String, PlatformApiConfig),

--- a/crates/apollo-mcp-server/src/operations/operation.rs
+++ b/crates/apollo-mcp-server/src/operations/operation.rs
@@ -48,6 +48,7 @@ impl Operation {
         self.inner
     }
 
+    #[tracing::instrument(skip(graphql_schema, custom_scalar_map))]
     pub fn from_document(
         raw_operation: RawOperation,
         graphql_schema: &GraphqlSchema,
@@ -138,6 +139,7 @@ impl Operation {
     }
 
     /// Generate a description for an operation based on documentation in the schema
+    #[tracing::instrument(skip(comments, tree_shaker, graphql_schema))]
     fn tool_description(
         comments: Option<String>,
         tree_shaker: &mut SchemaTreeShaker,
@@ -335,6 +337,7 @@ impl graphql::Executable for Operation {
 }
 
 #[allow(clippy::type_complexity)]
+#[tracing::instrument(skip_all)]
 pub fn operation_defs(
     source_text: &str,
     allow_mutations: bool,
@@ -424,6 +427,7 @@ pub fn operation_name(
         .to_string())
 }
 
+#[tracing::instrument(skip(source_text))]
 pub fn variable_description_overrides(
     source_text: &str,
     operation_definition: &Node<OperationDefinition>,
@@ -455,6 +459,7 @@ pub fn variable_description_overrides(
     argument_overrides_map
 }
 
+#[tracing::instrument(skip(source_text))]
 pub fn find_opening_parens_offset(
     source_text: &str,
     operation_definition: &Node<OperationDefinition>,
@@ -512,6 +517,7 @@ fn tool_character_length(tool: &Tool) -> Result<usize, serde_json::Error> {
         + tool_schema_string.len())
 }
 
+#[tracing::instrument(skip_all)]
 fn get_json_schema(
     operation: &Node<OperationDefinition>,
     schema_argument_descriptions: &HashMap<String, Vec<String>>,

--- a/crates/apollo-mcp-server/src/operations/operation_source.rs
+++ b/crates/apollo-mcp-server/src/operations/operation_source.rs
@@ -22,7 +22,7 @@ use super::RawOperation;
 const OPERATION_DOCUMENT_EXTENSION: &str = "graphql";
 
 /// The source of the operations exposed as MCP tools
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum OperationSource {
     /// GraphQL document files
     Files(Vec<PathBuf>),
@@ -38,6 +38,7 @@ pub enum OperationSource {
 }
 
 impl OperationSource {
+    #[tracing::instrument]
     pub async fn into_stream(self) -> impl Stream<Item = Event> {
         match self {
             OperationSource::Files(paths) => Self::stream_file_changes(paths).boxed(),
@@ -73,6 +74,7 @@ impl OperationSource {
         }
     }
 
+    #[tracing::instrument]
     fn stream_file_changes(paths: Vec<PathBuf>) -> impl Stream<Item = Event> {
         let path_count = paths.len();
         let state = Arc::new(Mutex::new(HashMap::<PathBuf, Vec<RawOperation>>::new()));

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -105,6 +105,7 @@ impl Running {
         Ok(self)
     }
 
+    #[tracing::instrument(skip_all)]
     pub(super) async fn update_operations(
         self,
         operations: Vec<RawOperation>,
@@ -146,6 +147,7 @@ impl Running {
     }
 
     /// Notify any peers that tools have changed. Drops unreachable peers from the list.
+    #[tracing::instrument(skip_all)]
     async fn notify_tool_list_changed(peers: Arc<RwLock<Vec<Peer<RoleServer>>>>) {
         let mut peers = peers.write().await;
         if !peers.is_empty() {

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -193,15 +193,27 @@ impl Starting {
                         //start OpenTelemetry trace on incoming request
                         .layer(OtelAxumLayer::default())
                         // Add tower-http tracing layer for additional HTTP-level tracing
-                        .layer(TraceLayer::new_for_http().make_span_with(
-                            |request: &axum::http::Request<_>| {
-                                tracing::info_span!(
-                                    "mcp_server",
-                                    method = %request.method(),
-                                    uri = %request.uri(),
-                                )
-                            },
-                        ));
+                        .layer(
+                            TraceLayer::new_for_http()
+                                .make_span_with(|request: &axum::http::Request<_>| {
+                                    tracing::info_span!(
+                                        "mcp_server",
+                                        method = %request.method(),
+                                        uri = %request.uri(),
+                                        status_code = tracing::field::Empty,
+                                    )
+                                })
+                                .on_response(
+                                    |response: &axum::http::Response<_>,
+                                     _latency: std::time::Duration,
+                                     span: &tracing::Span| {
+                                        span.record(
+                                            "status_code",
+                                            tracing::field::display(response.status()),
+                                        );
+                                    },
+                                ),
+                        );
 
                 // Add health check endpoint if configured
                 if let Some(health_check) = health_check.filter(|h| h.config().enabled) {

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -200,7 +200,7 @@ impl Starting {
                                         "mcp_server",
                                         method = %request.method(),
                                         uri = %request.uri(),
-                                        status_code = tracing::field::Empty,
+                                        status = tracing::field::Empty,
                                     )
                                 })
                                 .on_response(
@@ -208,7 +208,7 @@ impl Starting {
                                      _latency: std::time::Duration,
                                      span: &tracing::Span| {
                                         span.record(
-                                            "status_code",
+                                            "status",
                                             tracing::field::display(response.status()),
                                         );
                                     },


### PR DESCRIPTION
We were missing traces for the MCP server generating Tools from Operations and performing authorization. This PR also add the HTTP status code to the top level HTTP trace