### PR TITLE
Update release workflows for unique branch names

### DIFF
--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -5,6 +5,12 @@ on:
     types: [closed]
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to publish (e.g., 1.6.0)
+        required: true
+        type: string
   workflow_call:
     inputs:
       version:

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -5,6 +5,12 @@ on:
     types: [closed]
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to publish (e.g., 1.6.0)
+        required: true
+        type: string
   workflow_call:
     inputs:
       version:


### PR DESCRIPTION
PR #581 changed the Prepare Release workflow to create unique branch names like `release/1.6.0` instead of reusing a single `release` branch. However, the release workflows weren't updated to match, so they still checked. This caused the v1.6.0 release workflows to not trigger when the release PR was merged.