### PR TITLE
fix(telemetry): capture return values in tool execution spans

### DIFF
--- a/crates/apollo-mcp-server/src/introspection/tools/execute.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/execute.rs
@@ -1,14 +1,16 @@
-use crate::operations::{MutationMode, operation_defs, operation_name};
+use crate::operations::{MutationMode, execute_operation, operation_defs, operation_name};
 use crate::{
+    errors::McpError,
     graphql::{self, OperationDetails, ValidationError},
     schema_from_type,
 };
 use reqwest::header::{HeaderMap, HeaderValue};
-use rmcp::model::Tool;
+use rmcp::model::{CallToolResult, JsonObject, Tool};
 use rmcp::schemars::JsonSchema;
 use rmcp::serde_json::Value;
 use rmcp::{schemars, serde_json};
 use serde::Deserialize;
+use url::Url;
 
 /// The name of the tool to execute an ad hoc GraphQL operation
 pub const EXECUTE_TOOL_NAME: &str = "execute";
@@ -40,6 +42,16 @@ impl Execute {
                 schema_from_type!(Input),
             ),
         }
+    }
+
+    #[tracing::instrument(skip(self, headers, endpoint), ret)]
+    pub async fn execute(
+        &self,
+        headers: &HeaderMap<HeaderValue>,
+        arguments: Option<&JsonObject>,
+        endpoint: &Url,
+    ) -> Result<CallToolResult, McpError> {
+        execute_operation(self, headers, arguments, endpoint).await
     }
 }
 

--- a/crates/apollo-mcp-server/src/introspection/tools/introspect.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/introspect.rs
@@ -55,7 +55,7 @@ impl Introspect {
         }
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self), ret)]
     pub async fn execute(&self, input: Input) -> Result<CallToolResult, McpError> {
         let schema = self.schema.read().await;
         let type_name = input.type_name.as_str();
@@ -316,4 +316,6 @@ mod tests {
             "Should contain Mutation type definition"
         );
     }
+
+
 }

--- a/crates/apollo-mcp-server/src/introspection/tools/introspect.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/introspect.rs
@@ -316,6 +316,4 @@ mod tests {
             "Should contain Mutation type definition"
         );
     }
-
-
 }

--- a/crates/apollo-mcp-server/src/introspection/tools/search.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/search.rs
@@ -87,7 +87,7 @@ impl Search {
         })
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self), ret)]
     pub async fn execute(&self, input: Input) -> Result<CallToolResult, McpError> {
         let mut root_paths = self
             .index

--- a/crates/apollo-mcp-server/src/introspection/tools/validate.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/validate.rs
@@ -44,7 +44,7 @@ impl Validate {
     }
 
     /// Validates the provided GraphQL query
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self), ret)]
     pub async fn execute(&self, input: Value) -> CallToolResult {
         let input = match serde_json::from_value::<Input>(input) {
             Ok(i) => i,

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -387,12 +387,9 @@ impl ServerHandler for Running {
                     self.headers.clone()
                 };
 
-            execute_tool.execute(
-                &headers,
-                request.arguments.as_ref(),
-                &self.endpoint,
-            )
-            .await
+            execute_tool
+                .execute(&headers, request.arguments.as_ref(), &self.endpoint)
+                .await
         } else if tool_name == VALIDATE_TOOL_NAME
             && let Some(validate_tool) = &self.validate_tool
         {

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -27,7 +27,7 @@ use crate::apps::resource::{attach_resource_mime_type, get_app_resource};
 use crate::apps::tool::{attach_tool_metadata, find_and_execute_app_tool, make_tool_private};
 use crate::generated::telemetry::{TelemetryAttribute, TelemetryMetric};
 use crate::meter;
-use crate::operations::{execute_operation, find_and_execute_operation};
+use crate::operations::find_and_execute_operation;
 use crate::server::states::telemetry::get_parent_span;
 use crate::server_info::ServerInfoConfig;
 use crate::{
@@ -387,8 +387,7 @@ impl ServerHandler for Running {
                     self.headers.clone()
                 };
 
-            execute_operation(
-                execute_tool,
+            execute_tool.execute(
                 &headers,
                 request.arguments.as_ref(),
                 &self.endpoint,


### PR DESCRIPTION
<!--https://apollographql.atlassian.net/browse/AMS-391-->

## Summary
This PR updates the tracing instrumentation for all introspection tools (`introspect`, `execute`, `search`, `validate`) to capture their return values in OpenTelemetry spans. This improves observability and aligns the server with [OpenInference semantics](https://arize-ai.github.io/openinference/spec/semantic_conventions.html).

## Changes
- **Introspection Tools:** Added the `ret` argument to `#[tracing::instrument]` in `introspect.rs`, `search.rs`, and `validate.rs` to automatically record return values.
- **Execute Tool:**`Execute` now uses a dedicated `execute()` instance method with tracing that wraps the `execute_operation` logic, allowing us to trace the tool invocation without adding noise to internal operation calls.

## Fixes
Fixes #604