### PR TITLE
Load and serve basic apps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,7 @@ dependencies = [
  "apollo-federation",
  "apollo-mcp-registry",
  "apollo-schema-index",
+ "assert_fs",
  "async-trait",
  "axum",
  "axum-extra",
@@ -312,6 +313,21 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "assert_fs"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652f6cb1f516886fcfee5e7a5c078b9ade62cfcb889524efe5a64d682dd27a9"
+dependencies = [
+ "anstyle",
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
 ]
 
 [[package]]
@@ -962,6 +978,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +1003,12 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
 name = "downcast-rs"
@@ -1390,6 +1418,17 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags 2.9.4",
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -1827,6 +1866,22 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2839,6 +2894,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -3910,6 +3992,12 @@ dependencies = [
  "rustix 1.1.2",
  "windows-sys 0.61.1",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-log"

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -73,6 +73,7 @@ url.workspace = true
 async-trait = "0.1.89"
 
 [dev-dependencies]
+assert_fs = "1"
 chrono = { version = "0.4.41", default-features = false, features = ["now"] }
 figment = { version = "0.10.19", features = ["test"] }
 insta.workspace = true
@@ -91,6 +92,9 @@ quote = "1.0.40"
 serde.workspace = true
 syn = "2.0.106"
 toml = "0.9.5"
+
+[features]
+apps = []
 
 [lints]
 workspace = true

--- a/crates/apollo-mcp-server/src/apps.rs
+++ b/crates/apollo-mcp-server/src/apps.rs
@@ -1,0 +1,226 @@
+use std::fs::read_to_string;
+use std::path::Path;
+
+use apollo_compiler::{Schema, validation::Valid};
+use rmcp::model::{Meta, RawResource, Resource};
+use serde::Deserialize;
+use tracing::debug;
+use url::Url;
+
+use crate::{
+    custom_scalar_map::CustomScalarMap,
+    operations::{MutationMode, Operation, RawOperation},
+};
+
+/// An app, which consists of a tool and a resource to be used together.
+#[derive(Clone, Debug)]
+pub(crate) struct App {
+    /// The GraphQL operation that defines the app's tool
+    pub(crate) operation: Operation,
+    /// The HTML resource that serves as the app's UI
+    pub(crate) resource: String,
+    /// The URI of the app's resource
+    pub(crate) uri: Url,
+}
+
+impl App {
+    pub(crate) fn resource(&self) -> Resource {
+        Resource::new(
+            RawResource {
+                name: self.operation.tool.name.clone().into(),
+                uri: self.uri.to_string(),
+                mime_type: Some("text/html+skybridge".to_string()),
+                // TODO: load all this from a manifest file
+                title: None,
+                description: None,
+                icons: None,
+                size: None,
+            },
+            None,
+        )
+    }
+}
+
+const MANIFEST_FILE_NAME: &str = ".application-manifest.json";
+
+pub(crate) fn load_from_path(
+    path: &Path,
+    schema: &Valid<Schema>,
+    custom_scalar_map: Option<&CustomScalarMap>,
+    mutation_mode: MutationMode,
+    disable_type_description: bool,
+    disable_schema_description: bool,
+) -> Result<Vec<App>, String> {
+    let Ok(apps_dir) = path.read_dir() else {
+        return Ok(Vec::new());
+    };
+
+    let mut apps = Vec::new();
+    for app_dir in apps_dir {
+        let app_dir = match app_dir {
+            Ok(app_dir) => app_dir,
+            Err(err) => {
+                debug!("Failed to read app directory, ignoring: {}", err);
+                continue;
+            }
+        };
+        let path = app_dir.path();
+        if !path.is_dir() {
+            debug!("{} is not a directory, ignoring", path.to_string_lossy());
+            continue;
+        }
+
+        let Ok(manifest) = read_to_string(path.join(MANIFEST_FILE_NAME)) else {
+            debug!(
+                "No manifest file found in {}, ignoring",
+                path.to_string_lossy()
+            );
+            continue;
+        };
+
+        let manifest: Manifest = serde_json::from_str(&manifest).map_err(|err| {
+            format!(
+                "Failed to parse manifest from {}: {}",
+                path.to_string_lossy(),
+                err
+            )
+        })?;
+
+        let Some(operation_str) = manifest
+            .operations
+            .iter()
+            .find_map(|op| op.prefetch_id.is_some().then(|| op.body.to_string()))
+        else {
+            // TODO: Allow applications with only post-fetch operations
+            return Err("Exactly one prefetch operation must be defined".into());
+        };
+
+        let raw = RawOperation::from((operation_str, path.to_str().map(String::from)));
+        let mut operation = match Operation::from_document(
+            raw,
+            schema,
+            custom_scalar_map,
+            mutation_mode,
+            disable_type_description,
+            disable_schema_description,
+        ) {
+            Err(err) => {
+                return Err(format!(
+                    "Failed to parse operation from {path}: {err}",
+                    path = path.to_string_lossy()
+                ));
+            }
+            Ok(None) => {
+                return Err(format!(
+                    "No operation in {path}",
+                    path = path.to_string_lossy()
+                ));
+            }
+            Ok(Some(op)) => op,
+        };
+
+        let resource_path = path.join(manifest.resource);
+        let resource = read_to_string(&resource_path).map_err(|err| {
+            format!(
+                "Failed to read resource from {resource_path}: {err}",
+                resource_path = resource_path.to_string_lossy(),
+            )
+        })?;
+
+        let name = manifest
+            .name
+            .unwrap_or_else(|| app_dir.file_name().to_string_lossy().to_string());
+        let uri_string = format!("ui://widget/{name}#{}", manifest.hash);
+        let uri = Url::parse(&uri_string)
+            .map_err(|err| format!("Failed to create a URI for resource {uri_string}: {err}",))?;
+
+        let mut meta = Meta::new();
+        meta.insert("openai/outputTemplate".to_string(), uri.to_string().into());
+        meta.insert("openai/widgetAccessible".to_string(), true.into());
+        operation.tool.name = name.into();
+        operation.tool.meta = Some(meta);
+        if let Some(description) = manifest.description {
+            operation.tool.description = Some(description.into());
+        }
+
+        apps.push(App {
+            uri,
+            operation,
+            resource,
+        });
+    }
+    Ok(apps)
+}
+
+#[derive(Clone, Deserialize)]
+struct Manifest {
+    hash: String,
+    operations: Vec<OperationDefinition>,
+    resource: String,
+    name: Option<String>,
+    description: Option<String>,
+    #[allow(dead_code)] // Only used to verify we recognize the file
+    format: ManifestFormat,
+    #[allow(dead_code)] // Only used to verify we recognize the version
+    version: ManifestVersion,
+}
+
+#[derive(Clone, Copy, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum ManifestFormat {
+    ApolloAiAppManifest,
+}
+
+#[derive(Clone, Copy, Deserialize)]
+enum ManifestVersion {
+    #[serde(rename = "1")]
+    V1,
+}
+
+#[derive(Clone, Deserialize)]
+struct OperationDefinition {
+    body: String,
+    #[serde(rename = "prefetchID", default)]
+    prefetch_id: Option<String>,
+}
+
+#[cfg(test)]
+mod test_load_from_path {
+    use super::*;
+    use assert_fs::{TempDir, prelude::*};
+
+    #[test]
+    fn test_happy_path() {
+        let temp = TempDir::new().expect("Could not create temporary directory for test");
+        let app_dir = temp.child("MyApp");
+        app_dir
+            .child(MANIFEST_FILE_NAME)
+            .write_str(
+                r#"{"format": "apollo-ai-app-manifest",
+                            "version": "1",
+                            "hash": "abcdef",
+                            "resource": "index.html",
+                            "operations": [{"body": "query MyOperation { hello }", "prefetch": true, "prefetchID": "__anonymous"}]}"#,
+            )
+            .unwrap();
+        let html = "<html>blelo</html>";
+        app_dir.child("index.html").write_str(html).unwrap();
+        let apps = load_from_path(
+            temp.path(),
+            &Schema::parse("type Query { hello: String }", "schema.graphql")
+                .unwrap()
+                .validate()
+                .unwrap(),
+            None,
+            MutationMode::All,
+            false,
+            false,
+        )
+        .expect("Failed to load apps");
+        assert_eq!(apps.len(), 1);
+        let app = &apps[0];
+        assert_eq!(app.resource, html);
+        assert_eq!(app.uri, "ui://widget/MyApp#abcdef".parse().unwrap());
+        assert_eq!(app.operation.tool.name, "MyApp");
+    }
+}

