### PR TITLE
Update changeset workflow

### DIFF
--- a/.github/workflows/verify-changeset.yml
+++ b/.github/workflows/verify-changeset.yml
@@ -56,7 +56,6 @@ jobs:
               "Please use `knope document-change` to create a changeset. (installation instructions: https://knope.tech/installation/)"
             ].join("\n");
 
-            // Check if comment already exists
             const comments = await github.paginate(
               github.rest.issues.listComments,
               { owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number }
@@ -64,7 +63,6 @@ jobs:
             const existing = comments.find(c => c.body.includes(marker));
 
             if (existing) {
-              // Update existing comment back to failure state (in case it was previously resolved)
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -72,7 +70,6 @@ jobs:
                 body: body
               });
             } else {
-              // Create new comment
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -100,17 +97,53 @@ jobs:
             const existing = comments.find(c => c.body.includes(marker));
 
             if (existing) {
-              // Only update if not already showing success
-              if (!existing.body.includes('✅')) {
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: existing.id,
-                  body: body
-                });
-              }
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body
+              });
             } else {
-              // Create new success comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: body
+              });
+            }
+
+  handle-skip-label:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changeset') && github.head_ref != 'release' && !startsWith(github.head_ref, 'release/') && !startsWith(github.head_ref, 'conflict/') && !github.event.pull_request.draft }}
+    name: Handle Skip Label
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add or update comment to show skipped
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const marker = '<!-- changeset-bot-comment -->';
+            const body = [
+              marker,
+              "⏭️ **Changeset check skipped via label**"
+            ].join("\n");
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number }
+            );
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body
+              });
+            } else {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
Update changeset workflow to update comments when changesets are added after the initial PR, replacing stale failure messages with success status or skipped status