### PR TITLE
fix: remove verbose logging

### DIFF
--- a/.changesets/fix_fix_remove_verbose_logging.md
+++ b/.changesets/fix_fix_remove_verbose_logging.md
@@ -1,0 +1,5 @@
+### fix: remove verbose logging - @swcollard PR #401
+
+The tracing-subscriber crate we are using to create logs does not have a configuration to exclude the span name and attributes from the log line. This led to rather verbose logs on app startup which would dump the full operation object into the logs before the actual log line. 
+
+This change strips the attributes from the top level spans so that we still have telemetry and tracing during this important work the server is doing, but they don't make it into the logs. The relevant details are provided in child spans after the operation has been parsed so we aren't losing any information other than a large json blob in the top level trace of generating Tools from GraphQL Operations.

--- a/crates/apollo-mcp-server/src/operations/operation.rs
+++ b/crates/apollo-mcp-server/src/operations/operation.rs
@@ -48,7 +48,7 @@ impl Operation {
         self.inner
     }
 
-    #[tracing::instrument(skip(graphql_schema, custom_scalar_map))]
+    #[tracing::instrument(skip_all, name = "load_tool")]
     pub fn from_document(
         raw_operation: RawOperation,
         graphql_schema: &GraphqlSchema,

--- a/crates/apollo-schema-index/src/lib.rs
+++ b/crates/apollo-schema-index/src/lib.rs
@@ -119,6 +119,7 @@ pub struct SchemaIndex {
 }
 
 impl SchemaIndex {
+    #[tracing::instrument(skip_all, name = "schema_index")]
     pub fn new(
         schema: &Valid<Schema>,
         root_types: EnumSet<OperationType>,


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AIR-14 -->

The tracing-subscriber crate we are using to create logs does not have a configuration to exclude the span name and attributes from the log line, see implementation here, https://github.com/tokio-rs/tracing/blob/c297a37096ae1562d453624984aa5f924ab490a1/tracing-subscriber/src/fmt/format/mod.rs#L966-L982

This led to rather verbose logs on app startup looking like,

**v0.9.0**
```sh
2025-09-30T19:45:36.762634Z  INFO Apollo MCP Server v0.9.0 // (c) Apollo Graph, Inc. // Licensed under MIT
2025-09-30T19:45:36.782298Z  INFO from_document{raw_operation=RawOperation { source_text: "query GetAlerts($state: String!) {\n  alerts(state: $state) {\n    severity\n    description\n    instruction\n  }\n}\n", persisted_query_id: None, headers: None, variables: None, source_path: Some("./graphql/weather/operations/alerts.graphql") } mutation_mode=None disable_type_description=false disable_schema_description=false}: Tool GetAlerts loaded with a character count of 552. Estimated tokens: 138
2025-09-30T19:45:36.790895Z  INFO from_document{raw_operation=RawOperation { source_text: "query GetForecast($coordinate: InputCoordinate!) {\n  forecast(coordinate: $coordinate) {\n    detailed\n  }\n}\n", persisted_query_id: None, headers: None, variables: None, source_path: Some("./graphql/weather/operations/forecast.graphql") } mutation_mode=None disable_type_description=false disable_schema_description=false}: Tool GetForecast loaded with a character count of 902. Estimated tokens: 225
2025-09-30T19:45:36.799648Z  INFO from_document{raw_operation=RawOperation { source_text: "query GetAllWeatherData($coordinate: InputCoordinate!, $state: String!) {\n  forecast(coordinate: $coordinate) {\n    detailed\n  }\n  alerts(state: $state) {\n    severity\n    description\n    instruction\n  }\n}\n", persisted_query_id: None, headers: None, variables: None, source_path: Some("./graphql/weather/operations/all.graphql") } mutation_mode=None disable_type_description=false disable_schema_description=false}: Tool GetAllWeatherData loaded with a character count of 1388. Estimated tokens: 347
2025-09-30T19:45:36.821965Z  INFO Indexed 4 types in 21.99ms
2025-09-30T19:45:36.822293Z  INFO Starting MCP server in Streamable HTTP mode port=5080 address=0.0.0.0
```

This change strips the attributes from the top level spans so that we still have telemetry and tracing during this important work the server is doing, but they don't make it into the logs.

**This PR**
```sh
2025-09-30T19:39:39.731803Z  INFO Apollo MCP Server v0.9.0 // (c) Apollo Graph, Inc. // Licensed under MIT
2025-09-30T19:39:39.760125Z  INFO load_tool: Tool GetAlerts loaded with a character count of 552. Estimated tokens: 138
2025-09-30T19:39:39.770882Z  INFO load_tool: Tool GetForecast loaded with a character count of 902. Estimated tokens: 225
2025-09-30T19:39:39.780333Z  INFO load_tool: Tool GetAllWeatherData loaded with a character count of 1388. Estimated tokens: 347
2025-09-30T19:39:39.806771Z  INFO schema_index: Indexed 4 types in 26.04ms
2025-09-30T19:39:39.807204Z  INFO Starting MCP server in Streamable HTTP mode port=5080 address=0.0.0.0
```


Previously, before telemetry was added, v0.8.0 just showed,
```sh
2025-09-30T19:48:29.811330Z  INFO Apollo MCP Server v0.8.0 // (c) Apollo Graph, Inc. // Licensed under MIT
2025-09-30T19:48:29.888464Z  INFO Tool ExploreCelestialBodies loaded with a character count of 759. Estimated tokens: 189
2025-09-30T19:48:29.889093Z  INFO Tool GetAstronautDetails loaded with a character count of 898. Estimated tokens: 224
2025-09-30T19:48:29.889701Z  INFO Tool GetAstronautsCurrentlyInSpace loaded with a character count of 501. Estimated tokens: 125
2025-09-30T19:48:29.890525Z  INFO Tool SearchUpcomingLaunches loaded with a character count of 545. Estimated tokens: 136
2025-09-30T19:48:29.915875Z  INFO Indexed 50 types in 24.95ms
2025-09-30T19:48:29.917262Z  INFO Starting MCP server in Streamable HTTP mode port=5000 address=0.0.0.0
```