### PR TITLE
ci: run e2e tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,24 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: codecov.json
           fail_ci_if_error: true
+
+  e2e:
+    name: End-to-End Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Run e2e tests (local-operations)
+        run: ./e2e/mcp-server-tester/run_tests.sh local-operations
+
+      - name: Run e2e tests (pq-manifest)
+        run: ./e2e/mcp-server-tester/run_tests.sh pq-manifest

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ target/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Generated e2e test configs
+e2e/**/config.generated.yaml

--- a/e2e/mcp-server-tester/local-operations/config.yaml
+++ b/e2e/mcp-server-tester/local-operations/config.yaml
@@ -4,10 +4,10 @@ transport:
 operations:
   source: local
   paths:
-    - ./local-operations/operations
+    - <test-dir>/operations
 schema:
   source: local
-  path: ./local-operations/api.graphql
+  path: <test-dir>/api.graphql
 overrides:
   mutation_mode: all
 introspection:

--- a/e2e/mcp-server-tester/pq-manifest/config.yaml
+++ b/e2e/mcp-server-tester/pq-manifest/config.yaml
@@ -3,10 +3,10 @@ transport:
   type: stdio
 operations:
   source: manifest
-  path: ./pq-manifest/apollo.json
+  path: <test-dir>/apollo.json
 schema:
   source: local
-  path: ./pq-manifest/api.graphql
+  path: <test-dir>/api.graphql
 overrides:
   mutation_mode: all
 introspection:

--- a/e2e/mcp-server-tester/server-config.template.json
+++ b/e2e/mcp-server-tester/server-config.template.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "mcp-server": {
-      "command": "../../target/release/apollo-mcp-server",
-      "args": ["./<test-dir>/config.yaml"]
+      "command": "<bin-path>",
+      "args": ["<test-dir>/config.generated.yaml"]
     }
   }
 }


### PR DESCRIPTION
Adds new e2e job to ci.yml that runs mcp-server-tester for both local-operations and pq-manifest test suites. Also Fixed path resolution bug in that overwrote TEST_DIR and bumped mcp-server-tester from 1.4.0 to 1.4.1.

## Testing
The tests ran successfully on this PR: https://github.com/apollographql/apollo-mcp-server/actions/runs/21687772789/job/62539292043?pr=620