### PR TITLE
docs: update minimum Rover version to v0.36 for consistency

### DIFF
--- a/docs/source/guides/auth-auth0.mdx
+++ b/docs/source/guides/auth-auth0.mdx
@@ -16,7 +16,7 @@ This guide uses [Auth0](https://auth0.com/) as the Identity Provider.
    git clone git@github.com:apollographql/apollo-mcp-server.git
    ```
 
-1. Install or update the Rover CLI. You need at least v0.35 or later.
+1. Install or update the Rover CLI. You need at least v0.36 or later.
 
    ```sh showLineNumbers=false
    curl -sSL https://rover.apollo.dev/nix/latest | sh

--- a/docs/source/run.mdx
+++ b/docs/source/run.mdx
@@ -16,7 +16,7 @@ There are multiple ways to run the Apollo MCP server.
 
 The Rover CLI is a tool for working with GraphQL APIs locally.
 
-You can use the [`rover dev`](/rover/commands/dev) command of Rover CLI `v0.35` or later to run an Apollo MCP Server instance alongside your local graph. Use the `--mcp` flag to start an MCP server and provide an optional configuration file.
+You can use the [`rover dev`](/rover/commands/dev) command of Rover CLI `v0.36` or later to run an Apollo MCP Server instance alongside your local graph. Use the `--mcp` flag to start an MCP server and provide an optional configuration file.
 
 ```sh
 rover dev --mcp <PATH/TO/CONFIG> [...other rover dev flags]


### PR DESCRIPTION
Fixes inconsistent minimum Rover version requirements in docs. Updates `auth-auth0.mdx` and `run.mdx` from v0.35 to v0.36 to align with `quickstart.mdx`:

https://github.com/apollographql/apollo-mcp-server/blob/1d90de70e3adf983c2583e35e49778c73c2e4684/docs/source/quickstart.mdx?plain=1#L12