### PR TITLE
chore: remove unused dependencies to improve build time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,6 @@ dependencies = [
  "apollo-mcp-registry",
  "apollo-schema-index",
  "assert_fs",
- "async-trait",
  "axum",
  "axum-extra",
  "axum-otel-metrics",
@@ -228,11 +227,8 @@ dependencies = [
  "lz-str",
  "mockito",
  "opentelemetry",
- "opentelemetry-appender-log",
  "opentelemetry-otlp",
- "opentelemetry-resource-detectors",
  "opentelemetry-semantic-conventions",
- "opentelemetry-stdout",
  "opentelemetry_sdk",
  "prettyplease",
  "quote",
@@ -256,7 +252,6 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-appender",
- "tracing-core",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tracing-test",
@@ -2595,16 +2590,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-appender-log"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e688026e48f4603494f619583e0aa0b0edd9c0b9430e1c46804df2ff32bc8798"
-dependencies = [
- "log",
- "opentelemetry",
-]
-
-[[package]]
 name = "opentelemetry-http"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2649,32 +2634,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-resource-detectors"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a44e076f07fa3d76e741991f4f7d3ecbac0eed8521ced491fbdf8db77d024cf"
-dependencies = [
- "opentelemetry",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
-]
-
-[[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
-
-[[package]]
-name = "opentelemetry-stdout"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447191061af41c3943e082ea359ab8b64ff27d6d34d30d327df309ddef1eef6f"
-dependencies = [
- "chrono",
- "opentelemetry",
- "opentelemetry_sdk",
-]
 
 [[package]]
 name = "opentelemetry_sdk"

--- a/crates/apollo-mcp-registry/Cargo.toml
+++ b/crates/apollo-mcp-registry/Cargo.toml
@@ -30,13 +30,13 @@ tower = "0.5.2"
 tracing.workspace = true
 url.workspace = true
 uuid = { version = "1.16.0", features = ["serde", "v4"] }
-tracing-core.workspace = true
 tracing-subscriber.workspace = true
 
 [dev-dependencies]
 test-log = { version = "0.2.16", default-features = false, features = [
   "trace",
 ] }
+tracing-core.workspace = true
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 wiremock = "0.6.3"
 

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -32,7 +32,6 @@ jsonwebtoken = "9"
 jwks = "0.4.0"
 lz-str = "0.2.1"
 opentelemetry = "0.30.0"
-opentelemetry-appender-log = "0.30.0"
 opentelemetry-otlp = { version = "0.30.0", features = [
   "grpc-tonic",
   "tonic",
@@ -40,9 +39,7 @@ opentelemetry-otlp = { version = "0.30.0", features = [
   "metrics",
   "trace",
 ] }
-opentelemetry-resource-detectors = "0.9.0"
 opentelemetry-semantic-conventions = "0.30.0"
-opentelemetry-stdout = "0.30.0"
 opentelemetry_sdk = { version = "0.30.0", features = [
   "spec_unstable_metrics_views",
 ] }
@@ -65,12 +62,10 @@ tokio-util = "0.7.15"
 tonic = "0.13.1"
 tower-http = { version = "0.6.6", features = ["cors", "trace"] }
 tracing-appender = "0.2.3"
-tracing-core.workspace = true
 tracing-opentelemetry = "0.31.0"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tracing.workspace = true
 url.workspace = true
-async-trait = "0.1.89"
 
 [dev-dependencies]
 assert_fs = "1"


### PR DESCRIPTION
## Summary

Remove unused dependencies to improve build time by ~8 seconds (6.1% reduction).

### Changes

**Removed from apollo-mcp-server (5 dependencies)**:
- `async-trait` - No usage found in codebase
- `opentelemetry-appender-log` - No usage found
- `opentelemetry-resource-detectors` - No usage found  
- `opentelemetry-stdout` - No usage found (uses `std::io::stdout` instead)
- `tracing-core` - No usage in this crate

**Moved to dev-dependencies in apollo-mcp-registry**:
- `tracing-core` - Only used in test-related code (test macros and `#[cfg(test)]` modules), so it won't be compiled in release builds

### Build Time Impact

Measured across 3 clean release builds each:

| Configuration | Build 1 | Build 2 | Build 3 | Average |
|--------------|---------|---------|---------|---------|
| **Before** | 130s | 136s | 126s | **130.7s** |
| **After** | 120s | 126s | 122s | **122.7s** |
| **Improvement** | -10s | -10s | -4s | **-8.0s (6.1%)** |

### Testing

Dependencies were identified as unused using `cargo-machete` and verified by:
1. Searching codebase for any usage with `grep`
2. Confirming no compilation errors after removal
3. Running full clean builds to measure impact

For `tracing-core` in apollo-mcp-registry, verified it's only used in:
- Test macro definitions (`assert_snapshot_subscriber!`)
- Code within `#[cfg(test)]` modules