### PR TITLE
docs: update the toggle name on Auth0

### DIFF
--- a/docs/source/guides/auth-auth0.mdx
+++ b/docs/source/guides/auth-auth0.mdx
@@ -66,7 +66,7 @@ Your Auth0 setup is now complete. You have an API with an audience and a connect
 <ExpansionPanel title="Something went wrong? Try these troubleshooting steps">
   - Check that the `curl` command is correct and that you have the correct values for `<CONNECTION ID>`, `<AUTH0 DOMAIN>`, and `<MGMT API ACCESS TOKEN>`.
   - Check that you have the correct permissions to promote the connection to domain level. 
-    - In your Auth0 dashboard, navigate to **Applications** -> **API Explorer Application** -> **APIs**. Ensure that the **Auth0 Management API** is authorized.
+    - In your Auth0 dashboard, navigate to **Applications** -> **Applications** -> **API Explorer Application** -> **APIs**. Ensure that the **Auth0 Management API** is authorized.
     - Expand the **Auth0 Management API** item and enable the `update:connections` permission.
     ![Auth0 Management API Permissions](../images/auth0-permissions-enable.png)
     - Click **Update** to save your changes.


### PR DESCRIPTION
I noticed that Auth0 changed the toggle name to make it clearer.

<img width="1021" height="823" alt="image" src="https://github.com/user-attachments/assets/60b6feeb-244e-4d51-a822-0bad16ea2fc9" />
