### PR TITLE
chore(release): bumping to version 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-mcp-registry"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "derive_more",
  "educe",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-mcp-server"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "apollo-compiler",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-schema-index"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "apollo-compiler",
  "enumset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2024"
 license-file = "LICENSE"
 repository = "https://github.com/apollographql/apollo-mcp-server"
 rust-version = "1.89.0"
-version = "0.8.0"
+version = "0.9.0"
 
 [workspace.dependencies]
 apollo-compiler = "1.27.0"


### PR DESCRIPTION
In PR #378, the version number somehow got reverted during the rebase. This PR only bumps the version in the main branch. I deleted the tag and release so we can ship v0.9.0 again.