### PR TITLE
Refactor apps code into app, manifest, resource, and tool

### DIFF
--- a/crates/apollo-mcp-server/src/apps/app.rs
+++ b/crates/apollo-mcp-server/src/apps/app.rs
@@ -1,0 +1,201 @@
+use std::sync::Arc;
+
+use rmcp::model::{ErrorCode, Extensions, RawResource, Resource, Tool};
+use url::Url;
+
+use crate::apps::manifest::{AppLabels, CSPSettings, WidgetSettings};
+use crate::errors::McpError;
+use crate::operations::Operation;
+
+/// An app, which consists of a tool and a resource to be used together.
+#[derive(Clone, Debug)]
+pub(crate) struct App {
+    pub(crate) name: String,
+    pub(crate) description: Option<String>,
+    /// The HTML resource that serves as the app's UI
+    pub(crate) resource: AppResource,
+    /// Any CSP settings to apply to the resource
+    pub(crate) csp_settings: Option<CSPSettings>,
+    /// Various resource meta data
+    pub(crate) widget_settings: Option<WidgetSettings>,
+    /// The URI of the app's resource
+    pub(crate) uri: Url,
+    /// Entrypoint tools for this app
+    pub(crate) tools: Vec<AppTool>,
+    /// Any operations that should _always_ be executed for any of the tools (after the initial tool operation)
+    pub(crate) prefetch_operations: Vec<PrefetchOperation>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum AppResource {
+    Local(String),
+    Remote(Url),
+}
+
+/// An MCP tool which serves as an entrypoint for an app.
+#[derive(Clone, Debug)]
+pub(crate) struct AppTool {
+    /// The GraphQL operation that's executed when the tool is called. Its data is injected into the UI
+    pub(crate) operation: Arc<Operation>,
+    // The labels for this tool
+    pub(crate) labels: AppLabels,
+    /// The MCP tool definition
+    pub(crate) tool: Tool,
+}
+
+/// An operation that should be executed for every invocation of an app.
+#[derive(Clone, Debug)]
+pub(crate) struct PrefetchOperation {
+    /// The operation to execute
+    pub(crate) operation: Arc<Operation>,
+    /// A unique ID for the operation that the UI will use to look up its data
+    pub(crate) prefetch_id: String,
+}
+
+impl App {
+    pub(crate) fn resource(&self) -> Resource {
+        Resource::new(
+            RawResource {
+                name: self.name.clone(),
+                uri: self.uri.to_string(),
+                mime_type: None,
+                // TODO: load all this from a manifest file
+                title: None,
+                description: self.description.clone(),
+                icons: None,
+                size: None,
+                meta: None,
+            },
+            None,
+        )
+    }
+}
+
+pub(crate) enum AppTarget {
+    AppsSDK,
+    MCPApps,
+}
+
+impl TryFrom<Extensions> for AppTarget {
+    type Error = McpError;
+
+    fn try_from(extensions: Extensions) -> Result<Self, Self::Error> {
+        let app_target_param = extensions
+            .get::<axum::http::request::Parts>()
+            .and_then(|parts| parts.uri.query())
+            .and_then(|query| {
+                url::form_urlencoded::parse(query.as_bytes())
+                    .find(|(key, _)| key == "appTarget")
+                    .map(|(_, value)| value.into_owned())
+            });
+
+        match app_target_param {
+            Some(app_target) if app_target.to_lowercase() == "openai" => Ok(AppTarget::AppsSDK),
+            Some(app_target) if app_target.to_lowercase() == "mcp" => Ok(AppTarget::MCPApps),
+            Some(app_target) => Err(McpError::new(
+                ErrorCode::INVALID_REQUEST,
+                format!(
+                    "App target {app_target} not recognized. Valid values are 'openai' or 'mcp'."
+                ),
+                None,
+            )),
+            // TODO: In the future, once host capabilities are advertised, we should try auto detection before defaulting to apps sdk
+            None => Ok(AppTarget::AppsSDK),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_app_target_openai_lowercase() {
+        let mut extensions = Extensions::new();
+        let request = axum::http::Request::builder()
+            .uri("http://localhost?appTarget=openai")
+            .body(())
+            .unwrap();
+        let (parts, _) = request.into_parts();
+        extensions.insert(parts);
+
+        let app_target = AppTarget::try_from(extensions).unwrap();
+        assert!(matches!(app_target, AppTarget::AppsSDK));
+    }
+
+    #[test]
+    fn test_app_target_openai_uppercase() {
+        let mut extensions = Extensions::new();
+        let request = axum::http::Request::builder()
+            .uri("http://localhost?appTarget=OPENAI")
+            .body(())
+            .unwrap();
+        let (parts, _) = request.into_parts();
+        extensions.insert(parts);
+
+        let app_target = AppTarget::try_from(extensions).unwrap();
+        assert!(matches!(app_target, AppTarget::AppsSDK));
+    }
+
+    #[test]
+    fn test_app_target_mcp_lowercase() {
+        let mut extensions = Extensions::new();
+        let request = axum::http::Request::builder()
+            .uri("http://localhost?appTarget=mcp")
+            .body(())
+            .unwrap();
+        let (parts, _) = request.into_parts();
+        extensions.insert(parts);
+
+        let app_target = AppTarget::try_from(extensions).unwrap();
+        assert!(matches!(app_target, AppTarget::MCPApps));
+    }
+
+    #[test]
+    fn test_app_target_mcp_uppercase() {
+        let mut extensions = Extensions::new();
+        let request = axum::http::Request::builder()
+            .uri("http://localhost?appTarget=MCP")
+            .body(())
+            .unwrap();
+        let (parts, _) = request.into_parts();
+        extensions.insert(parts);
+
+        let app_target = AppTarget::try_from(extensions).unwrap();
+        assert!(matches!(app_target, AppTarget::MCPApps));
+    }
+
+    #[test]
+    fn test_app_target_invalid_value() {
+        let mut extensions = Extensions::new();
+        let request = axum::http::Request::builder()
+            .uri("http://localhost?appTarget=invalid")
+            .body(())
+            .unwrap();
+        let (parts, _) = request.into_parts();
+        extensions.insert(parts);
+
+        let result = AppTarget::try_from(extensions);
+        assert!(result.is_err());
+        let err = result.err().unwrap();
+        assert_eq!(err.code, ErrorCode::INVALID_REQUEST);
+        assert!(
+            err.message
+                .contains("App target invalid not recognized. Valid values are 'openai' or 'mcp'.")
+        );
+    }
+
+    #[test]
+    fn test_app_target_missing_defaults_to_apps_sdk() {
+        let mut extensions = Extensions::new();
+        let request = axum::http::Request::builder()
+            .uri("http://localhost")
+            .body(())
+            .unwrap();
+        let (parts, _) = request.into_parts();
+        extensions.insert(parts);
+
+        let app_target = AppTarget::try_from(extensions).unwrap();
+        assert!(matches!(app_target, AppTarget::AppsSDK));
+    }
+}

--- a/crates/apollo-mcp-server/src/apps/mod.rs
+++ b/crates/apollo-mcp-server/src/apps/mod.rs
@@ -1,0 +1,7 @@
+pub(crate) mod app;
+pub(crate) mod manifest;
+pub(crate) mod resource;
+pub(crate) mod tool;
+
+pub(crate) use app::App;
+pub(crate) use manifest::load_from_path;

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -22,10 +22,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error};
 use url::Url;
 
-use crate::apps::{
-    attach_resource_mime_type, attach_tool_metadata, find_and_execute_app, get_app_resource,
-    get_app_target, make_tool_private,
-};
+use crate::apps::app::AppTarget;
+use crate::apps::resource::{attach_resource_mime_type, get_app_resource};
+use crate::apps::tool::{attach_tool_metadata, find_and_execute_app_tool, make_tool_private};
 use crate::generated::telemetry::{TelemetryAttribute, TelemetryMetric};
 use crate::meter;
 use crate::operations::{execute_operation, find_and_execute_operation};
@@ -210,7 +209,7 @@ impl Running {
                     .find(|(key, _)| key == "app")
                     .map(|(_, value)| value.into_owned())
             });
-        let app_target = get_app_target(extensions)?;
+        let app_target = AppTarget::try_from(extensions)?;
 
         // If we get the app param, we'll run in a special "app mode" where we only expose the tools for that app (+execute)
         if let Some(app_name) = app_param {
@@ -272,7 +271,7 @@ impl Running {
     }
 
     fn list_resources_impl(&self, extensions: Extensions) -> Result<ListResourcesResult, McpError> {
-        let app_target = get_app_target(extensions)?;
+        let app_target = AppTarget::try_from(extensions)?;
 
         Ok(ListResourcesResult {
             resources: self
@@ -296,7 +295,7 @@ impl Running {
                 None,
             )
         })?;
-        let app_target = get_app_target(extensions)?;
+        let app_target = AppTarget::try_from(extensions)?;
 
         let resource = get_app_resource(&self.apps, request, request_uri, &app_target).await?;
 
@@ -418,7 +417,7 @@ impl ServerHandler for Running {
             {
                 res
             } else if let Some(app_name) = app_param
-                && let Some(res) = find_and_execute_app(
+                && let Some(res) = find_and_execute_app_tool(
                     &self.apps,
                     &app_name,
                     &tool_name,
@@ -536,7 +535,11 @@ fn convert_arguments<T: serde::de::DeserializeOwned>(
 mod tests {
     use rmcp::model::{JsonObject, ReadResourceRequestParam, ResourceContents, Tool};
 
-    use crate::apps::{App, AppLabels, AppResource, AppTool, CSPSettings, WidgetSettings};
+    use crate::apps::{
+        App,
+        app::{AppResource, AppTool},
+        manifest::{AppLabels, CSPSettings, WidgetSettings},
+    };
 
     use super::*;
 


### PR DESCRIPTION
- Refactor apps code into app, manifest, resource, and tool
- Add additional tests for app_target
- Some minor function renames
- `get_app_target` refactored to `AppTarget::try_from`