### PR TITLE
Describe stateful_mode: false in the deploy documentation

### DIFF
--- a/docs/source/deploy.mdx
+++ b/docs/source/deploy.mdx
@@ -98,6 +98,20 @@ When an MCP client initializes a session with Apollo MCP Server, it receives a s
 
 Most cloud load balancers (ALB, GCP LB) don't support header-based session affinity. Use Nginx, HAProxy, or Envoy/Istio for proper session routing.
 
+#### Stateless mode
+
+While MCP is a stateful protocol by default, the Streamable HTTP transport does support operating in a stateless mode.
+This means that the session id will not be passed back and forth between the client and server and each request made to the MCP server happens in its own HTTP POST.
+Disabling the session state being managed in memory by a single host allows for horizontal scaling of the server, though could lead to unknown issues if your MCP client has a dependency on sticky sessions.
+
+Stateless mode can be configured in the transport config section,
+
+```yaml
+transport:
+  type: streamable_http
+  stateful_mode: false
+```
+
 ### Scaling Recommendations
 
 For the Apollo Runtime Container:

--- a/docs/source/deploy.mdx
+++ b/docs/source/deploy.mdx
@@ -100,11 +100,11 @@ Most cloud load balancers (ALB, GCP LB) don't support header-based session affin
 
 #### Stateless mode
 
-While MCP is a stateful protocol by default, the Streamable HTTP transport does support operating in a stateless mode.
-This means that the session id will not be passed back and forth between the client and server and each request made to the MCP server happens in its own HTTP POST.
+Although MCP is a stateful protocol by default, the Streamable HTTP transport supports operating in a stateless mode.
+This means that the session ID will not be passed back and forth between the client and server and each request made to the MCP server happens in its own HTTP POST.
 Disabling the session state being managed in memory by a single host allows for horizontal scaling of the server, though could lead to unknown issues if your MCP client has a dependency on sticky sessions.
 
-Stateless mode can be configured in the transport config section,
+You can configure stateless mode in the transport config section:
 
 ```yaml
 transport:


### PR DESCRIPTION
Our deployment docs include words of caution to describe how the MCP requiring sticky sessions by default necessitates fronting the service with a load balancer that can maintain sticky session by the `mcp-session-id` header in order to scale horizontally.

The rust SDK has more information and links about this functionality. Our MCP Server implementation simply exposes the configuration option. https://github.com/modelcontextprotocol/rust-sdk/issues/212