### PR TITLE
docs: remove link to grafana integration

### DIFF
--- a/docs/source/telemetry.mdx
+++ b/docs/source/telemetry.mdx
@@ -40,8 +40,6 @@ The fastest way to see Apollo MCP Server telemetry in action is with a local set
 1. Restart your MCP server with the updated config
 1. Open Grafana at `http://localhost:3000` and explore your telemetry data. Default credentials are username `admin` with password `admin`.
 
-For detailed steps and dashboard examples, see the [complete Grafana setup guide](guides/telemetry-grafana.mdx).
-
 ### Production deployment
 
 For production environments, configure your MCP server to send telemetry to any OTLP-compatible backend. The Apollo MCP Server uses standard OpenTelemetry protocols, ensuring compatibility with all major observability platforms.


### PR DESCRIPTION
The link is broken since there is no docs page for grafana integration yet.