--- a/crates/apollo-mcp-server/src/errors.rs
+++ b/crates/apollo-mcp-server/src/errors.rs
@@ -103,6 +103,9 @@ pub enum ServerError {
 
     #[error("CORS configuration error: {0}")]
     Cors(String),
+
+    #[error("Failed to load apps: {0}")]
+    Apps(String),
 }
 
 /// An MCP tool error

--- a/crates/apollo-mcp-server/src/lib.rs
+++ b/crates/apollo-mcp-server/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
+pub mod apps;
 pub mod auth;
 pub mod cors;
 pub mod custom_scalar_map;

--- a/crates/apollo-mcp-server/src/operations/operation.rs
+++ b/crates/apollo-mcp-server/src/operations/operation.rs
@@ -26,7 +26,7 @@ use super::{MutationMode, RawOperation, schema_walker};
 /// A valid GraphQL operation
 #[derive(Debug, Clone, Serialize)]
 pub struct Operation {
-    tool: Tool,
+    pub(crate) tool: Tool,
     inner: RawOperation,
     operation_name: String,
 }


### PR DESCRIPTION
This PR introduces the concept of "apps" which, right now, correspond to [OpenAPI Apps SDK](https://developers.openai.com/apps-sdk), but can be more broadly understood as [MCP Apps](https://blog.modelcontextprotocol.io/posts/2025-11-21-mcp-apps/) once that is stabilized.

At startup, the new `apps::load_from_path` function is called, right now looking for a hard-coded `apps/` folder, though we can make that configurable in the future. Each app is a directory within that `apps/` folder which contains an `.application-manifest.json`. An app then registers as a tool (exposed in `list_tools` and `call_tool`) and a resource (`list_resources` and `read_resource`).

Apps won't actually be loaded unless the cargo feature `"apps"` is enabled. I only gated the actual runtime component with that feature flag right now, but we could optionally skip compiling the entire module if we want.

The only immediate effect of the default build of this server after this PR is that the server will now report it has resource capabilities. Since the resource list will always be empty, I think that change is very minor. But we could disable that for now as well if it's concerning.