### PR TITLE
test: do tool calls improve with openai input schema style?

### DIFF
--- a/crates/apollo-mcp-server/src/json_schema.rs
+++ b/crates/apollo-mcp-server/src/json_schema.rs
@@ -16,14 +16,19 @@ macro_rules! schema_from_type {
 
 #[cfg(test)]
 mod tests {
-    use schemars::JsonSchema;
+    use schemars::{JsonSchema, Schema, SchemaGenerator};
     use serde::Deserialize;
     use serde_json::Value;
 
     #[derive(JsonSchema, Deserialize)]
     struct TestInput {
         #[allow(dead_code)]
-        field: String,
+        #[schemars(schema_with = "option_schema")]
+        pub field: Option<String>,
+    }
+
+    fn option_schema(generator: &mut SchemaGenerator) -> Schema {
+        Option::<String>::json_schema(generator)
     }
 
     #[test]
@@ -38,7 +43,7 @@ mod tests {
                 "type": "object",
                 "properties": {
                     "field": {
-                        "type": "string"
+                        "type": ["string","null"]
                     }
                 },
                 "required": ["field"]

--- a/crates/apollo-mcp-server/src/json_schema.rs
+++ b/crates/apollo-mcp-server/src/json_schema.rs
@@ -16,19 +16,14 @@ macro_rules! schema_from_type {
 
 #[cfg(test)]
 mod tests {
-    use schemars::{JsonSchema, Schema, SchemaGenerator};
+    use schemars::JsonSchema;
     use serde::Deserialize;
     use serde_json::Value;
 
     #[derive(JsonSchema, Deserialize)]
     struct TestInput {
         #[allow(dead_code)]
-        #[schemars(schema_with = "option_schema")]
-        pub field: Option<String>,
-    }
-
-    fn option_schema(generator: &mut SchemaGenerator) -> Schema {
-        Option::<String>::json_schema(generator)
+        field: String,
     }
 
     #[test]

--- a/crates/apollo-mcp-server/src/json_schema.rs
+++ b/crates/apollo-mcp-server/src/json_schema.rs
@@ -38,7 +38,7 @@ mod tests {
                 "type": "object",
                 "properties": {
                     "field": {
-                        "type": ["string","null"]
+                        "type": "string"
                     }
                 },
                 "required": ["field"]

--- a/crates/apollo-mcp-server/src/operations/operation.rs
+++ b/crates/apollo-mcp-server/src/operations/operation.rs
@@ -95,7 +95,6 @@ impl Operation {
                 )
             });
 
-            // here!
             let mut object = serde_json::to_value(get_json_schema(
                 &operation,
                 tree_shaker.argument_descriptions(),

--- a/crates/apollo-mcp-server/src/operations/operation.rs
+++ b/crates/apollo-mcp-server/src/operations/operation.rs
@@ -95,6 +95,7 @@ impl Operation {
                 )
             });
 
+            // here!
             let mut object = serde_json::to_value(get_json_schema(
                 &operation,
                 tree_shaker.argument_descriptions(),
@@ -605,6 +606,13 @@ fn get_json_schema(
                 custom_scalar_map,
                 description,
             );
+
+            let nested = if variable.ty.is_non_null() {
+                nested
+            } else {
+                json_schema!({"oneOf": [nested, {"type": "null"}]})
+            };
+
             schema
                 .ensure_object()
                 .entry("properties")
@@ -613,15 +621,18 @@ fn get_json_schema(
                 .get_or_insert(&mut Map::default())
                 .insert(variable_name.clone(), nested.into());
 
-            if variable.ty.is_non_null() {
-                schema
-                    .ensure_object()
-                    .entry("required")
-                    .or_insert(serde_json::Value::Array(Vec::new()))
-                    .as_array_mut()
-                    .get_or_insert(&mut Vec::default())
-                    .push(variable_name.into());
-            }
+            schema
+                .ensure_object()
+                .entry("additionalProperties")
+                .or_insert(serde_json::Value::Bool(false));
+
+            schema
+                .ensure_object()
+                .entry("required")
+                .or_insert(serde_json::Value::Array(Vec::new()))
+                .as_array_mut()
+                .get_or_insert(&mut Vec::default())
+                .push(variable_name.into());
         }
     });
 
@@ -754,9 +765,20 @@ mod tests {
                 "type": String("object"),
                 "properties": Object {
                     "id": Object {
-                        "type": String("string"),
+                        "oneOf": Array [
+                            Object {
+                                "type": String("string"),
+                            },
+                            Object {
+                                "type": String("null"),
+                            },
+                        ],
                     },
                 },
+                "additionalProperties": Bool(false),
+                "required": Array [
+                    String("id"),
+                ],
             },
             output_schema: Some(
                 {
@@ -849,11 +871,22 @@ mod tests {
         let json = to_sorted_json!(tool.input_schema);
         insta::assert_snapshot!(serde_json::to_string_pretty(&json).unwrap(), @r#"
         {
+          "additionalProperties": false,
           "properties": {
             "id": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
+          "required": [
+            "id"
+          ],
           "type": "object"
         }
         "#);
@@ -895,6 +928,7 @@ mod tests {
                         "type": String("string"),
                     },
                 },
+                "additionalProperties": Bool(false),
                 "required": Array [
                     String("id"),
                 ],
@@ -994,6 +1028,7 @@ mod tests {
               "type": "string"
             }
           },
+          "additionalProperties": false,
           "required": [
             "id"
           ]


### PR DESCRIPTION
@jerelmiller has told me that a number of tools just don't get called right by some agents, so my suspicion is that these tools first try to "just generate the tool call", and if that doesn't work apply a step similar to the Vercel SDK's `experimental_repairToolCall`, in which they probably try to call the model's variant of `generateObject` with the `inputSchema`.
In the case of OpenAI models, the JSON Schema specification for that kind of call is *very* restricted, see [their documentation](https://developers.openai.com/api/docs/guides/structured-outputs/).

Most importantly: there are no optional fields - every field has to be `required`, and `additionalProperties` always needs to be `false`.

Our schemas currently don't fit these requirements - so let's just try if that improves the situation.

Obviously, this is not a fully functional PR, and tons of tests are still failing, but it should be enough for Jerel to build this locally and try out if the quality of tool calls improves.

Note: there are a lot of additional subtleties, so please inspect the generated schema if it really matches the OpenAI requirements before drawing any conclusions from this 😅 