### PR TITLE
docs: rover dev supports .env

### DIFF
--- a/docs/source/guides/auth-auth0.mdx
+++ b/docs/source/guides/auth-auth0.mdx
@@ -16,7 +16,7 @@ This guide uses [Auth0](https://auth0.com/) as the Identity Provider.
    git clone git@github.com:apollographql/apollo-mcp-server.git
    ```
 
-1. Install or update the Rover CLI. You need at least v0.36 or later.
+1. Install or update the Rover CLI. You need at least v0.37 or later.
 
    ```sh showLineNumbers=false
    curl -sSL https://rover.apollo.dev/nix/latest | sh

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -9,7 +9,7 @@ This guide walks you through the process of creating, running and configuring an
 
 ## Prerequisites
 
-- [Rover CLI](/rover/getting-started) v0.36 or later. We'll use Rover to initialize a project and run the MCP server. Follow the instructions for [installing](/rover/getting-started) and [authenticating](/rover/getting-started#connecting-to-graphos) Rover with a GraphOS account.
+- [Rover CLI](/rover/getting-started) v0.37 or later. We'll use Rover to initialize a project and run the MCP server. Follow the instructions for [installing](/rover/getting-started) and [authenticating](/rover/getting-started#connecting-to-graphos) Rover with a GraphOS account.
 - [Node.js](https://nodejs.org/) v18 or later (for `mcp-remote`)
 - [Claude Desktop](https://claude.ai/download) or another MCP-compatible client
 

--- a/docs/source/run.mdx
+++ b/docs/source/run.mdx
@@ -16,7 +16,7 @@ There are multiple ways to run the Apollo MCP server.
 
 The Rover CLI is a tool for working with GraphQL APIs locally.
 
-You can use the [`rover dev`](/rover/commands/dev) command of Rover CLI `v0.36` or later to run an Apollo MCP Server instance alongside your local graph. Use the `--mcp` flag to start an MCP server and provide an optional configuration file.
+You can use the [`rover dev`](/rover/commands/dev) command of Rover CLI `v0.37` or later to run an Apollo MCP Server instance alongside your local graph. Use the `--mcp` flag to start an MCP server and provide an optional configuration file.
 
 ```sh
 rover dev --mcp <PATH/TO/CONFIG> [...other rover dev flags]


### PR DESCRIPTION
Rover added support for `.env` files in `rover dev` in https://github.com/apollographql/rover/pull/2730, and it's been available since v0.37. This PR updates the docs to eliminate the hassle of having to prefix `rover dev` with `set -a && source .env && set +a &&` to enhance the onboarding experience.