### PR TITLE
deps: upgrade rmcp from 0.17 to 1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3885,9 +3885,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.17.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0ce46f9101dc911f07e1468084c057839d15b08040d110820c5513312ef56a"
+checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
 dependencies = [
  "async-trait",
  "base64",
@@ -3916,9 +3916,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.17.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abad6f5f46e220e3bda2fc90fd1ad64c1c2a2bd716d52c845eb5c9c64cda7542"
+checksum = "ab9d95d7ed26ad8306352b0d5f05b593222b272790564589790d210aa15caa9e"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ insta = { version = "1.43.1", features = [
   "yaml",
   "glob",
 ] }
-rmcp = { version = "0.17", features = [
+rmcp = { version = "1.2", features = [
   "server",
   "transport-io",
   "transport-streamable-http-server",

--- a/crates/apollo-mcp-server/src/apps/app.rs
+++ b/crates/apollo-mcp-server/src/apps/app.rs
@@ -252,10 +252,8 @@ mod tests {
                 .unwrap()
                 .clone(),
         );
-        let client_capabilities = ClientCapabilities {
-            extensions: Some(extension_capabilities),
-            ..Default::default()
-        };
+        let mut client_capabilities = ClientCapabilities::default();
+        client_capabilities.extensions = Some(extension_capabilities);
 
         let app_target = AppTarget::try_from((extensions, Some(&client_capabilities))).unwrap();
         assert!(matches!(app_target, AppTarget::MCPApps));

--- a/crates/apollo-mcp-server/src/apps/manifest.rs
+++ b/crates/apollo-mcp-server/src/apps/manifest.rs
@@ -114,27 +114,25 @@ pub(crate) fn load_from_path(
                         .or(labels.tool_invocation_invoked);
                 }
 
-                let mcp_tool = Tool {
-                    name: tool.name.into(),
-                    meta: None,
-                    description: Some(if let Some(app_description) = description.clone() {
+                let mut mcp_tool = Tool::new_with_raw(
+                    tool.name,
+                    Some(if let Some(app_description) = description.clone() {
                         format!("{} {}", app_description, tool.description).into()
                     } else {
                         tool.description.into()
                     }),
-                    input_schema: if let Some(extra_inputs) = tool.extra_inputs {
+                    if let Some(extra_inputs) = tool.extra_inputs {
                         let mut merged = operation.tool.input_schema.as_ref().clone();
                         merge_inputs(&mut merged, extra_inputs)?;
                         Arc::new(merged)
                     } else {
                         operation.tool.input_schema.clone()
                     },
-                    title: operation.tool.title.clone(),
-                    output_schema: operation.tool.output_schema.clone(),
-                    annotations: operation.tool.annotations.clone(),
-                    icons: operation.tool.icons.clone(),
-                    execution: None,
-                };
+                );
+                mcp_tool.title = operation.tool.title.clone();
+                mcp_tool.output_schema = operation.tool.output_schema.clone();
+                mcp_tool.annotations = operation.tool.annotations.clone();
+                mcp_tool.icons = operation.tool.icons.clone();
 
                 tools.push(AppTool {
                     operation: operation.clone(),

--- a/crates/apollo-mcp-server/src/apps/resource.rs
+++ b/crates/apollo-mcp-server/src/apps/resource.rs
@@ -233,10 +233,7 @@ mod tests {
 
         let result = get_app_resource(
             &[app],
-            rmcp::model::ReadResourceRequestParams {
-                uri: "ui://widget/TestApp".to_string(),
-                meta: None,
-            },
+            rmcp::model::ReadResourceRequestParams::new("ui://widget/TestApp"),
             "ui://widget/TestApp".parse().unwrap(),
             &AppTarget::AppsSDK,
             "TestApp",
@@ -297,10 +294,7 @@ mod tests {
 
         let result = get_app_resource(
             &[app],
-            rmcp::model::ReadResourceRequestParams {
-                uri: "ui://widget/TestApp".to_string(),
-                meta: None,
-            },
+            rmcp::model::ReadResourceRequestParams::new("ui://widget/TestApp"),
             "ui://widget/TestApp".parse().unwrap(),
             &AppTarget::MCPApps,
             "TestApp",
@@ -349,10 +343,7 @@ mod tests {
 
         let result = get_app_resource(
             &[app],
-            rmcp::model::ReadResourceRequestParams {
-                uri: "ui://widget/NonExistent".to_string(),
-                meta: None,
-            },
+            rmcp::model::ReadResourceRequestParams::new("ui://widget/NonExistent"),
             "ui://widget/NonExistent".parse().unwrap(),
             &AppTarget::AppsSDK,
             "TestApp",
@@ -377,10 +368,7 @@ mod tests {
 
         let result = get_app_resource(
             &[app],
-            rmcp::model::ReadResourceRequestParams {
-                uri: "ui://widget/TestApp".to_string(),
-                meta: None,
-            },
+            rmcp::model::ReadResourceRequestParams::new("ui://widget/TestApp"),
             "ui://widget/TestApp".parse().unwrap(),
             &AppTarget::AppsSDK,
             "WrongApp",
@@ -408,10 +396,7 @@ mod tests {
 
         let result = get_app_resource(
             &[app],
-            rmcp::model::ReadResourceRequestParams {
-                uri: "ui://widget/TestApp".to_string(),
-                meta: None,
-            },
+            rmcp::model::ReadResourceRequestParams::new("ui://widget/TestApp"),
             "ui://widget/TestApp".parse().unwrap(),
             &AppTarget::AppsSDK,
             "TestApp",
@@ -443,10 +428,7 @@ mod tests {
 
         let result = get_app_resource(
             &[app],
-            rmcp::model::ReadResourceRequestParams {
-                uri: "ui://widget/TestApp".to_string(),
-                meta: None,
-            },
+            rmcp::model::ReadResourceRequestParams::new("ui://widget/TestApp"),
             "ui://widget/TestApp".parse().unwrap(),
             &AppTarget::MCPApps,
             "TestApp",
@@ -478,10 +460,7 @@ mod tests {
 
         let result = get_app_resource(
             &[app],
-            rmcp::model::ReadResourceRequestParams {
-                uri: "ui://widget/TestApp".to_string(),
-                meta: None,
-            },
+            rmcp::model::ReadResourceRequestParams::new("ui://widget/TestApp"),
             "ui://widget/TestApp".parse().unwrap(),
             &AppTarget::MCPApps,
             "TestApp",

--- a/crates/apollo-mcp-server/src/apps/tool.rs
+++ b/crates/apollo-mcp-server/src/apps/tool.rs
@@ -899,12 +899,8 @@ mod tests {
     fn nest_app_tool_result_no_private_no_prefetch() {
         let primary_data = json!({"data": {"fieldA": "a"}});
 
-        let result = CallToolResult {
-            content: vec![],
-            is_error: None,
-            meta: None,
-            structured_content: Some(primary_data.clone()),
-        };
+        let mut result = CallToolResult::success(vec![]);
+        result.structured_content = Some(primary_data.clone());
 
         let nested = nest_app_tool_result(result, "MyTool", vec![], None);
 
@@ -927,12 +923,9 @@ mod tests {
         let mut meta = Meta::new();
         meta.insert("structuredContent".into(), full.clone());
 
-        let result = CallToolResult {
-            content: vec![],
-            is_error: None,
-            meta: Some(meta),
-            structured_content: Some(restricted.clone()),
-        };
+        let mut result = CallToolResult::success(vec![]);
+        result.structured_content = Some(restricted.clone());
+        result.meta = Some(meta);
 
         let nested = nest_app_tool_result(result, "MyTool", vec![], None);
 
@@ -956,12 +949,9 @@ mod tests {
         let mut primary_meta = Meta::new();
         primary_meta.insert("structuredContent".into(), full_primary.clone());
 
-        let result = CallToolResult {
-            content: vec![],
-            is_error: None,
-            meta: Some(primary_meta),
-            structured_content: Some(restricted_primary.clone()),
-        };
+        let mut result = CallToolResult::success(vec![]);
+        result.structured_content = Some(restricted_primary.clone());
+        result.meta = Some(primary_meta);
 
         let restricted_prefetch = json!({"data": {"x": 1}});
         let full_prefetch = json!({"data": {"x": 1, "y": 2}});
@@ -969,12 +959,9 @@ mod tests {
         let mut prefetch_meta = Meta::new();
         prefetch_meta.insert("structuredContent".into(), full_prefetch.clone());
 
-        let prefetch_result = CallToolResult {
-            content: vec![],
-            is_error: None,
-            meta: Some(prefetch_meta),
-            structured_content: Some(restricted_prefetch.clone()),
-        };
+        let mut prefetch_result = CallToolResult::success(vec![]);
+        prefetch_result.structured_content = Some(restricted_prefetch.clone());
+        prefetch_result.meta = Some(prefetch_meta);
 
         let nested = nest_app_tool_result(
             result,
@@ -1006,12 +993,8 @@ mod tests {
         // Primary has no @private fields
         let primary_data = json!({"data": {"fieldA": "a"}});
 
-        let result = CallToolResult {
-            content: vec![],
-            is_error: None,
-            meta: None,
-            structured_content: Some(primary_data.clone()),
-        };
+        let mut result = CallToolResult::success(vec![]);
+        result.structured_content = Some(primary_data.clone());
 
         // Prefetch has @private fields
         let restricted_prefetch = json!({"data": {"x": 1}});
@@ -1020,12 +1003,9 @@ mod tests {
         let mut prefetch_meta = Meta::new();
         prefetch_meta.insert("structuredContent".into(), full_prefetch.clone());
 
-        let prefetch_result = CallToolResult {
-            content: vec![],
-            is_error: None,
-            meta: Some(prefetch_meta),
-            structured_content: Some(restricted_prefetch.clone()),
-        };
+        let mut prefetch_result = CallToolResult::success(vec![]);
+        prefetch_result.structured_content = Some(restricted_prefetch.clone());
+        prefetch_result.meta = Some(prefetch_meta);
 
         let nested = nest_app_tool_result(
             result,
@@ -1061,21 +1041,14 @@ mod tests {
         let mut primary_meta = Meta::new();
         primary_meta.insert("structuredContent".into(), full_primary.clone());
 
-        let result = CallToolResult {
-            content: vec![],
-            is_error: None,
-            meta: Some(primary_meta),
-            structured_content: Some(restricted_primary.clone()),
-        };
+        let mut result = CallToolResult::success(vec![]);
+        result.structured_content = Some(restricted_primary.clone());
+        result.meta = Some(primary_meta);
 
         // Prefetch has no @private fields
         let prefetch_data = json!({"data": {"x": 1}});
-        let prefetch_result = CallToolResult {
-            content: vec![],
-            is_error: None,
-            meta: None,
-            structured_content: Some(prefetch_data.clone()),
-        };
+        let mut prefetch_result = CallToolResult::success(vec![]);
+        prefetch_result.structured_content = Some(prefetch_data.clone());
 
         let nested = nest_app_tool_result(
             result,
@@ -1104,12 +1077,8 @@ mod tests {
         let primary_data = json!({"data": {"fieldA": "a"}});
         let extra = json!({"widgetUrl": "https://example.com", "version": 2});
 
-        let result = CallToolResult {
-            content: vec![],
-            is_error: None,
-            meta: None,
-            structured_content: Some(primary_data.clone()),
-        };
+        let mut result = CallToolResult::success(vec![]);
+        result.structured_content = Some(primary_data.clone());
 
         let nested = nest_app_tool_result(result, "MyTool", vec![], Some(&extra));
 
@@ -1126,12 +1095,9 @@ mod tests {
         let mut meta = Meta::new();
         meta.insert("structuredContent".into(), full.clone());
 
-        let result = CallToolResult {
-            content: vec![],
-            is_error: None,
-            meta: Some(meta),
-            structured_content: Some(restricted.clone()),
-        };
+        let mut result = CallToolResult::success(vec![]);
+        result.structured_content = Some(restricted.clone());
+        result.meta = Some(meta);
 
         let nested = nest_app_tool_result(result, "MyTool", vec![], Some(&extra));
 

--- a/crates/apollo-mcp-server/src/explorer.rs
+++ b/crates/apollo-mcp-server/src/explorer.rs
@@ -81,12 +81,9 @@ impl Explorer {
         };
         let url = self.create_explorer_url(input)?;
         debug!(?url, input=?pretty, "Created URL to open operation in Apollo Explorer");
-        Ok(CallToolResult {
-            content: vec![Content::text(url.clone())],
-            meta: None,
-            is_error: None,
-            structured_content: Some(Value::Array(vec![url.into()])),
-        })
+        let mut result = CallToolResult::success(vec![Content::text(url.clone())]);
+        result.structured_content = Some(Value::Array(vec![url.into()]));
+        Ok(result)
     }
 }
 

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -153,15 +153,12 @@ pub trait Executable {
                     (json, None)
                 };
 
-                Ok(CallToolResult {
-                    content: vec![
-                        Content::json(&structured_content)
-                            .unwrap_or(Content::text(structured_content.to_string())),
-                    ],
-                    is_error,
-                    meta,
-                    structured_content: Some(structured_content),
-                })
+                let result = if is_error == Some(true) {
+                    CallToolResult::structured_error(structured_content)
+                } else {
+                    CallToolResult::structured(structured_content)
+                };
+                Ok(result.with_meta(meta))
             }
             Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
                 "Failed to read GraphQL response body: {e}"

--- a/crates/apollo-mcp-server/src/introspection/tools/introspect.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/introspect.rs
@@ -77,18 +77,13 @@ impl Introspect {
                 },
             ),
             None => {
-                return Ok(CallToolResult {
-                    content: vec![],
-                    is_error: None,
-                    meta: None,
-                    structured_content: None,
-                });
+                return Ok(CallToolResult::success(vec![]));
             }
         }
         let shaken = tree_shaker.shaken().unwrap_or_else(|schema| schema.partial);
 
-        Ok(CallToolResult {
-            content: shaken
+        Ok(CallToolResult::success(
+            shaken
                 .types
                 .iter()
                 .filter(|(_name, extended_type)| {
@@ -109,11 +104,7 @@ impl Introspect {
                 .map(|extended_type| self.serialize(extended_type))
                 .map(Content::text)
                 .collect(),
-            is_error: None,
-            meta: None,
-            // The content being returned is a raw string, so no need to create structured content for it
-            structured_content: None,
-        })
+        ))
     }
 
     fn serialize(&self, extended_type: &ExtendedType) -> String {

--- a/crates/apollo-mcp-server/src/introspection/tools/search.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/search.rs
@@ -148,8 +148,8 @@ impl Search {
 
         let shaken = tree_shaker.shaken().unwrap_or_else(|schema| schema.partial);
 
-        Ok(CallToolResult {
-            content: shaken
+        Ok(CallToolResult::success(
+            shaken
                 .types
                 .iter()
                 .filter(|(_name, extended_type)| {
@@ -169,12 +169,7 @@ impl Search {
                 })
                 .map(Content::text)
                 .collect(),
-            is_error: None,
-            meta: None,
-
-            // Note: The returned content is treated as text, so no need to structure its output
-            structured_content: None,
-        })
+        ))
     }
 }
 

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -491,9 +491,7 @@ impl Running {
         if let Some(app_name) = app_param {
             let resource =
                 get_app_resource(&self.apps, request, request_uri, &app_target, &app_name).await?;
-            Ok(ReadResourceResult {
-                contents: vec![resource],
-            })
+            Ok(ReadResourceResult::new(vec![resource]))
         } else {
             Err(ErrorData::resource_not_found(
                 format!("Resource not found for URI: {}", request.uri),
@@ -586,13 +584,11 @@ impl ServerHandler for Running {
             .build()
             .add(1, &[]);
 
-        let capabilities = ServerCapabilities {
-            tools: Some(ToolsCapability {
-                list_changed: Some(true),
-            }),
-            resources: (!self.apps.is_empty()).then(ResourcesCapability::default),
-            ..Default::default()
-        };
+        let mut capabilities = ServerCapabilities::default();
+        capabilities.tools = Some(ToolsCapability {
+            list_changed: Some(true),
+        });
+        capabilities.resources = (!self.apps.is_empty()).then(ResourcesCapability::default);
 
         let protocol_version = if self.enable_output_schema {
             ProtocolVersion::default()
@@ -600,19 +596,22 @@ impl ServerHandler for Running {
             ProtocolVersion::V_2025_03_26
         };
 
-        ServerInfo {
-            protocol_version,
-            server_info: Implementation {
-                name: self.server_info.name().to_string(),
-                icons: None,
-                title: self.server_info.title().map(|s| s.to_string()),
-                version: self.server_info.version().to_string(),
-                website_url: self.server_info.website_url().map(|s| s.to_string()),
-                description: self.server_info.description().map(|s| s.to_string()),
-            },
-            capabilities,
-            instructions: None,
+        let mut impl_ = Implementation::new(
+            self.server_info.name().to_string(),
+            self.server_info.version().to_string(),
+        );
+        if let Some(t) = self.server_info.title() {
+            impl_ = impl_.with_title(t);
         }
+        if let Some(d) = self.server_info.description() {
+            impl_ = impl_.with_description(d);
+        }
+        if let Some(u) = self.server_info.website_url() {
+            impl_ = impl_.with_website_url(u);
+        }
+        InitializeResult::new(capabilities)
+            .with_protocol_version(protocol_version)
+            .with_server_info(impl_)
     }
 }
 
@@ -982,12 +981,9 @@ mod tests {
 
             let mut resource = running
                 .read_resource_impl(
-                    ReadResourceRequestParams {
-                        uri: "http://localhost:4000/resource#a_different_fragment"
-                            .parse()
-                            .unwrap(),
-                        meta: None,
-                    },
+                    ReadResourceRequestParams::new(
+                        "http://localhost:4000/resource#a_different_fragment",
+                    ),
                     extensions,
                     None,
                 )
@@ -1028,10 +1024,7 @@ mod tests {
 
             let result = running
                 .read_resource_impl(
-                    ReadResourceRequestParams {
-                        uri: "http://localhost:4000/invalid_resource".parse().unwrap(),
-                        meta: None,
-                    },
+                    ReadResourceRequestParams::new("http://localhost:4000/invalid_resource"),
                     extensions,
                     None,
                 )
@@ -1056,10 +1049,7 @@ mod tests {
 
             let result = running
                 .read_resource_impl(
-                    ReadResourceRequestParams {
-                        uri: "not a uri".parse().unwrap(),
-                        meta: None,
-                    },
+                    ReadResourceRequestParams::new("not a uri"),
                     extensions,
                     None,
                 )
@@ -1076,10 +1066,7 @@ mod tests {
             );
             let result = running
                 .read_resource_impl(
-                    ReadResourceRequestParams {
-                        uri: "http://localhost:4000/resource".parse().unwrap(),
-                        meta: None,
-                    },
+                    ReadResourceRequestParams::new("http://localhost:4000/resource"),
                     Extensions::new(),
                     None,
                 )
@@ -1104,10 +1091,7 @@ mod tests {
 
             let result = running
                 .read_resource_impl(
-                    ReadResourceRequestParams {
-                        uri: "http://localhost:4000/resource".parse().unwrap(),
-                        meta: None,
-                    },
+                    ReadResourceRequestParams::new("http://localhost:4000/resource"),
                     extensions,
                     None,
                 )
@@ -1144,10 +1128,7 @@ mod tests {
 
             let mut resource = running
                 .read_resource_impl(
-                    ReadResourceRequestParams {
-                        uri: RESOURCE_URI.to_string(),
-                        meta: None,
-                    },
+                    ReadResourceRequestParams::new(RESOURCE_URI),
                     extensions,
                     None,
                 )
@@ -1191,10 +1172,7 @@ mod tests {
 
             let mut resource = running
                 .read_resource_impl(
-                    ReadResourceRequestParams {
-                        uri: "http://localhost:4000/resource".parse().unwrap(),
-                        meta: None,
-                    },
+                    ReadResourceRequestParams::new("http://localhost:4000/resource"),
                     extensions,
                     None,
                 )
@@ -1267,10 +1245,7 @@ mod tests {
 
             let mut resource = running
                 .read_resource_impl(
-                    ReadResourceRequestParams {
-                        uri: "http://localhost:4000/resource".parse().unwrap(),
-                        meta: None,
-                    },
+                    ReadResourceRequestParams::new("http://localhost:4000/resource"),
                     extensions,
                     None,
                 )
@@ -1309,10 +1284,7 @@ mod tests {
 
             let mut resource = running
                 .read_resource_impl(
-                    ReadResourceRequestParams {
-                        uri: "http://localhost:4000/resource".parse().unwrap(),
-                        meta: None,
-                    },
+                    ReadResourceRequestParams::new("http://localhost:4000/resource"),
                     extensions,
                     None,
                 )
@@ -1350,10 +1322,7 @@ mod tests {
 
             let mut resource = running
                 .read_resource_impl(
-                    ReadResourceRequestParams {
-                        uri: "http://localhost:4000/resource".parse().unwrap(),
-                        meta: None,
-                    },
+                    ReadResourceRequestParams::new("http://localhost:4000/resource"),
                     extensions,
                     None,
                 )
@@ -1399,10 +1368,7 @@ mod tests {
 
             let mut resource = running
                 .read_resource_impl(
-                    ReadResourceRequestParams {
-                        uri: "http://localhost:4000/resource".parse().unwrap(),
-                        meta: None,
-                    },
+                    ReadResourceRequestParams::new("http://localhost:4000/resource"),
                     extensions,
                     None,
                 )
@@ -1451,10 +1417,7 @@ mod tests {
 
             let result = running
                 .read_resource_impl(
-                    ReadResourceRequestParams {
-                        uri: "http://localhost:4000/resource".parse().unwrap(),
-                        meta: None,
-                    },
+                    ReadResourceRequestParams::new("http://localhost:4000/resource"),
                     extensions,
                     None,
                 )
@@ -1660,10 +1623,8 @@ mod tests {
                     .unwrap()
                     .clone(),
             );
-            let client_capabilities = ClientCapabilities {
-                extensions: Some(extension_capabilities),
-                ..Default::default()
-            };
+            let mut client_capabilities = ClientCapabilities::default();
+            client_capabilities.extensions = Some(extension_capabilities);
 
             let result = running
                 .list_tools_impl(extensions, Some(&client_capabilities), None)
@@ -1921,12 +1882,8 @@ mod tests {
                 ..test_running(Arc::new(RwLock::new(schema)))
             };
 
-            let request = CallToolRequestParams {
-                meta: None,
-                name: "Hello".into(),
-                arguments: Some(Default::default()),
-                task: None,
-            };
+            let mut request = CallToolRequestParams::new("Hello");
+            request.arguments = Some(Default::default());
 
             let result = running
                 .call_tool_impl(
@@ -1970,12 +1927,8 @@ mod tests {
                 ..test_running(Arc::new(RwLock::new(schema)))
             };
 
-            let request = CallToolRequestParams {
-                meta: None,
-                name: "Hello".into(),
-                arguments: Some(Default::default()),
-                task: None,
-            };
+            let mut request = CallToolRequestParams::new("Hello");
+            request.arguments = Some(Default::default());
 
             let result = running
                 .call_tool_impl(
@@ -2069,12 +2022,8 @@ mod tests {
             let (parts, _) = request.into_parts();
             extensions.insert(parts);
 
-            let request = CallToolRequestParams {
-                meta: None,
-                name: "Hello".into(),
-                arguments: Some(Default::default()),
-                task: None,
-            };
+            let mut request = CallToolRequestParams::new("Hello");
+            request.arguments = Some(Default::default());
 
             let _result = running
                 .call_tool_impl(request, &extensions, None)


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-442 -->

Bumps the `rmcp` crate from 0.17 to 1.2 following [the migration guide](https://github.com/modelcontextprotocol/rust-sdk/discussions/716). The 1.x release added `#[non_exhaustive]` to many public model structs, so all struct-literal construction has been replaced with the new constructor + builder API.