### PR TITLE
fix: enable TLS for OTLP HTTP exporter's internal reqwest client

### DIFF
--- a/.changeset/fix_otlp_https_export_tls.md
+++ b/.changeset/fix_otlp_https_export_tls.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Fix OTLP HTTP exporter failing to connect to HTTPS endpoints
+
+When the workspace upgraded from reqwest 0.12 to 0.13, Cargo feature unification stopped applying the workspace's TLS features to the reqwest 0.12 still used internally by opentelemetry-otlp. This left the OTLP HTTP exporter's reqwest client with no TLS backend, causing `"invalid URL, scheme is not http"` errors when exporting to any `https://` telemetry endpoint (e.g. Langfuse, New Relic). Adding the `reqwest-rustls` feature to opentelemetry-otlp restores TLS support for the internal reqwest 0.12 client.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,7 +756,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1335,7 +1335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1957,6 +1957,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2257,7 +2258,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2715,7 +2716,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3443,7 +3444,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3661,16 +3662,22 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -3939,7 +3946,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3997,7 +4004,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4655,7 +4662,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5523,7 +5530,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -38,6 +38,7 @@ opentelemetry-otlp = { version = "0.31.0", features = [
   "http-proto",
   "metrics",
   "trace",
+  "reqwest-rustls",
 ] }
 opentelemetry-semantic-conventions = "0.31.0"
 opentelemetry_sdk = { version = "0.31.0", features = [

--- a/crates/apollo-mcp-server/tests/otlp_https_export.rs
+++ b/crates/apollo-mcp-server/tests/otlp_https_export.rs
@@ -1,0 +1,76 @@
+//! Verifies that the OTLP HTTP exporter can attempt TLS connections to
+//! https:// endpoints.
+//!
+//! Before the fix, the default reqwest 0.12 client pulled in by
+//! opentelemetry-otlp had no TLS features (due to Cargo feature unification
+//! loss when the workspace moved to reqwest 0.13), causing an immediate
+//! "invalid URL, scheme is not http" error instead of a connection-level error.
+//!
+//! The opentelemetry-otlp default (`reqwest-blocking-client`) creates an
+//! internal tokio runtime inside the reqwest blocking client. That runtime
+//! cannot be created or dropped inside another tokio `block_on` context, so
+//! we run the entire export on a standalone OS thread and use
+//! `futures::executor::block_on` (not tokio) to poll the async export.
+
+use opentelemetry::trace::{SpanContext, SpanKind, Status, TraceState};
+use opentelemetry::{InstrumentationScope, SpanId, TraceFlags, TraceId};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::trace::{SpanData, SpanEvents, SpanExporter, SpanLinks};
+use std::time::SystemTime;
+
+#[test]
+fn http_protobuf_exporter_supports_https_endpoints() {
+    // Run everything on a dedicated thread so there is no ambient tokio
+    // runtime context. The reqwest-blocking-client inside opentelemetry-otlp
+    // creates its own runtime and panics if one already exists.
+    let err_msg = std::thread::spawn(|| {
+        let exporter = opentelemetry_otlp::SpanExporter::builder()
+            .with_http()
+            .with_endpoint("https://localhost:4318")
+            .build()
+            .expect("exporter should construct successfully");
+
+        let span_data = SpanData {
+            span_context: SpanContext::new(
+                TraceId::from_bytes(1u128.to_be_bytes()),
+                SpanId::from_bytes(1u64.to_be_bytes()),
+                TraceFlags::default(),
+                false,
+                TraceState::default(),
+            ),
+            parent_span_id: SpanId::INVALID,
+            parent_span_is_remote: false,
+            span_kind: SpanKind::Internal,
+            name: "test-span".into(),
+            start_time: SystemTime::now(),
+            end_time: SystemTime::now(),
+            attributes: vec![],
+            dropped_attributes_count: 0,
+            events: SpanEvents::default(),
+            links: SpanLinks::default(),
+            status: Status::Ok,
+            instrumentation_scope: InstrumentationScope::builder("test").build(),
+        };
+
+        // Export the span. Nothing is listening, so this will fail — but
+        // the error type tells us whether TLS is configured.
+        //
+        // Use futures::executor instead of tokio::block_on because the
+        // reqwest-blocking-client inside otel creates its own tokio runtime
+        // and panics if nested inside another one.
+        let result = futures::executor::block_on(exporter.export(vec![span_data]));
+        let err = result.expect_err("export to non-listening endpoint should fail");
+        format!("{err:?}")
+    })
+    .join()
+    .expect("test thread panicked");
+
+    assert!(
+        !err_msg.contains("scheme is not http"),
+        "TLS connector is missing — the default reqwest client used by \
+         opentelemetry-otlp has no TLS support. This is caused by Cargo \
+         feature unification loss when reqwest 0.12 (used by otel) and \
+         reqwest 0.13 (workspace) coexist. Add the `reqwest-rustls` feature \
+         to opentelemetry-otlp to fix. Error was: {err_msg}"
+    );
+}


### PR DESCRIPTION
## Summary

- Fixes #694
- Adds `reqwest-rustls` feature to `opentelemetry-otlp` to restore TLS support for the internal `reqwest 0.12` client that lost it after the workspace reqwest 0.13 upgrade (PR #610)
- Adds a regression test that verifies HTTPS OTLP export attempts reach the connection layer rather than failing with `"scheme is not http"`

## Root Cause

PR #610 upgraded the workspace `reqwest` from `0.12` to `0.13`. Before this, Cargo's feature unification merged the workspace's TLS features onto the same `reqwest 0.12` that `opentelemetry-otlp` uses internally. After the upgrade, `0.12` and `0.13` are separate semver-incompatible crates — no unification occurs. The OTLP exporter's `reqwest 0.12` was left with only the `blocking` feature and zero TLS support.

## Changes

| File | Change |
|---|---|
| `crates/apollo-mcp-server/Cargo.toml` | Add `reqwest-rustls` feature to `opentelemetry-otlp` |
| `Cargo.lock` | Updated dependency resolution |
| `crates/apollo-mcp-server/tests/otlp_https_export.rs` | Regression test for HTTPS OTLP export |
| `.changeset/fix_otlp_https_export_tls.md` | Changeset for release notes |

## Verification

```
# Before fix
reqwest v0.12.28 features=blocking

# After fix
reqwest v0.12.28 features=blocking,rustls-tls-native-roots,__rustls,__tls,...
```

Test reproduces the exact user error without the fix:
```
"invalid URL, scheme is not http"
```