### PR TITLE
Remove workflow_dispatch from release-bins job

### DIFF
--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -5,12 +5,6 @@ on:
     types: [closed]
     branches:
       - main
-  workflow_dispatch:
-    inputs:
-      version:
-        description: Version to publish (e.g., 1.6.0)
-        required: true
-        type: string
   workflow_call:
     inputs:
       version:


### PR DESCRIPTION
Quick follow-up to #597. Removes the workflow_dispatch trigger from `release-bins.yml` for consistency with `release-container.yml`.