### PR TITLE
(docs) update quickstart guide

### DIFF
--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -1,296 +1,550 @@
 ---
-title: Get Started
-subtitle: Run Apollo MCP Server for the first time
+title: MCP Server Quickstart
+subtitle: Create and run an MCP server in minutes with Apollo
 ---
 
-<PreviewFeature>
+Apollo MCP Server is a [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes your GraphQL API operations as MCP tools.
 
-This feature is in [preview](/graphos/resources/feature-launch-stages#preview). Your questions and feedback are highly valued—don't hesitate to get in touch with your Apollo contact or post in the [Apollo Community MCP Server Category](https://community.apollographql.com/c/mcp-server/41).
+This getting started guide will walk you through the process of creating, running and configuring an MCP server with Apollo.
 
-</PreviewFeature>
 
-Let's run Apollo MCP Server for the first time! You will:
+[Step 1: Create Your MCP Server](#Step-1-Create-an-MCP-Server)
+[Step 2: Run Your MCP Server](#Step-2-Run-Your-MCP-Server)
+[Step 3: Connect to Claude Desktop (or another MCP client)](#Step-3-Connect-to-Claude-Desktop)
+[Step 4: Working with MCP Tools](#Step-4-Working-with-MCP-Tools)
+[Step 5: Deploy Your MCP Server](#Step-5-Deploy-Your-MCP-Server)
 
-- Understand an MCP Server example
-- Run an MCP Server example
-- Connect an MCP client (Claude Desktop) to the MCP Server
+### Prerequisites
 
-Want a quick overview of what we can do with Apollo MCP Server? Check out [this YouTube video](https://www.youtube.com/watch?v=QTvMYUP4E30) or [blog post](https://www.apollographql.com/blog/getting-started-with-apollo-mcp-server-for-any-graphql-api) about what we'll cover in more detail here.
+- [Rover CLI](https://www.apollographql.com/docs/rover/getting-started) v0.36 or later
+- [Node.js](https://nodejs.org/) v18 or later (for mcp-remote)
+- [Claude Desktop](https://claude.ai/download) or another MCP-compatible client
 
-## What You'll Build
+## Step 1: Create an MCP Server
 
-In this quickstart, you'll create a working AI integration where Claude Desktop can query space-related data through GraphQL. By the end, you'll be able to:
+[Rover](https://www.apollographql.com/docs/rover) is the fastest way to create an Apollo MCP Server is using `rover init --mcp`. This command creates a complete project with:
 
-- Ask Claude natural questions like "Who are the astronauts currently in space?" or "What rocket launches are coming up?"
-- See Claude use MCP tools to fetch real-time data from The Space Devs API
-- Understand how GraphQL operations become AI-accessible tools
+- Pre-configured MCP server setup
+- A federated GraphQL schema
+- Sample GraphQL operations as MCP tools
+- Claude Desktop configuration
 
-Here's what the end result looks like:
+### Authenticate with GraphOS
 
-> **You**: "Tell me about the astronauts currently in space"
-> **Claude**: *[Uses GetAstronautsCurrentlyInSpace tool]* "There are currently 7 astronauts aboard the International Space Station..."
+First, authenticate Rover with your Apollo account:
 
-This example uses a pre-built space API, but the same approach works with any GraphQL API - including your own production services.
+```bash
+rover config auth
+```
 
-<OdysseyCallout>
+This opens your browser to create a personal API key. If you don't have an Apollo account, you'll be prompted to create one.
 
-If you learn best with videos and exercises, this [interactive course](https://www.apollographql.com/tutorials/intro-mcp-graphql) teaches you how to set up Apollo MCP Server and create tools from GraphQL operations.
+### Initialize Your MCP Project
 
-</OdysseyCallout>
+Run the interactive initialization command:
 
-## Prerequisites
+```bash
+rover init --mcp
+```
 
-- Clone the [Apollo MCP Server repo](https://github.com/apollographql/apollo-mcp-server)
-    ```sh showLineNumbers=false
-    git clone https://github.com/apollographql/apollo-mcp-server.git
-    ```
-- Install [Apollo Rover CLI](/rover/getting-started) v0.35 or later
+The CLI wizard will guide you through several prompts:
 
-## Step 1: Understand the Example
+1. Select option
 
-This guide uses an MCP example from the Apollo MCP Server repo. The example uses APIs from [The Space Devs](https://thespacedevs.com/), and it defines a federated graph and the GraphQL operations of the graph to expose as MCP tools.
+- Choose "Create MCP tools from a new Apollo GraphOS project" for a fresh start
+- Or choose "Create MCP tools from an existing Apollo GraphOS project" to add MCP to an existing graph
 
-The example files located in `graphql/TheSpaceDevs/` include:
-- **A federated graph** connecting to The Space Devs API
-  - `supergraph.yaml` is a [supergraph configuration file](/rover/commands/supergraphs#yaml-configuration-file) used by the Rover CLI
-- **4 pre-built operations** that become your AI tools:
-  - `ExploreCelestialBodies` - Search planets, moons, and stars
-  - `GetAstronautDetails` - Get info about specific astronauts
-  - `GetAstronautsCurrentlyInSpace` - See who's in space right now
-  - `SearchUpcomingLaunches` - Find upcoming rocket launches
+2. Choose a template
 
-## Step 2: Run the MCP Server
+- Apollo graph with Apollo connectors - Connect to REST services _(recommended for most use cases)_
+- Apollo graph with GraphQL connectors - Connect to existing GraphQL endpoints
 
-You can run the MCP Server using the Rover CLI or Docker. 
+3. Name your project
 
-> **Note**: We recommend using Docker if you typically use it in your developer workflow. Otherwise, use Rover.
+- Enter a descriptive name (e.g., "my-mcp-server", "spacedevs-mcp")
 
-### Run with Rover
+4. Review and confirm
 
-1. From the root directory of your local repo, run `rover dev` to start a local graph with an MCP Server:
-    ```sh showLineNumbers=false
-    rover dev --supergraph-config ./graphql/TheSpaceDevs/supergraph.yaml \
-    --mcp ./graphql/TheSpaceDevs/config.yaml
-    ```
+The wizard shows all files that will be created:
 
-    This command:
-    - Starts a local graph using the supergraph configuration
-    - Starts an MCP Server with the `--mcp` flag
-    - Provides a configuration file with MCP Server options
+```bash
+MCP Server: Config, sample tools and tests
+- claude_desktop_config.json
+- mcp.Dockerfile (optional Docker container)
+- mcpconfig/mcp.local.yaml
+- mcpconfig/mcp.staging.yaml
 
-    See the [config file reference](/apollo-mcp-server/config-file) for a list of available configuration options. 
+Apollo GraphOS: Graph credentials and project files
+- apollo.config.yaml
+- schema.graphql
+- supergraph.yaml
+- .env
 
-### Run with Docker
+IDE: Project settings
+- .gitignore
+- .idea/
+- .vscode/
+- tasks.json
 
-1. Modify the MCP server configuration in `graphql/TheSpaceDevs/config.yaml`. Update the paths to point to the `/data` directory, as the Docker container expects:
-    ```yaml title="graphql/TheSpaceDevs/config.yaml" {7, 10}
-    endpoint: https://thespacedevs-production.up.railway.app/
-    transport:
-      type: streamable_http
-    operations:
-      source: local
-      paths:
-        - /data/operations
-    schema:
-      source: local
-      path: /data/api.graphql
-    overrides:
-      mutation_mode: all
-    introspection:
-      execute:
-        enabled: true
-      introspect:
-        enabled: true
-      search:
-        enabled: true
-    ```
+Guides and references
+- GETTING_STARTED.md
+- MCP_README.md
+- AGENTS.md
+```
 
-1. In a new terminal, from the root directory of your local repo, run this Docker command to start the MCP Server:
-    ```sh showLineNumbers=false
-    docker run \
-      -it --rm \
-      --name apollo-mcp-server \
-      -p 5000:5000 \
-      -v $PWD/graphql/TheSpaceDevs/config.yaml:/config.yaml \
-      -v $PWD/graphql/TheSpaceDevs:/data \
-      --pull always \
-      ghcr.io/apollographql/apollo-mcp-server:latest /config.yaml
+Type `Y` to confirm and create your project - your MCP server will be initialized and ready for next steps.
+
+
+## Step 2: Run Your MCP Server
+
+Now that your project is created, you can start your MCP server locally with `rover dev`.
+
+### Load Environment Variables and Start MCP Server
+
+<Tabs>
+
+    <Tab label="Linux / MacOS">
+    
+    ```terminal showLineNumbers=false
+    source .env && rover dev --supergraph-config supergraph.yaml --mcp mcpconfig/mcp.local.yaml
     ```
 
-    This command:
-    - Starts an MCP Server in a Docker container
-    - Maps configuration files into the proper place for the Apollo MCP Server container
-    - Forwards port 5000 for accessing the MCP Server
+    <Tab label="Windows">
 
-## Step 3: Verify the MCP Server with MCP Inspector
+    ##### Powershell
 
-1. Start MCP Inspector to verify the server is running:
-
-    ```sh
-    npx @modelcontextprotocol/inspector
-    ```
-
-1. Open a browser and go to [`http://127.0.0.1:6274`](http://127.0.0.1:6274)
-
-1. In Inspector:
-    - Select `Streamable HTTP` as the Transport Type
-    - Enter `http://127.0.0.1:5000/mcp` as the URL
-    - Click **Connect**, then **List Tools**
-
-    You should see the tools from your server listed.
-
-## Step 4: Connect Claude Desktop
-
-We're using [Claude](https://claude.ai/download) as our AI Assistant (acting as our MCP Client).
-
-First, locate your Claude configuration file:
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-- **Linux**: `~/.config/Claude/claude_desktop_config.json`
-
-Then add the following configuration
-
-1. Open Claude's JSON config file and add this configuration:
-
-    ```json
-    {
-      "mcpServers": {
-        "thespacedevs": {
-            "command": "npx",
-            "args": [
-                "mcp-remote",
-                "http://127.0.0.1:5000/mcp"
-            ]
+    ```terminal showLineNumbers=false
+        Get-Content .env | ForEach-Object {
+            $name, $value = $_.split('=',2);
+            [System.Environment]::SetEnvironmentVariable($name, $value)
         }
-      }
-    }
+
+        rover dev --supergraph-config supergraph.yaml --mcp mcpconfig/mcp.local.yaml
     ```
+</Tabs>
 
-<Note>
+You should see:
 
-You need Node v18 or later installed for `mcp-remote` to work. If you have an older version of Node, uninstall it and install the latest version from [nodejs.org](https://nodejs.org/).
+```
+✓ MCP server running at http://localhost:5050
+✓ GraphQL API running at http://localhost:4000
+```
 
-</Note>
+Alternatively, you can also run the Apollo MCP Server via Docker, Apollo Runtime Container or using the MCP server binary - see the full guide on [Running the Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server/run).
 
-2. Restart Claude.
 
-## Step 5: Test Your Setup with Claude
+### Verify with MCP Inspector
 
-Let's verify everything is working:
+Before connecting Claude, verify your MCP server is working:
 
-1. In Claude Desktop, type: "What MCP tools do you have available?"
-   - Claude should list tools like `ExploreCelestialBodies`, `GetAstronautDetails`, etc.
+```terminal
+npx @modelcontextprotocol/inspector
+```
 
-2. Try a real query: "Who are the astronauts currently in space?"
-   - Claude should use the `GetAstronautsCurrentlyInSpace` tool and return current data
+1. Open your browser to `http://127.0.0.1:6274`
+2. Select **Streamable HTTP** as the Transport Type
+3. Enter `http://127.0.0.1:5050/mcp` as the URL
+4. Click **Connect**, then **List Tools**
 
-3. If Claude can't see the tools:
-   - Ensure you restarted Claude Desktop after editing the config
-   - Check that your MCP server is still running
-   - Verify the port numbers match between your server and Claude config
+You should see your GraphQL operations listed as MCP tools.
+
+## Step 3: Connect to Claude Desktop
+
+Apollo MCP Server works with **any** MCP-compatible client - add the generated initial`config.json` to the AI application of your choosing:
+
+<details>
+<summary>Claude Desktop</summary>
+
+```
+# Copy the configuration for Claude Desktop
+# macOS:
+cp claude_desktop_config.json ~/Library/Application\ Support/Claude/claude_desktop_config.json
+
+# Windows:
+copy claude_desktop_config.json "%APPDATA%\Claude\claude_desktop_config.json"
+
+# Linux:
+cp claude_desktop_config.json ~/.config/Claude/claude_desktop_config.json
+
+# Restart Claude Desktop
+```
+
+</details>
+<details>
+<summary>Claude Code</summary>
+
+Install using the CLI:
+
+```bash
+claude mcp add apollo-mcp npx mcp-remote http://127.0.0.1:5050/mcp
+```
+</details>
+<details>
+<summary>Cursor</summary>
+
+Click the button to quick install:
+
+[![Install Apollo MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](cursor://anysphere.cursor-deeplink/mcp/install?name=apollo-mcp&config=eyJjb21tYW5kIjoibnB4IG1jcC1yZW1vdGUgaHR0cDovLzEyNy4wLjAuMTo1MDUwL21jcCJ9)
+
+Or install manually:
+
+1. Go to **Cursor Settings** → **MCP** → **Add new MCP Server**
+2. Name: `Apollo MCP` (choose a title)
+3. Command: `npx`
+4. Arguments: `["mcp-remote", "http://127.0.0.1:5050/mcp"]`
+</details>
+
+<details>
+<summary>Goose</summary>
+Add Apollo MCP Server to your Goose configuration. Edit your `~/.config/goose/profiles.yaml`:
+
+
+```yaml
+default:
+  provider: openai
+  processor: gpt-4
+  accelerator: gpt-4o-mini
+  moderator: passive
+  toolkits:
+    - name: developer
+    - name: mcp
+      requires:
+        apollo-mcp:
+          command: npx
+          args:
+            - mcp-remote
+            - http://127.0.0.1:5050/mcp
+```
+
+Or use the Goose CLI to add the MCP server:
+
+```bash
+goose mcp add apollo-mcp npx mcp-remote http://127.0.0.1:5050/mcp
+```
+</details>
+<details>
+<summary>Cline (VS Code Extension)</summary>
+
+1. Go to **Advanced settings** → **Extensions** → **Add custom extension**
+2. Name: `Apollo MCP`
+3. Type: **STDIO**
+4. Command: `npx mcp-remote http://127.0.0.1:5050/mcp`
+</details>
+<details>
+<summary>OpenCode</summary>
+
+Edit `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "apollo-mcp": {
+      "type": "local", 
+      "command": [
+        "npx",
+        "mcp-remote",
+        "http://127.0.0.1:5050/mcp"
+      ],
+      "enabled": true
+    }
+  }
+}
+```
+</details>
+<details>
+<summary>Windsurf</summary>
+
+Go to **Windsurf Settings → MCP → Add new MCP Server**
+Name: `Apollo MCP`
+Command: `npx`
+Arguments: `["mcp-remote", "http://127.0.0.1:5050/mcp"]`
+
+Alternatively, edit your Windsurf configuration file directly:
+
+```json
+{
+  "mcpServers": {
+    "apollo-mcp": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "http://127.0.0.1:5050/mcp"
+      ]
+    }
+  }
+}
+```
+</details>
+
+
+
+## Configuration Options
+
+When using Apollo MCP Server, you can customize the server configuration through your `config.yaml` file - see the [YAML Config Reference page](./config-file) for a list of options.
+
+Examples:
+
+<details>
+<summary>Basic Configuration</summary>
+
+```yaml
+endpoint: https://your-graphql-endpoint.com/graphql
+operations:
+  source: local
+  paths:
+    - ./operations
+schema:
+  source: local
+  path: ./schema.graphql
+transport:
+  type: http
+  port: 5050
+```
+</details>
+<details>
+<summary>Advanced Configuration</summary>
+
+```yaml
+endpoint: https://your-graphql-endpoint.com/graphql
+operations:
+  source: local
+  paths:
+    - ./operations
+schema:
+  source: local
+  path: ./schema.graphql
+transport:
+  type: http
+  port: 5050
+  host: localhost
+headers:
+  Authorization: Bearer ${GRAPHQL_TOKEN}
+  X-API-Key: ${API_KEY}
+timeout: 30000
+retry:
+  attempts: 3
+  delay: 1000
+```
+
+</details>
+
+<details>
+<summary>Environment Variables</summary>
+
+You can use environment variables in your configuration:
+
+```yaml
+endpoint: ${GRAPHQL_ENDPOINT}
+headers:
+  Authorization: Bearer ${GRAPHQL_TOKEN}
+```
+
+Set these in your environment:
+```bash
+export GRAPHQL_ENDPOINT="https://your-api.com/graphql"
+export GRAPHQL_TOKEN="your-token-here"
+```
+</details>
+
+## Verification
+
+After adding Apollo MCP Server to your client:
+
+1. **Restart your MCP client** (Claude Desktop, Cursor, etc.)
+2. **Test the connection** by asking: "What MCP tools do you have available?"
+3. **Verify GraphQL operations** are listed as available tools
+4. **Test a query** using one of your configured operations
 
 ## Troubleshooting
 
-### Common Issues
+<details>
+<summary>Common Issues</summary>
 
-#### MCP Server Won't Start
-- **Error**: "Port 5000 is already in use"
-  - Solution: Kill any existing processes using port 5000 or specify a different port with the `transport.port` option or `APOLLO_MCP_TRANSPORT__PORT` env variable
-- **Error**: "Failed to load supergraph configuration"
-  - Solution: Verify you're running the command from the repo root directory
-  - Solution: Check that the path to `supergraph.yaml` is correct
+**Client doesn't see tools:**
+- Ensure you restarted your MCP client after configuration
+- Verify the Apollo MCP Server is running (`rover dev` command)
+- Check port numbers match between server and client config
 
-#### MCP Inspector Connection Issues
-- **Error**: "Failed to connect to server"
-  - Solution: Ensure the MCP server is running (check terminal output)
-  - Solution: Verify you're using the correct URL (`http://127.0.0.1:5000/mcp`)
-  - Solution: Check if your firewall is blocking the connection
+**Connection refused errors:**
+- Confirm the server is running on the correct port (default: 5050)
+- Verify firewall settings allow connections to localhost:5050
+- For remote connections, ensure the host is set to `0.0.0.0` in your config
 
-#### Claude Desktop Issues
-- **Problem**: Claude doesn't recognize the tools
-  - Solution: Verify the config file path is correct for your OS
-  - Solution: Ensure the JSON is properly formatted (no trailing commas)
-  - Solution: Try restarting Claude Desktop completely
-- **Problem**: "Connection refused" errors
-  - Solution: Check if the MCP server is still running
-  - Solution: Verify the port numbers match in both the server and Claude config
-- **Problem**: "MCP thespacedevs: Server disconnected" errors
-  - Solution: Uninstall older versions of Node. `mcp-remote` only works with Node v18 or later.
-  - Solution: Restart Claude Desktop
+**GraphQL operation errors:**
+- Verify your operations files exist in the specified paths
+- Check that operation names match your GraphQL schema
+- Ensure your GraphQL endpoint is accessible
 
-#### GraphQL Operation Issues
-- **Error**: "Operation not found"
-  - Solution: Verify the operation files exist in the specified path
-  - Solution: Check that the operation names match exactly
-- **Error**: "Schema validation failed"
-  - Solution: Ensure your GraphQL operations match the schema
-  - Solution: Check for syntax errors in your operation files
+**Authentication issues:**
+- Verify environment variables are properly set
+- Check that your GraphQL endpoint accepts the provided headers
+- Test your GraphQL endpoint directly with tools like GraphiQL
+</details>
+<details>
+<summary>Getting Help</summary>
+
+- Check [Apollo MCP Server GitHub issues](https://github.com/apollographql/apollo-mcp-server/issues)
+- Join the [Apollo Community MCP Server Category](https://community.apollographql.com/c/mcp-server/41)
+- Contact your Apollo representative for direct support
+
+</details>
+
+## Step 4: Working with MCP Tools
+
+Now that your MCP server is connected, learn how to customize and create tools.
+
+### Understanding Tools
+
+MCP tools are GraphQL operations that Claude can execute. Each operation in your `operations/` directory becomes a tool with:
+
+- **Tool name**: Derived from the operation name
+- **Description**: From GraphQL comments or operation descriptions
+- **Parameters**: Mapped from GraphQL variables
+- **Response**: The GraphQL response data
+
+### Defining Custom Tools
+
+Create new tools by adding GraphQL operation files to your `operations/` directory:
+
+```graphql
+# operations/GetProducts.graphql
+
+# Retrieves product information by ID
+query GetProducts($productId: ID!) {
+  product(id: $productId) {
+    id
+    name
+    price
+    description
+  }
+}
+```
+
+Apollo MCP Server automatically detects new `.graphql` files and exposes them as tools. No server restart needed!
+
+**Learn more:** [Defining MCP Tools](https://www.apollographql.com/docs/apollo-mcp-server/define-tools)
+
+### Testing Operations in GraphOS Studio
+
+The `rover dev` command includes a built-in GraphQL explorer:
+
+1. Open http://localhost:4000 in your browser
+2. You'll see GraphOS Studio's Sandbox Explorer
+3. Test your operations directly:
+   - Browse your schema
+   - Run queries and mutations
+   - Experiment with variables
+   - View responses
+
+This is invaluable for:
+- Verifying operations before exposing them as MCP tools
+- Understanding your schema structure
+- Debugging query issues
+- Exploring available data
+
+### Testing with MCP Inspector
+
+Before connecting to Claude, test tools with MCP Inspector:
+
+```bash
+npx @modelcontextprotocol/inspector
+```
+
+Connect to `http://127.0.0.1:5050/mcp` and:
+- List available tools
+- Execute tools with test inputs
+- Inspect tool responses
+- Debug parameter mapping
+
+## Step 5: Deploy Your MCP Server
+
+Once you're ready to deploy, Apollo MCP Server can run in any container environment.
+
+### Using the All-in-One Container
+
+Your project includes a pre-configured `mcp.Dockerfile` for easy deployment. This container includes:
+
+- Apollo Router for serving your GraphQL API
+- Apollo MCP Server for MCP protocol support
+- All necessary dependencies
+
+**Build the container:**
+```bash
+docker build -f mcp.Dockerfile -t my-mcp-server .
+```
+
+**Run locally:**
+```bash
+docker run -p 4000:4000 -p 5050:5050 \
+  -e APOLLO_KEY=$APOLLO_KEY \
+  -e APOLLO_GRAPH_REF=$APOLLO_GRAPH_REF \
+  my-mcp-server
+```
+
+**Deploy to your platform:**
+
+The container can be deployed to any platform supporting Docker:
+- AWS ECS/Fargate
+- Google Cloud Run
+- Azure Container Instances
+- Kubernetes
+- Fly.io
+- Railway
+- Render
+
+### Update Client Configuration
+
+After deploying, update your MCP client configuration to use the deployed URL:
+
+```json
+{
+  "mcpServers": {
+    "my-api": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://your-deployed-server.com/mcp"
+      ]
+    }
+  }
+}
+```
+
+### Environment Variables
+
+Ensure these variables are set in your deployment environment:
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `APOLLO_KEY` | Your graph's API key | Yes |
+| `APOLLO_GRAPH_REF` | Your graph reference | Yes |
+| `APOLLO_MCP_TRANSPORT__PORT` | MCP server port (default: 5050) | No |
+| `APOLLO_ROUTER_PORT` | Router port (default: 4000) | No |
+
+For more deployment options, see the [Deploy the MCP Server](.deploy) page.
+
+## Additional Resources
+
+### Odyssey Tutorials
+
+- [Odyssey Tutorial: Getting started with MCP and GraphQL](https://www.apollographql.com/tutorials/intro-mcp-graphql)
+- [Odyssey Tutorial: Agentic GraphQL: MCP for the Enterprise](https://www.apollographql.com/tutorials/enterprise-mcp-graphql)
+
+### Blog Posts
+
+- [Getting Started with Apollo MCP Server](https://www.apollographql.com/blog/getting-started-with-apollo-mcp-server-for-any-graphql-api)
+- [Building AI Tools with GraphQL](https://www.apollographql.com/blog)
+
+### Video Tutorials
+
+- [Apollo MCP Server Quickstart (YouTube)](https://www.youtube.com/watch?v=QTvMYUP4E30)
+- [Interactive Course](https://www.apollographql.com/tutorials/intro-mcp-graphql)
 
 ### Getting Help
 
 If you're still having issues:
-1. Check the [Apollo MCP Server GitHub issues](https://github.com/apollographql/apollo-mcp-server/issues)
-2. Join the [Apollo Community MCP Server Category](https://community.apollographql.com/c/mcp-server/41)
-3. Contact your Apollo representative for direct support
 
-## Next Steps
-
-Learn how to define tools from:
-- [Operation files](/apollo-mcp-server/define-tools#from-operation-files)
-- [Persisted query manifests](/apollo-mcp-server/define-tools#from-persisted-query-manifests)
-- [Operation collections](/apollo-mcp-server/define-tools#from-operation-collection)
-- [Schema introspection](/apollo-mcp-server/define-tools#introspection-tools)
-
-When you are ready, [deploy the MCP server](https://www.apollographql.com/docs/apollo-mcp-server/deploy).
-
-### Additional Resources
-
-Check out these blog posts to learn more about Apollo MCP Server:
-- [Getting started with Apollo MCP Server](https://www.apollographql.com/blog/getting-started-with-apollo-mcp-server-for-any-graphql-api)
-- [The Future of MCP is GraphQL](https://www.apollographql.com/blog/the-future-of-mcp-is-graphql)
-
-### Advanced Options
-
-<details>
-<summary>Alternative ways to run the MCP Server</summary>
-
-#### Using STDIO Transport
-
-You can run the MCP Server using STDIO transport instead of Streamable HTTP. This is useful for certain environments or when you need more direct control over the server process.
-
-1. Download the binary of the latest version of Apollo MCP Server
-2. Use MCP Inspector to run the server:
-
-    ```yaml title="Config for stdio transport"
-    endpoint: https://thespacedevs-production.up.railway.app/
-    operations:
-      source: local
-      paths:
-      - <absolute-path-to-MCP-example-dir>/operations
-    schema:
-      source: local
-      path: <absolute-path-to-MCP-example-dir>/api.graphql
-    transport:
-      type: stdio
-    ```
-
-    ```sh
-    npx @modelcontextprotocol/inspector apollo-mcp-server <path to the preceding config>
-    ```
-
-3. Configure Claude Desktop to use STDIO:
-
-    ```json
-    {
-      "mcpServers": {
-        "thespacedevs": {
-          "command": "<absolute-path-to-MCP-server-binary>",
-          "args": [
-            "<path to the preceding config>"
-          ]
-        }
-      }
-    }
-    ```
-
-</details>
+- Check [Apollo MCP Server GitHub issues](https://github.com/apollographql/apollo-mcp-server/issues)
+- Join the [Apollo Community MCP Server Category](https://community.apollographql.com/c/mcp-server/41)
+- Contact your Apollo representative for direct support

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -1,18 +1,17 @@
 ---
-title: MCP Server Quickstart
+title: Apollo MCP Server Quickstart
 subtitle: Create and run an MCP server in minutes with Apollo
 ---
 
 Apollo MCP Server is a [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes your GraphQL API operations as MCP tools.
 
-This getting started guide will walk you through the process of creating, running and configuring an MCP server with Apollo.
+This guide walks you through the process of creating, running and configuring an MCP server with Apollo.
 
-
-[Step 1: Create Your MCP Server](#Step-1-Create-an-MCP-Server)
-[Step 2: Run Your MCP Server](#Step-2-Run-Your-MCP-Server)
-[Step 3: Connect to Claude Desktop (or another MCP client)](#Step-3-Connect-to-Claude-Desktop)
-[Step 4: Working with MCP Tools](#Step-4-Working-with-MCP-Tools)
-[Step 5: Deploy Your MCP Server](#Step-5-Deploy-Your-MCP-Server)
+- [Step 1: Create Your MCP Server](#Step-1-Create-an-MCP-Server)
+- [Step 2: Run Your MCP Server](#Step-2-Run-Your-MCP-Server)
+- [Step 3: Connect to Claude Desktop (or another MCP client)](#Step-3-Connect-to-Claude-Desktop)
+- [Step 4: Working with MCP Tools](#Step-4-Working-with-MCP-Tools)
+- [Step 5: Deploy Your MCP Server](#Step-5-Deploy-Your-MCP-Server)
 
 ### Prerequisites
 
@@ -91,6 +90,7 @@ Now that your project is created, you can start your MCP server locally with `ro
     source .env && rover dev --supergraph-config supergraph.yaml --mcp mcpconfig/mcp.local.yaml
     ```
 
+    </Tab>
     <Tab label="Windows">
 
     ##### Powershell

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -20,7 +20,7 @@ This getting started guide will walk you through the process of creating, runnin
 - [Node.js](https://nodejs.org/) v18 or later (for mcp-remote)
 - [Claude Desktop](https://claude.ai/download) or another MCP-compatible client
 
-## Step 1: Create an MCP Server
+## Step 1: Create an MCP server
 
 [Rover](https://www.apollographql.com/docs/rover) is the fastest way to create an Apollo MCP Server is using `rover init --mcp`. This command creates a complete project with:
 
@@ -39,7 +39,7 @@ rover config auth
 
 This opens your browser to create a personal API key. If you don't have an Apollo account, you'll be prompted to create one.
 
-### Initialize Your MCP Project
+### Initialize your MCP project
 
 Run the interactive initialization command:
 
@@ -65,34 +65,16 @@ The CLI wizard will guide you through several prompts:
 
 4. Review and confirm
 
-The wizard shows all files that will be created:
+The wizard shows all files that will be created, including:
 
 ```bash
-MCP Server: Config, sample tools and tests
-- claude_desktop_config.json
-- mcp.Dockerfile (optional Docker container)
-- mcpconfig/mcp.local.yaml
-- mcpconfig/mcp.staging.yaml
-
-Apollo GraphOS: Graph credentials and project files
-- apollo.config.yaml
-- schema.graphql
-- supergraph.yaml
-- .env
-
-IDE: Project settings
-- .gitignore
-- .idea/
-- .vscode/
-- tasks.json
-
-Guides and references
-- GETTING_STARTED.md
-- MCP_README.md
-- AGENTS.md
+- MCP server configuration files
+- GraphQL schema and operations
+- Client configuration (Claude Desktop, etc.)
+- Docker setup for (optional) deployment 
 ```
 
-Type `Y` to confirm and create your project - your MCP server will be initialized and ready for next steps.
+Type `Y` to confirm and create your project. Your MCP server will be initialized and ready for next steps.
 
 
 ## Step 2: Run Your MCP Server
@@ -126,7 +108,7 @@ Now that your project is created, you can start your MCP server locally with `ro
 You should see:
 
 ```
-✓ MCP server running at http://localhost:5050
+✓ MCP server running at http://localhost:5000
 ✓ GraphQL API running at http://localhost:4000
 ```
 
@@ -138,19 +120,17 @@ Alternatively, you can also run the Apollo MCP Server via Docker, Apollo Runtime
 Before connecting Claude, verify your MCP server is working:
 
 ```terminal
-npx @modelcontextprotocol/inspector
+npx @modelcontextprotocol/inspector http://127.0.0.1:5000/mcp --transport http
 ```
 
 1. Open your browser to `http://127.0.0.1:6274`
-2. Select **Streamable HTTP** as the Transport Type
-3. Enter `http://127.0.0.1:5050/mcp` as the URL
-4. Click **Connect**, then **List Tools**
+2. Click **Connect**, then **List Tools**
 
 You should see your GraphQL operations listed as MCP tools.
 
 ## Step 3: Connect to Claude Desktop
 
-Apollo MCP Server works with **any** MCP-compatible client - add the generated initial`config.json` to the AI application of your choosing:
+Apollo MCP Server works with **any** MCP-compatible client - add the generated initial `config.json` to the AI application of your choosing:
 
 <details>
 <summary>Claude Desktop</summary>
@@ -176,7 +156,7 @@ cp claude_desktop_config.json ~/.config/Claude/claude_desktop_config.json
 Install using the CLI:
 
 ```bash
-claude mcp add apollo-mcp npx mcp-remote http://127.0.0.1:5050/mcp
+claude mcp add apollo-mcp npx mcp-remote http://127.0.0.1:5000/mcp
 ```
 </details>
 <details>
@@ -191,7 +171,7 @@ Or install manually:
 1. Go to **Cursor Settings** → **MCP** → **Add new MCP Server**
 2. Name: `Apollo MCP` (choose a title)
 3. Command: `npx`
-4. Arguments: `["mcp-remote", "http://127.0.0.1:5050/mcp"]`
+4. Arguments: `["mcp-remote", "http://127.0.0.1:5000/mcp"]`
 </details>
 
 <details>
@@ -213,13 +193,13 @@ default:
           command: npx
           args:
             - mcp-remote
-            - http://127.0.0.1:5050/mcp
+            - http://127.0.0.1:5000/mcp
 ```
 
 Or use the Goose CLI to add the MCP server:
 
 ```bash
-goose mcp add apollo-mcp npx mcp-remote http://127.0.0.1:5050/mcp
+goose mcp add apollo-mcp npx mcp-remote http://127.0.0.1:5000/mcp
 ```
 </details>
 <details>
@@ -228,7 +208,7 @@ goose mcp add apollo-mcp npx mcp-remote http://127.0.0.1:5050/mcp
 1. Go to **Advanced settings** → **Extensions** → **Add custom extension**
 2. Name: `Apollo MCP`
 3. Type: **STDIO**
-4. Command: `npx mcp-remote http://127.0.0.1:5050/mcp`
+4. Command: `npx mcp-remote http://127.0.0.1:5000/mcp`
 </details>
 <details>
 <summary>OpenCode</summary>
@@ -244,7 +224,7 @@ Edit `~/.config/opencode/opencode.json`:
       "command": [
         "npx",
         "mcp-remote",
-        "http://127.0.0.1:5050/mcp"
+        "http://127.0.0.1:5000/mcp"
       ],
       "enabled": true
     }
@@ -258,7 +238,7 @@ Edit `~/.config/opencode/opencode.json`:
 Go to **Windsurf Settings → MCP → Add new MCP Server**
 Name: `Apollo MCP`
 Command: `npx`
-Arguments: `["mcp-remote", "http://127.0.0.1:5050/mcp"]`
+Arguments: `["mcp-remote", "http://127.0.0.1:5000/mcp"]`
 
 Alternatively, edit your Windsurf configuration file directly:
 
@@ -269,7 +249,7 @@ Alternatively, edit your Windsurf configuration file directly:
       "command": "npx",
       "args": [
         "mcp-remote",
-        "http://127.0.0.1:5050/mcp"
+        "http://127.0.0.1:5000/mcp"
       ]
     }
   }
@@ -299,7 +279,7 @@ schema:
   path: ./schema.graphql
 transport:
   type: http
-  port: 5050
+  port: 5000
 ```
 </details>
 <details>
@@ -316,7 +296,7 @@ schema:
   path: ./schema.graphql
 transport:
   type: http
-  port: 5050
+  port: 5000
   host: localhost
 headers:
   Authorization: Bearer ${GRAPHQL_TOKEN}
@@ -367,8 +347,8 @@ After adding Apollo MCP Server to your client:
 - Check port numbers match between server and client config
 
 **Connection refused errors:**
-- Confirm the server is running on the correct port (default: 5050)
-- Verify firewall settings allow connections to localhost:5050
+- Confirm the server is running on the correct port (default: 5000)
+- Verify firewall settings allow connections to localhost:5000
 - For remote connections, ensure the host is set to `0.0.0.0` in your config
 
 **GraphQL operation errors:**
@@ -379,15 +359,7 @@ After adding Apollo MCP Server to your client:
 **Authentication issues:**
 - Verify environment variables are properly set
 - Check that your GraphQL endpoint accepts the provided headers
-- Test your GraphQL endpoint directly with tools like GraphiQL
-</details>
-<details>
-<summary>Getting Help</summary>
-
-- Check [Apollo MCP Server GitHub issues](https://github.com/apollographql/apollo-mcp-server/issues)
-- Join the [Apollo Community MCP Server Category](https://community.apollographql.com/c/mcp-server/41)
-- Contact your Apollo representative for direct support
-
+- Test your GraphQL endpoint directly using GraphOS Sandbox at http://localhost:4000
 </details>
 
 ## Step 4: Working with MCP Tools
@@ -427,11 +399,10 @@ Apollo MCP Server automatically detects new `.graphql` files and exposes them as
 
 ### Testing Operations in GraphOS Studio
 
-The `rover dev` command includes a built-in GraphQL explorer:
+The `rover dev` command command includes Sandbox:
 
 1. Open http://localhost:4000 in your browser
-2. You'll see GraphOS Studio's Sandbox Explorer
-3. Test your operations directly:
+2. Test your operations directly:
    - Browse your schema
    - Run queries and mutations
    - Experiment with variables
@@ -443,25 +414,11 @@ This is invaluable for:
 - Debugging query issues
 - Exploring available data
 
-### Testing with MCP Inspector
-
-Before connecting to Claude, test tools with MCP Inspector:
-
-```bash
-npx @modelcontextprotocol/inspector
-```
-
-Connect to `http://127.0.0.1:5050/mcp` and:
-- List available tools
-- Execute tools with test inputs
-- Inspect tool responses
-- Debug parameter mapping
-
 ## Step 5: Deploy Your MCP Server
 
 Once you're ready to deploy, Apollo MCP Server can run in any container environment.
 
-### Using the All-in-One Container
+### Using the Apollo Runtime Container
 
 Your project includes a pre-configured `mcp.Dockerfile` for easy deployment. This container includes:
 
@@ -476,7 +433,7 @@ docker build -f mcp.Dockerfile -t my-mcp-server .
 
 **Run locally:**
 ```bash
-docker run -p 4000:4000 -p 5050:5050 \
+docker run -p 4000:4000 -p 5050:5000 \
   -e APOLLO_KEY=$APOLLO_KEY \
   -e APOLLO_GRAPH_REF=$APOLLO_GRAPH_REF \
   my-mcp-server
@@ -519,7 +476,7 @@ Ensure these variables are set in your deployment environment:
 |----------|-------------|----------|
 | `APOLLO_KEY` | Your graph's API key | Yes |
 | `APOLLO_GRAPH_REF` | Your graph reference | Yes |
-| `APOLLO_MCP_TRANSPORT__PORT` | MCP server port (default: 5050) | No |
+| `APOLLO_MCP_TRANSPORT__PORT` | MCP server port (default: 5000) | No |
 | `APOLLO_ROUTER_PORT` | Router port (default: 4000) | No |
 
 For more deployment options, see the [Deploy the MCP Server](.deploy) page.

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -359,7 +359,7 @@ After adding Apollo MCP Server to your client:
 **Authentication issues:**
 - Verify environment variables are properly set
 - Check that your GraphQL endpoint accepts the provided headers
-- Test your GraphQL endpoint directly using GraphOS Sandbox at http://localhost:4000
+- When using `rover dev` you can test your GraphQL endpoint using GraphOS Sandbox at [http://localhost:4000](http://localhost:4000)
 </details>
 
 ## Step 4: Working with MCP Tools
@@ -436,6 +436,7 @@ docker build -f mcp.Dockerfile -t my-mcp-server .
 docker run -p 4000:4000 -p 5050:5000 \
   -e APOLLO_KEY=$APOLLO_KEY \
   -e APOLLO_GRAPH_REF=$APOLLO_GRAPH_REF \
+  -e MCP_ENABLE=1 \
   my-mcp-server
 ```
 

--- a/docs/source/run.mdx
+++ b/docs/source/run.mdx
@@ -22,7 +22,7 @@ You can use the [`rover dev`](/rover/commands/dev) command of Rover CLI `v0.35` 
 rover dev --mcp <PATH/TO/CONFIG> [...other rover dev flags]
 ```
 
-For more information, see the [Rover CLI documentation](/rover/dev).
+For more information, see the [Rover CLI documentation](/rover).
 
 ## Standalone MCP server binary
 

--- a/docs/source/run.mdx
+++ b/docs/source/run.mdx
@@ -4,13 +4,25 @@ title: Running the Apollo MCP Server
 
 There are multiple ways to run the Apollo MCP server.
 
-If you have an existing GraphQL API deployed, use the standalone MCP server binary to get started quickly.
+- If you have an existing GraphQL API deployed, use the standalone MCP server binary to get started quickly.
 
-If you use Docker in your developer workflow, use the Apollo MCP Server Docker image.
+- If you use Docker in your developer workflow, use the Apollo MCP Server Docker image.
 
-If you are running your GraphQL API locally with Rover, you can use the Rover CLI's `rover dev` command to run the MCP server alongside your local graph.
+- If you are running your GraphQL API locally with Rover, you can use the Rover CLI's `rover dev` command to run the MCP server alongside your local graph.
 
-If you are using the Apollo Runtime Container, you can use the container to run both the MCP server and the Apollo Router in a single container.
+- If you are using the Apollo Runtime Container, you can use the container to run both the MCP server and the Apollo Router in a single container.
+
+## With the Rover CLI
+
+The Rover CLI is a tool for working with GraphQL APIs locally.
+
+You can use the [`rover dev`](/rover/commands/dev) command of Rover CLI `v0.35` or later to run an Apollo MCP Server instance alongside your local graph. Use the `--mcp` flag to start an MCP server and provide an optional configuration file.
+
+```sh
+rover dev --mcp <PATH/TO/CONFIG> [...other rover dev flags]
+```
+
+For more information, see the [Rover CLI documentation](/rover/dev).
 
 ## Standalone MCP server binary
 
@@ -128,18 +140,6 @@ This command:
 - Starts an MCP Server in a Docker container
 - Maps configuration files into the proper place for the Apollo MCP Server container
 - Forwards port 5000 for accessing the MCP Server
-
-## With the Rover CLI
-
-The Rover CLI is a tool for working with GraphQL APIs locally.
-
-You can use the [`rover dev`](/rover/commands/dev) command of Rover CLI `v0.35` or later to run an Apollo MCP Server instance alongside your local graph. Use the `--mcp` flag to start an MCP server and provide an optional configuration file.
-
-```sh
-rover dev --mcp <PATH/TO/CONFIG> [...other rover dev flags]
-```
-
-For more information, see the [Rover CLI documentation](/rover).
 
 ## With the Apollo Runtime Container
 


### PR DESCRIPTION
This PR updates the [Quickstart](https://www.apollographql.com/docs/apollo-mcp-server/quickstart) guide

* add rover init --mcp
* update claude client (and others) config, add to cursor button, goose, etc