### PR TITLE
chore: Rmcp sdk update 0.8.x changeset

### DIFF
--- a/.changesets/maint_rmcp_sdk_update_0_8_x.md
+++ b/.changesets/maint_rmcp_sdk_update_0_8_x.md
@@ -1,0 +1,3 @@
+### Update rmcp sdk to version 0.8.x - @swcollard PR #433 
+
+Bumping the Rust MCP SDK version used in this server up to 0.8.x


### PR DESCRIPTION
Previous PR #433  was missing a changeset but was not flagged by CI. I think we need to include one to indicate our underlying sdk was updated.