### PR TITLE
Change JSON schema type mapping for Int and Float

### DIFF
--- a/crates/apollo-mcp-server/src/operations/schema_walker/name.rs
+++ b/crates/apollo-mcp-server/src/operations/schema_walker/name.rs
@@ -40,7 +40,8 @@ impl From<Name<'_>> for JSONSchema {
         let result = match name.as_str() {
             // Basic types map nicely
             "String" | "ID" => json_schema!({"type": "string"}),
-            "Int" | "Float" => json_schema!({"type": "number"}),
+            "Float" => json_schema!({"type": "number"}),
+            "Int" => json_schema!({"type": "integer"}),
             "Boolean" => json_schema!({"type": "boolean"}),
 
             // If we've already cached it, then return the reference immediately


### PR DESCRIPTION
GraphQL servers are strict about Int types. Mapping Int to `{ "type": "integer" }` forces MCP clients to send integers instead of floats (1234.0).
We get this error when using ChatGPT as a MCP client:
```
invalid input value at `$input.chartSettings.entities[0].dataSeries[0].id`: found JSON number for GraphQL type `Int!
```
The proposed change fixed the error.