### PR TITLE
Release workflow fixes

### DIFF
--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -1,4 +1,4 @@
-name: Build Release Binaries (new)
+name: Build Release Binaries
 
 on:
   pull_request:

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -1,4 +1,4 @@
-name: Build Release Container (New)
+name: Build Release Container
 
 on:
   pull_request:

--- a/.github/workflows/release-experimental.yml
+++ b/.github/workflows/release-experimental.yml
@@ -1,4 +1,4 @@
-name: Build Experimental Release Binaries (new)
+name: Build Experimental Release Binaries
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/verify-changeset.yml
+++ b/.github/workflows/verify-changeset.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   verify-changeset:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changeset') && !startsWith(github.head_ref, 'release/') && !startsWith(github.head_ref, 'conflict/') && !github.event.pull_request.draft }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changeset') && github.head_ref != 'release' && !startsWith(github.head_ref, 'release/') && !startsWith(github.head_ref, 'conflict/') && !github.event.pull_request.draft }}
     name: Verify
     runs-on: ubuntu-24.04
     permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-mcp-registry"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "derive_more",
  "educe",
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-schema-index"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "apollo-compiler",
  "enumset",

--- a/knope.toml
+++ b/knope.toml
@@ -1,10 +1,12 @@
 [package]
 versioned_files = [
-    "Cargo.toml", 
+    "Cargo.toml",
     { path = "Cargo.lock", dependency = "apollo-mcp-server" },
     { path = "scripts/nix/install.sh", regex = "PACKAGE_VERSION=\"v(?<version>\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9.]+)?)\"" },
     { path = "scripts/windows/install.ps1", regex = "\\$package_version = 'v(?<version>\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9.]+)?)'" },
-    { path = "docs/source/run.mdx", regex = "(^|[^\\w.-])v?(?<version>\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9.]+)?)([^\\w.]|$)" }
+    { path = "docs/source/run.mdx", regex = "(^|[^\\w.-])v?(?<version>\\d+\\.\\d+\\.\\d+)(-[a-zA-Z0-9.]+)?([^\\w.]|$)" },
+    { path = "server.json", regex = "\"version\": \"(?<version>\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9.]+)?)\"" },
+    { path = "server.json", regex = "apollo-mcp-server:v(?<version>\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9.]+)?)\"" },
 ]
 changelog = "CHANGELOG.md"
 assets = "artifacts/*"


### PR DESCRIPTION
- Use Knope to manage version in server.json file
- Don't replace -rc of versions in docs
- Remove "new" from job names
- Fix verify changeset to skip release PRs