### PR TITLE
Multiple tool definitions per app

### DIFF
--- a/crates/apollo-mcp-server/src/apps.rs
+++ b/crates/apollo-mcp-server/src/apps.rs
@@ -1,8 +1,8 @@
-use std::fs::read_to_string;
 use std::path::Path;
+use std::{fs::read_to_string, sync::Arc};
 
 use apollo_compiler::{Schema, validation::Valid};
-use rmcp::model::{Meta, RawResource, Resource};
+use rmcp::model::{Meta, RawResource, Resource, Tool};
 use serde::Deserialize;
 use tracing::debug;
 use url::Url;
@@ -15,12 +15,22 @@ use crate::{
 /// An app, which consists of a tool and a resource to be used together.
 #[derive(Clone, Debug)]
 pub(crate) struct App {
-    /// The GraphQL operation that defines the app's tool
-    pub(crate) operation: Operation,
+    pub(crate) name: String,
     /// The HTML resource that serves as the app's UI
     pub(crate) resource: AppResource,
     /// The URI of the app's resource
     pub(crate) uri: Url,
+    /// Entrypoint tools for this app
+    pub(crate) tools: Vec<AppTool>,
+}
+
+/// An MCP tool which serves as an entrypoint for an app.
+#[derive(Clone, Debug)]
+pub(crate) struct AppTool {
+    /// The GraphQL operation that's executed when the tool is called. Its data is injected into the UI
+    pub(crate) operation: Arc<Operation>,
+    /// The MCP tool definition
+    pub(crate) tool: Tool,
 }
 
 #[derive(Clone, Debug)]
@@ -33,7 +43,7 @@ impl App {
     pub(crate) fn resource(&self) -> Resource {
         Resource::new(
             RawResource {
-                name: self.operation.tool.name.clone().into(),
+                name: self.name.clone(),
                 uri: self.uri.to_string(),
                 mime_type: Some("text/html+skybridge".to_string()),
                 // TODO: load all this from a manifest file
@@ -92,38 +102,69 @@ pub(crate) fn load_from_path(
             )
         })?;
 
-        let Some(operation_str) = manifest
-            .operations
-            .iter()
-            .find_map(|op| op.prefetch_id.is_some().then(|| op.body.to_string()))
-        else {
-            // TODO: Allow applications with only post-fetch operations
-            return Err("Exactly one prefetch operation must be defined".into());
-        };
+        let name = manifest
+            .name
+            .unwrap_or_else(|| app_dir.file_name().to_string_lossy().to_string());
 
-        let raw = RawOperation::from((operation_str, path.to_str().map(String::from)));
-        let mut operation = match Operation::from_document(
-            raw,
-            schema,
-            custom_scalar_map,
-            mutation_mode,
-            disable_type_description,
-            disable_schema_description,
-        ) {
-            Err(err) => {
-                return Err(format!(
-                    "Failed to parse operation from {path}: {err}",
-                    path = path.to_string_lossy()
-                ));
+        let uri_string = format!("ui://widget/{name}#{}", manifest.hash);
+        let uri = Url::parse(&uri_string)
+            .map_err(|err| format!("Failed to create a URI for resource {uri_string}: {err}",))?;
+
+        let mut meta = Meta::new();
+        meta.insert("openai/outputTemplate".to_string(), uri.to_string().into());
+        meta.insert("openai/widgetAccessible".to_string(), true.into());
+
+        let mut tools = Vec::new();
+
+        for operation_def in manifest.operations {
+            let raw = RawOperation::from((operation_def.body, path.to_str().map(String::from)));
+            let operation = match Operation::from_document(
+                raw,
+                schema,
+                custom_scalar_map,
+                mutation_mode,
+                disable_type_description,
+                disable_schema_description,
+            ) {
+                Err(err) => {
+                    return Err(format!(
+                        "Failed to parse operation from {path}: {err}",
+                        path = path.to_string_lossy()
+                    ));
+                }
+                Ok(None) => {
+                    return Err(format!(
+                        "Failed parsing tools: No operation in {path}",
+                        path = path.to_string_lossy()
+                    ));
+                }
+                Ok(Some(op)) => Arc::new(op),
+            };
+
+            for tool in operation_def.tools {
+                let tool = Tool {
+                    name: format!("{name}--{}", tool.name).into(),
+                    meta: Some(meta.clone()),
+                    description: Some(
+                        if let Some(app_description) = manifest.description.clone() {
+                            format!("{} {}", app_description, tool.description).into()
+                        } else {
+                            tool.description.into()
+                        },
+                    ),
+                    input_schema: operation.tool.input_schema.clone(),
+                    title: operation.tool.title.clone(),
+                    output_schema: operation.tool.output_schema.clone(),
+                    annotations: operation.tool.annotations.clone(),
+                    icons: operation.tool.icons.clone(),
+                };
+
+                tools.push(AppTool {
+                    operation: operation.clone(),
+                    tool,
+                })
             }
-            Ok(None) => {
-                return Err(format!(
-                    "No operation in {path}",
-                    path = path.to_string_lossy()
-                ));
-            }
-            Ok(Some(op)) => op,
-        };
+        }
 
         let resource = if manifest.resource.starts_with("http://")
             || manifest.resource.starts_with("https://")
@@ -143,26 +184,11 @@ pub(crate) fn load_from_path(
             AppResource::Local(contents)
         };
 
-        let name = manifest
-            .name
-            .unwrap_or_else(|| app_dir.file_name().to_string_lossy().to_string());
-        let uri_string = format!("ui://widget/{name}#{}", manifest.hash);
-        let uri = Url::parse(&uri_string)
-            .map_err(|err| format!("Failed to create a URI for resource {uri_string}: {err}",))?;
-
-        let mut meta = Meta::new();
-        meta.insert("openai/outputTemplate".to_string(), uri.to_string().into());
-        meta.insert("openai/widgetAccessible".to_string(), true.into());
-        operation.tool.name = name.into();
-        operation.tool.meta = Some(meta);
-        if let Some(description) = manifest.description {
-            operation.tool.description = Some(description.into());
-        }
-
         apps.push(App {
+            name,
             uri,
-            operation,
             resource,
+            tools,
         });
     }
     Ok(apps)
@@ -195,9 +221,20 @@ enum ManifestVersion {
 
 #[derive(Clone, Deserialize)]
 struct OperationDefinition {
+    /// The GraphQL operation itself
     body: String,
+    /// If this operation should be prefetched, this ID indicates where the UI expects to find the data
     #[serde(rename = "prefetchID", default)]
+    #[allow(dead_code)] // Will use in follow-up PR
     prefetch_id: Option<String>,
+    /// The tools which make up this app
+    tools: Vec<ToolDefinition>,
+}
+
+#[derive(Clone, Deserialize)]
+struct ToolDefinition {
+    name: String,
+    description: String,
 }
 
 #[cfg(test)]
@@ -216,7 +253,7 @@ mod test_load_from_path {
                             "version": "1",
                             "hash": "abcdef",
                             "resource": "index.html",
-                            "operations": [{"body": "query MyOperation { hello }", "prefetch": true, "prefetchID": "__anonymous"}]}"#,
+                            "operations": []}"#,
             )
             .unwrap();
         let html = "<html>blelo</html>";
@@ -240,7 +277,6 @@ mod test_load_from_path {
             AppResource::Remote(url) => panic!("unexpected remote resource {url}"),
         }
         assert_eq!(app.uri, "ui://widget/MyApp#abcdef".parse().unwrap());
-        assert_eq!(app.operation.tool.name, "MyApp");
     }
 
     #[test]
@@ -254,7 +290,7 @@ mod test_load_from_path {
                             "version": "1",
                             "hash": "abcdef",
                             "resource": "https://example.com/widget/index.html",
-                            "operations": [{"body": "query MyOperation { hello }", "prefetch": true, "prefetchID": "__anonymous"}]}"#,
+                            "operations": []}"#,
             )
             .unwrap();
         let apps = load_from_path(
@@ -279,5 +315,66 @@ mod test_load_from_path {
                 panic!("expected remote resource, found local: {contents}")
             }
         }
