### PR TITLE
docs: align discovery docs with RFC 8414/OIDC behavior

### DIFF
--- a/docs/source/auth.mdx
+++ b/docs/source/auth.mdx
@@ -76,7 +76,7 @@ transport:
 ```
 
 **Considerations:**
-- Discovery happens during token validation and can add latency to the first authorized request
-- With multiple fallback URLs (RFC 8414, OIDC Discovery), the cumulative timeout can be 10-15 seconds if all URLs fail
-- Increase the timeout if your OAuth server is on a slow network or responds slowly
-- Decrease the timeout in high-performance environments where fast failure is preferred
+- Discovery happens during token validation and can add latency to the first authorized request.
+- With multiple fallback URLs (RFC 8414, OIDC Discovery), the cumulative timeout can be 10-15 seconds if all URLs fail.
+- Increase the timeout if your OAuth server is on a slow network or responds slowly.
+- Decrease the timeout in high-performance environments where fast failure is preferred.

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -245,7 +245,7 @@ These fields are under the top-level `transport` key, nested under the `auth` ke
 
 | Option                            | Type           | Default | Description                                                                                                                                       |
 | :-------------------------------- | :------------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `servers`                         | `List<URL>`    |         | List of upstream delegated OAuth servers (must support RFC 8414 or OIDC metadata discovery endpoint)                                               |
+| `servers`                         | `List<URL>`    |         | List of upstream delegated OAuth servers (must support RFC 8414 or OIDC metadata discovery endpoint).                                              |
 | `audiences`                       | `List<string>` | `[]`    | List of accepted audiences from upstream signed JWTs (ignored if `allow_any_audience` is `true`)                                                  |
 | `allow_any_audience`              | `bool`         | `false` | Set to `true` to skip audience validation entirely (use with caution)                                                                             |
 | `resource`                        | `string`       |         | The externally available URL pointing to this MCP server. Can be `localhost` when testing locally.                                                |
@@ -263,7 +263,7 @@ transport:
   type: streamable_http
   auth:
     # List of upstream delegated OAuth servers
-    # Note: These need to support RFC 8414 or OIDC metadata discovery
+    # These must support RFC 8414 or OIDC metadata discovery.
     servers:
       - https://auth.example.com
 


### PR DESCRIPTION
ref DXM-349



  **Summary**

  - Clarify that auth.servers must support RFC 8414 or OIDC discovery.
  - Update discovery timeout guidance to reflect per-request discovery during token validation.

  **Details**

  - Updated config docs note and table entry for servers.
  - Adjusted auth guide “Discovery timeout” considerations to avoid implying one-time startup discovery or cached JWKS behavior.
  
  **References in Source Code**
    - “Supports RFC 8414 or OIDC discovery” and “multiple discovery URL patterns in sequence”:
      - crates/apollo-mcp-server/src/auth/networked_token_validator.rs:44-115 (builds RFC 8414 + OIDC URLs, ordered)
      - crates/apollo-mcp-server/src/auth/networked_token_validator.rs:115-147 (tries each URL sequentially until one succeeds)
  - “Discovery happens during token validation and can add latency to the first authorized request”:
      - crates/apollo-mcp-server/src/auth/valid_token.rs:51-139 (validation path calls get_key)
      - crates/apollo-mcp-server/src/auth/networked_token_validator.rs:163-165 (get_key triggers discovery)
      - crates/apollo-mcp-server/src/auth/networked_token_validator.rs:125-141 (per-URL timeout during discovery)

