### PR TITLE
docs: fix wrong docker flag

### DIFF
--- a/docs/source/deploy.mdx
+++ b/docs/source/deploy.mdx
@@ -28,7 +28,7 @@ docker run \
   --env APOLLO_GRAPH_REF="<your-graph-ref>" \
   --env APOLLO_KEY="<your-graph-api-key>" \
   --env MCP_ENABLE=1 \
-  -m /path/to/config:/config/mcp_config.yaml \
+  -v /path/to/config:/config/mcp_config.yaml \
   --rm \
   ghcr.io/apollographql/apollo-runtime:latest
 ```


### PR DESCRIPTION
`-v` should be used for volume mount instead of `-m`, which is for memory limit.