### PR TITLE
ci: re-verify changeset when labels are added

### DIFF
--- a/.github/workflows/verify-changeset.yml
+++ b/.github/workflows/verify-changeset.yml
@@ -1,7 +1,7 @@
 name: Verify Changeset
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, labeled]
     paths-ignore:
       - ".github/**"
       - ".cargo/**"


### PR DESCRIPTION
I was wondering why the Verify Changeset check often fails on PRs with the skip-changeset label. It turns out that adding the label doesn't trigger the workflow, so it stays failed until you make more commits to the PR. To avoid confusion, I've updated the workflow so it can be triggered when the label is added.