### PR TITLE
ci: add workflow to notify skills repo on release

### DIFF
--- a/.github/workflows/notify-skills.yml
+++ b/.github/workflows/notify-skills.yml
@@ -25,7 +25,7 @@ jobs:
           client-payload: |-
             {
               "product": "apollo-mcp-server",
-              "version": "${{ github.event.release.tag_name }}",
-              "repository": "${{ github.repository }}",
-              "sender": "${{ github.actor }}"
+              "version": ${{ toJSON(github.event.release.tag_name) }},
+              "repository": ${{ toJSON(github.repository) }},
+              "sender": ${{ toJSON(github.actor) }}
             }


### PR DESCRIPTION
When apollo-mcp-server publishes a stable release, the skills repo needs to know so it can check whether the apollo-mcp-server skill is still accurate. This adds a lightweight workflow that dispatches a `product-update` event to `apollographql/skills` on every non-pre-release publish. The event payload includes metadata for [the receiving workflow](https://github.com/apollographql/skills/blob/main/.github/workflows/ai-skill-sync.yml) to triage and, if needed, generate an AI-powered skill update PR.