### PR TITLE
When calculating app target, attempt to autodetect from advertised capabilities if not specified in url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,6 +647,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +842,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,7 +938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -1573,6 +1593,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core 0.10.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,6 +2086,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2344,6 +2384,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "levenshtein"
@@ -3392,6 +3438,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3428,6 +3485,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_distr"
@@ -3679,12 +3742,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a621b37a548ff6ab6292d57841eb25785a7f146d89391a19c9f199414bd13da"
+checksum = "cc4c9c94680f75470ee8083a0667988b5d7b5beb70b9f998a8e51de7c682ce60"
 dependencies = [
  "async-trait",
- "axum",
  "base64",
  "bytes",
  "chrono",
@@ -3694,7 +3756,7 @@ dependencies = [
  "http-body-util",
  "pastey",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.10.0",
  "rmcp-macros",
  "schemars",
  "serde",
@@ -3711,9 +3773,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b79ed92303f9262db79575aa8c3652581668e9d136be6fd0b9ededa78954c95"
+checksum = "90c23c8f26cae4da838fbc3eadfaecf2d549d97c04b558e7bd90526a9c28b42a"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -4166,7 +4228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4177,7 +4239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5286,6 +5348,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5342,6 +5413,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -5740,6 +5845,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.114",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -47,7 +47,7 @@ regex = "1.11.1"
 reqwest-middleware = "0.4.2"
 reqwest-tracing = { version = "0.5.8", features = ["opentelemetry_0_30"] }
 reqwest.workspace = true
-rmcp = { version = "0.14", features = [
+rmcp = { version = "0.16", features = [
   "server",
   "transport-io",
   "transport-streamable-http-server",

--- a/crates/apollo-mcp-server/src/apps/manifest.rs
+++ b/crates/apollo-mcp-server/src/apps/manifest.rs
@@ -133,6 +133,7 @@ pub(crate) fn load_from_path(
                     output_schema: operation.tool.output_schema.clone(),
                     annotations: operation.tool.annotations.clone(),
                     icons: operation.tool.icons.clone(),
+                    execution: None,
                 };
 
                 tools.push(AppTool {

--- a/crates/apollo-mcp-server/src/apps/resource.rs
+++ b/crates/apollo-mcp-server/src/apps/resource.rs
@@ -186,7 +186,7 @@ mod tests {
             .unwrap();
         let (parts, _) = request.into_parts();
         extensions.insert(parts);
-        let app_target = AppTarget::try_from(extensions);
+        let app_target = AppTarget::try_from((extensions, None));
 
         assert!(app_target.is_err());
         assert_eq!(

--- a/crates/apollo-mcp-server/src/operations/operation.rs
+++ b/crates/apollo-mcp-server/src/operations/operation.rs
@@ -837,6 +837,7 @@ mod tests {
                     open_world_hint: None,
                 },
             ),
+            execution: None,
             icons: None,
             meta: None,
         }
@@ -976,6 +977,7 @@ mod tests {
                     open_world_hint: None,
                 },
             ),
+            execution: None,
             icons: None,
             meta: None,
         }
@@ -1126,6 +1128,7 @@ mod tests {
                     open_world_hint: None,
                 },
             ),
+            execution: None,
             icons: None,
             meta: None,
         }
@@ -1279,6 +1282,7 @@ mod tests {
                     open_world_hint: None,
                 },
             ),
+            execution: None,
             icons: None,
             meta: None,
         }
@@ -1429,6 +1433,7 @@ mod tests {
                     open_world_hint: None,
                 },
             ),
+            execution: None,
             icons: None,
             meta: None,
         }
@@ -1576,6 +1581,7 @@ mod tests {
                     open_world_hint: None,
                 },
             ),
+            execution: None,
             icons: None,
             meta: None,
         }
@@ -1733,6 +1739,7 @@ mod tests {
                     open_world_hint: None,
                 },
             ),
+            execution: None,
             icons: None,
             meta: None,
         }
@@ -1905,6 +1912,7 @@ mod tests {
                     open_world_hint: None,
                 },
             ),
+            execution: None,
             icons: None,
             meta: None,
         }
@@ -2042,6 +2050,7 @@ mod tests {
                     open_world_hint: None,
                 },
             ),
+            execution: None,
             icons: None,
             meta: None,
         }
@@ -2290,6 +2299,7 @@ mod tests {
                     open_world_hint: None,
                 },
             ),
+            execution: None,
             icons: None,
             meta: None,
         }
@@ -2430,6 +2440,7 @@ mod tests {
                     open_world_hint: None,
                 },
             ),
+            execution: None,
             icons: None,
             meta: None,
         }
@@ -2574,6 +2585,7 @@ mod tests {
                     open_world_hint: None,
                 },
             ),
+            execution: None,
             icons: None,
             meta: None,
         }
@@ -2707,6 +2719,7 @@ mod tests {
                     open_world_hint: None,
                 },
             ),
+            execution: None,
             icons: None,
             meta: None,
         }
@@ -3238,6 +3251,7 @@ mod tests {
                     open_world_hint: None,
                 },
             ),
+            execution: None,
             icons: None,
             meta: None,
         }
@@ -3365,6 +3379,7 @@ mod tests {
                     open_world_hint: None,
                 },
             ),
+            execution: None,
             icons: None,
             meta: None,
         }
@@ -3926,6 +3941,7 @@ mod tests {
                     open_world_hint: None,
                 },
             ),
+            execution: None,
             icons: None,
             meta: None,
         }
@@ -4114,6 +4130,7 @@ mod tests {
                     open_world_hint: None,
                 },
             ),
+            execution: None,
             icons: None,
             meta: None,
         }
@@ -4317,6 +4334,7 @@ mod tests {
                         open_world_hint: None,
                     },
                 ),
+                execution: None,
                 icons: None,
                 meta: None,
             },
@@ -4446,6 +4464,7 @@ mod tests {
                         open_world_hint: None,
                     },
                 ),
+                execution: None,
                 icons: None,
                 meta: None,
             },
@@ -4575,6 +4594,7 @@ mod tests {
                     open_world_hint: None,
                 },
             ),
+            execution: None,
             icons: None,
             meta: None,
         }


### PR DESCRIPTION
When calculating app target, attempt to autodetect from advertised capabilities if not specified in url.

Note this PR also updated rmcp to latest (0.14 -> 0.16)

Changelogs:
- https://github.com/modelcontextprotocol/rust-sdk/releases/tag/rmcp-v0.15.0
- https://github.com/modelcontextprotocol/rust-sdk/releases/tag/rmcp-v0.16.0
