### PR TITLE
chore: Rmcp sdk update 0.8.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3174,9 +3174,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.6.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ab0892f4938752b34ae47cb53910b1b0921e55e77ddb6e44df666cab17939f"
+checksum = "6f35acda8f89fca5fd8c96cae3c6d5b4c38ea0072df4c8030915f3b5ff469c1c"
 dependencies = [
  "axum",
  "base64",
@@ -3205,9 +3205,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.6.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1827cd98dab34cade0513243c6fe0351f0f0b2c9d6825460bcf45b42804bdda0"
+checksum = "c9f1d5220aaa23b79c3d02e18f7a554403b3ccea544bbb6c69d6bcb3e854a274"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -50,7 +50,7 @@ regex = "1.11.1"
 reqwest-middleware = "0.4.2"
 reqwest-tracing = { version = "0.5.8", features = ["opentelemetry_0_30"] }
 reqwest.workspace = true
-rmcp = { version = "0.6", features = [
+rmcp = { version = "0.8", features = [
   "server",
   "transport-io",
   "transport-sse-server",


### PR DESCRIPTION
Checking the changelog we are now 2 minor versions behind the SDK. There were no breaking changes so this seemed like an easier update. There were several changes around oauth we should validate before release

https://github.com/modelcontextprotocol/rust-sdk/releases