### PR TITLE
docs: Add always pull latest docker image to sample docker run commands

### DIFF
--- a/docs/source/deploy.mdx
+++ b/docs/source/deploy.mdx
@@ -35,6 +35,7 @@ docker run \
   -p 5000:5000 \
   -v <path to the preceding config>:/config.yaml \
   -v $PWD/graphql/TheSpaceDevs:/data \
+  --pull always \
   ghcr.io/apollographql/apollo-mcp-server:latest /config.yaml
 ```
 

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -113,6 +113,7 @@ You can run the MCP Server using the Rover CLI or Docker.
       -p 5000:5000 \
       -v $PWD/graphql/TheSpaceDevs/config.yaml:/config.yaml \
       -v $PWD/graphql/TheSpaceDevs:/data \
+      --pull always \
       ghcr.io/apollographql/apollo-mcp-server:latest /config.yaml
     ```
 

--- a/docs/source/run.mdx
+++ b/docs/source/run.mdx
@@ -119,6 +119,7 @@ docker run \
   -p 5000:5000 \
   -v <PATH/TO/CONFIG/FILE>:/config.yaml \
   -v <PATH/TO/PROJECT/ROOT>:/data \
+  --pull always \
   ghcr.io/apollographql/apollo-mcp-server:latest /config.yaml
 ```
 


### PR DESCRIPTION
Docker first checks if an image with that tag already exists locally before attempting to pull from a registry. If it finds a local image tagged as latest, it will use that one without checking if there's a newer version available remotely. This can lead to users who come back to the documentation after months to be running an old version of the server and not `latest` as they'd expect

This change add  the `--pull always` flag to ensure the container uses the most recent image from the registry rather than potentially stale local cached versions.