### PR TITLE
fix(ci): remove manual release workflow trigger

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -5,12 +5,6 @@ on:
     types: [closed]
     branches:
       - main
-  workflow_dispatch:
-    inputs:
-      version:
-        description: Version to publish (e.g., 1.6.0)
-        required: true
-        type: string
   workflow_call:
     inputs:
       version:
@@ -24,7 +18,7 @@ env:
 
 jobs:
   get-version:
-    # Run on PR merge from release branch, workflow_dispatch, or workflow_call
+    # Run on PR merge from release branch or workflow_call
     if: (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')) || inputs.version
     runs-on: ubuntu-latest
     outputs:
@@ -41,28 +35,14 @@ jobs:
         id: store-version
         run: |
           if [ -n "${{ inputs.version }}" ]; then
-            echo "version=v${{ inputs.version }}" >> $GITHUB_OUTPUT
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
           else
             echo "version=v$(knope get-version)" >> $GITHUB_OUTPUT
-          fi
-  validate-version:
-    name: Validate version format
-    runs-on: ubuntu-24.04
-    if: ${{ inputs.version }}
-    steps:
-      - name: Validate version pattern
-        run: |
-          if ! echo "${{ inputs.version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+\.[0-9]+)?$'; then
-            echo "Error: Version must match pattern: X.Y.Z or X.Y.Z-prerelease.N"
-            echo "Examples: 1.2.1, 2.0.0"
-            echo "Do NOT include the 'v' prefix"
-            echo "Provided: ${{ inputs.version }}"
-            exit 1
           fi
   # Build a container for x86_64 and aarch64 linux
   build:
     name: Release Container
-    needs: [get-version, validate-version]
+    needs: get-version
     strategy:
       matrix:
         include:


### PR DESCRIPTION
This pr removes the `workflow_dispatch` trigger that was added for the v1.6.0 release in PR #595.

The core release workflows (`release-container.yml`, `release-bins.yml`) should not be triggered manually—they should always be called by entry point workflows.

#### Changes
- Removed `workflow_dispatch` trigger from `release-container.yml`
- Updated comment to reflect the remaining triggers (PR merge, `workflow_call`)

#### Verification
- [x] Canary builds still work (`release-canary.yml` passes version via `workflow_call`)
- [x] Stable releases still work (PR merge from `release/` branch works)
- [x] No manual trigger available (as is intended)