### PR TITLE
docs fix: cursor deeplink, image zoom and external icon

### DIFF
--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -114,12 +114,8 @@ claude mcp add apollo-mcp npx mcp-remote http://127.0.0.1:8000/mcp
 <ExpansionPanel title="Cursor">
 Click the button to quick install:
 
-<a href="cursor://anysphere.cursor-deeplink/mcp/install?name=apollo-mcp&config=eyJjb21tYW5kIjoibnB4IG1jcC1yZW1vdGUgaHR0cDovLzEyNy4wLjAuMTo1MDUwL21jcCJ9">
-  <img
-    src="https://cursor.com/deeplink/mcp-install-dark.svg"
-    alt="Install Apollo MCP Server"
-    width="200"
-  />
+<a href="cursor://anysphere.cursor-deeplink/mcp/install?name=apollo-mcp&config=eyJjb21tYW5kIjoibnB4IG1jcC1yZW1vdGUgaHR0cDovLzEyNy4wLjAuMTo4MDAwL21jcCJ9" hideExternalIcon>
+ <img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Install Apollo MCP Server to Cursor" width="150px" noZoom/>
 </a>
 
 Or install manually:


### PR DESCRIPTION
Original version was defaulting to port 5050. Fixed deeplink to use correct default port 8000.

<img width="1048" height="626" alt="Screenshot 2025-11-10 at 5 17 09 PM" src="https://github.com/user-attachments/assets/f2657b40-2b00-4a49-98a3-cd8a3116a435" />

Also hides the external link icon that showed up a new line and removed the zoomed-in image that occurs after you click the button.