### PR TITLE
docs: correct default otel endpoint

### DIFF
--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -261,7 +261,7 @@ transport:
 
 | Option      | Type      | Default                     | Description                                                      |
 | :---------  | :-------- | :-------------------------- | :--------------------------------------------------------------- |
-| `endpoint`  | `URL`     | `http://localhost:4137`     | URL to export data to. Requires full path.                       |
+| `endpoint`  | `URL`     | `http://localhost:4317`     | URL to export data to. Requires full path.                       |
 | `protocol`  | `string`  | `grpc`                      | Protocol for export. `grpc` and `http/protobuf` are supported.   |
 
 #### SamplerOption


### PR DESCRIPTION
Just aligning the docs with the code:

https://github.com/apollographql/apollo-mcp-server/blob/a618e2a8dbf8708924471ac1870064dc9ba60a1a/crates/apollo-mcp-server/src/runtime/telemetry.rs#L54-L56