### PR TITLE
refactor: encapsulate health check router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,7 @@ dependencies = [
  "futures",
  "headers",
  "http",
+ "http-body-util",
  "humantime-serde",
  "insta",
  "jsonschema",

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -71,6 +71,7 @@ url.workspace = true
 
 [dev-dependencies]
 assert_fs = "1"
+http-body-util = "0.1"
 tempfile = "3"
 chrono = { version = "0.4.41", default-features = false, features = ["now"] }
 figment = { version = "0.10.19", features = ["test"] }

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -317,7 +317,6 @@ impl Starting {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use http::HeaderMap;


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-341 -->

This PR extracts the router setup logic from `starting.rs` into the health check module, aligning it with the auth module's pattern. This refactoring also enabled me to add unit tests for the health check router.