### PR TITLE
[docs] Fixing broken link in config-file.mdx

### DIFF
--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -7,7 +7,7 @@ redirectFrom:
 
 You can configure Apollo MCP Server using a configuration file. You can also [override configuration options using environment variables](#override-configuration-options-using-environment-variables).
 
-See the [example config file](#example-config-files) for an example.
+See the [example config files](#example-config-files) for an example.
 
 ## Configuration options
 


### PR DESCRIPTION
Fixing a broken link to the example config files in the introduction paragraph.