+    }
+
+    #[test]
+    fn multiple_tools_in_an_app() {
+        let temp = TempDir::new().expect("Could not create temporary directory for test");
+        let app_dir = temp.child("MultipleToolsApp");
+        app_dir
+            .child(MANIFEST_FILE_NAME)
+            .write_str(
+                r#"{"format": "apollo-ai-app-manifest",
+                    "version": "1",
+                    "hash": "abcdef",
+                    "resource": "https://example.com/widget/index.html",
+                    "operations": [
+                        {"body": "query MyOperation { hello }", "tools": [
+                          {"name": "Tool1", "description": "Description for Tool1"},
+                          {"name": "Tool2", "description": "Description for Tool2"}
+                        ]},
+                        {"body": "query MyOtherOperation { world }", "tools": [
+                          {"name": "Tool3", "description": "Description for Tool3"}
+                        ]}
+                    ]}"#,
+            )
+            .unwrap();
+        let apps = load_from_path(
+            temp.path(),
+            &Schema::parse(
+                "type Query { hello: String, world: String }",
+                "schema.graphql",
+            )
+            .unwrap()
+            .validate()
+            .unwrap(),
+            None,
+            MutationMode::All,
+            false,
+            false,
+        )
+        .expect("Failed to load apps");
+        assert_eq!(apps.len(), 1);
+        let app = &apps[0];
+        assert_eq!(app.tools.len(), 3);
+        assert_eq!(app.tools[0].tool.name, "MultipleToolsApp--Tool1");
+        assert_eq!(
+            app.tools[0].tool.description.as_ref().unwrap(),
+            "Description for Tool1"
+        );
+        assert_eq!(
+            app.tools[0].operation.inner.source_text,
+            "query MyOperation { hello }"
+        );
+        assert_eq!(app.tools[1].tool.name, "MultipleToolsApp--Tool2");
+        assert_eq!(
+            app.tools[1].tool.description.as_ref().unwrap(),
+            "Description for Tool2"
+        );
+        assert_eq!(app.tools[2].tool.name, "MultipleToolsApp--Tool3");
+        assert_eq!(
+            app.tools[2].tool.description.as_ref().unwrap(),
+            "Description for Tool3"
+        );
     }
 }

