### PR TITLE
chore: enable cors in test config files

### DIFF
--- a/graphql/TheSpaceDevs/config.yaml
+++ b/graphql/TheSpaceDevs/config.yaml
@@ -17,3 +17,8 @@ introspection:
     enabled: true
   search:
     enabled: true
+  validate:
+    enabled: true
+cors:
+  enabled: true
+  allow_any_origin: true

--- a/graphql/weather/config.yaml
+++ b/graphql/weather/config.yaml
@@ -16,3 +16,6 @@ introspection:
     enabled: true
   validate:
     enabled: true
+cors:
+  enabled: true
+  allow_any_origin: true


### PR DESCRIPTION
MCP Inspector v0.17 supports direct connection, which lets you inspect actual MCP calls in the browser. Since this feature requires CORS, I’d like to enable it in our test config files for convenience.

### Before

<img width="1007" height="715" alt="image" src="https://github.com/user-attachments/assets/50479f3c-2e1c-4b6f-957f-5adb0abfca5f" />

### After

<img width="1006" height="641" alt="image" src="https://github.com/user-attachments/assets/d5d0ba93-ee84-41bf-a8c3-27913bcc22f0" />
