### PR TITLE
Update all workspace crate versions in `Cargo.lock` during release prep

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -26,8 +26,3 @@ jobs:
       - run: knope prepare-release --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Label release PR
-        run: gh pr edit --add-label release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/knope.toml
+++ b/knope.toml
@@ -45,6 +45,11 @@ template = "Release $version"
 [workflows.steps.body]
 template = "This PR was created by Knope. Merging it will create a new release\n\n$changelog"
 
+[[workflows.steps]]
+type = "Command"
+command = "gh pr edit --add-label release"
+shell = true
+
 [[workflows]]
 name = "release"
 


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-385 -->

While I was releasing v1.5.0, I checked out the release branch and saw that my IDE updated `Cargo.lock` because the Prepare Release workflow didn't update all the workspace crate versions. This PR fixes that issue.

I also have a couple of suggestions:

-  Change the branch naming from `release` to `release/$version` to avoid reusing the same branch for each release.
-  Automatically apply the `release` label to release PRs so it's easier to find them and keep consistency with previous release PRs.