--- a/crates/apollo-mcp-server/src/operations/operation.rs
+++ b/crates/apollo-mcp-server/src/operations/operation.rs
@@ -27,7 +27,7 @@ use super::{MutationMode, RawOperation, schema_walker};
 #[derive(Debug, Clone, Serialize)]
 pub struct Operation {
     pub(crate) tool: Tool,
-    inner: RawOperation,
+    pub(crate) inner: RawOperation,
     operation_name: String,
 }
 

--- a/crates/apollo-mcp-server/src/operations/raw_operation.rs
+++ b/crates/apollo-mcp-server/src/operations/raw_operation.rs
@@ -13,7 +13,7 @@ use super::{MutationMode, operation::Operation};
 
 #[derive(Debug, Clone)]
 pub struct RawOperation {
-    pub(super) source_text: String,
+    pub(crate) source_text: String,
     pub(super) persisted_query_id: Option<String>,
     pub(super) headers: Option<HeaderMap<HeaderValue>>,
     pub(super) variables: Option<HashMap<String, Value>>,


### PR DESCRIPTION
This PR decouples the tool definition from the app definition, and allows the user to configure multiple tools per app (and per operation).

Each tool is effectively an action that the agent wants to take. It's very common in ChatGPT apps to have several actions all result in the same UI.

The reasons to allow multiple tools per _operation_ are:

1. Allow multiple descriptions, which may help an agent pick a tool.
2. Allow _inputs_ that don't actually go to the GraphQL operation, only to the UI (coming in a follow-up PR)