### PR TITLE
feat: add MCP prompts support via YAML configuration 

### DIFF
--- a/crates/apollo-mcp-server/src/errors.rs
+++ b/crates/apollo-mcp-server/src/errors.rs
@@ -41,6 +41,25 @@ pub enum OperationError {
     Collection(CollectionError),
 }
 
+/// An error in prompt configuration
+#[derive(Debug, thiserror::Error)]
+pub enum PromptError {
+    #[error("Prompt definition has an empty name")]
+    EmptyName,
+
+    #[error("Duplicate prompt name '{0}'")]
+    DuplicateName(String),
+
+    #[error("Prompt not found: '{0}'")]
+    NotFound(String),
+
+    #[error("Missing required argument '{argument}' for prompt '{prompt_name}'")]
+    MissingRequiredArgument {
+        prompt_name: String,
+        argument: String,
+    },
+}
+
 /// An error in server initialization
 #[derive(Debug, thiserror::Error)]
 pub enum ServerError {
@@ -112,6 +131,9 @@ pub enum ServerError {
 
     #[error("There was a problem parsing Rhai scripts on startup.")]
     RhaiError,
+
+    #[error("Invalid prompt configuration: {0}")]
+    Prompt(#[from] PromptError),
 }
 
 /// An MCP tool error

--- a/crates/apollo-mcp-server/src/lib.rs
+++ b/crates/apollo-mcp-server/src/lib.rs
@@ -16,6 +16,7 @@ mod introspection;
 pub(crate) mod json_schema;
 pub(crate) mod meter;
 pub mod operations;
+pub mod prompts;
 pub(crate) mod schema_tree_shake;
 pub mod server;
 pub mod server_info;

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -156,6 +156,7 @@ async fn main() -> anyhow::Result<()> {
         .health_check(config.health_check)
         .cors(config.cors)
         .server_info(config.server_info)
+        .prompts(config.prompts)
         .build()
         .start()
         .await?)

--- a/crates/apollo-mcp-server/src/prompts.rs
+++ b/crates/apollo-mcp-server/src/prompts.rs
@@ -1,0 +1,9 @@
+mod config;
+mod render;
+mod store;
+
+pub use config::{
+    PromptArgumentConfig, PromptConfig, PromptContentConfig, PromptMessageConfig,
+    PromptMessageRoleConfig, ResourceContentConfig,
+};
+pub(crate) use store::Prompts;

--- a/crates/apollo-mcp-server/src/prompts/config.rs
+++ b/crates/apollo-mcp-server/src/prompts/config.rs
@@ -1,0 +1,380 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+/// Configuration for a single prompt definition in the YAML config
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PromptConfig {
+    /// Unique identifier for the prompt
+    pub name: String,
+    /// Human-readable title
+    #[serde(default)]
+    pub title: Option<String>,
+    /// What the prompt does
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Template arguments
+    #[serde(default)]
+    pub arguments: Option<Vec<PromptArgumentConfig>>,
+    /// Conversation messages
+    #[serde(default)]
+    pub messages: Vec<PromptMessageConfig>,
+}
+
+/// Configuration for a prompt argument
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PromptArgumentConfig {
+    /// Argument identifier, used in `{{name}}` placeholders
+    pub name: String,
+    /// Human-readable title
+    #[serde(default)]
+    pub title: Option<String>,
+    /// Purpose of the argument
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Whether the argument must be provided
+    #[serde(default)]
+    pub required: Option<bool>,
+}
+
+/// Configuration for a prompt message
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PromptMessageConfig {
+    /// Message sender role (defaults to "user")
+    #[serde(default)]
+    pub role: Option<PromptMessageRoleConfig>,
+    /// Message content
+    pub content: PromptContentConfig,
+}
+
+/// The role of a message sender
+#[derive(Debug, Clone, Copy, Default, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptMessageRoleConfig {
+    #[default]
+    User,
+    Assistant,
+}
+
+/// Content types that can be included in prompt messages.
+/// Discriminated by the `type` field, matching MCP `PromptMessageContent`.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum PromptContentConfig {
+    /// Plain text content with optional `{{arg}}` placeholders
+    Text { text: String },
+    /// Image content with base64-encoded data
+    Image {
+        data: String,
+        #[serde(rename = "mimeType")]
+        mime_type: String,
+    },
+    /// Embedded server-side resource
+    Resource { resource: ResourceContentConfig },
+    /// A link to a resource
+    ResourceLink {
+        uri: String,
+        name: String,
+        #[serde(default)]
+        description: Option<String>,
+        #[serde(default, rename = "mimeType")]
+        mime_type: Option<String>,
+    },
+}
+
+/// Embedded resource content (text or binary blob)
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ResourceContentConfig {
+    /// Text resource with URI
+    Text {
+        uri: String,
+        #[serde(default)]
+        mime_type: Option<String>,
+        text: String,
+    },
+    /// Binary blob resource with URI (base64-encoded)
+    Blob {
+        uri: String,
+        #[serde(default)]
+        mime_type: Option<String>,
+        blob: String,
+    },
+}
+
+impl Default for PromptContentConfig {
+    fn default() -> Self {
+        Self::Text {
+            text: String::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_full_prompt_config() {
+        let yaml = r#"
+name: check_order_history
+title: "Check Order History"
+description: "Look up a user's recent orders"
+arguments:
+  - name: email
+    title: "User Email"
+    description: "The email address"
+    required: true
+  - name: limit
+    description: "Max orders"
+messages:
+  - role: user
+    content:
+      type: text
+      text: "GetUserByEmail(email={{email}})"
+  - role: assistant
+    content:
+      type: text
+      text: "I'll look that up."
+"#;
+        let config: PromptConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.name, "check_order_history");
+        assert_eq!(config.title.as_deref(), Some("Check Order History"));
+        assert_eq!(
+            config.description.as_deref(),
+            Some("Look up a user's recent orders")
+        );
+        let args = config.arguments.unwrap();
+        assert_eq!(args.len(), 2);
+        assert_eq!(args[0].name, "email");
+        assert_eq!(args[0].required, Some(true));
+        assert_eq!(args[1].name, "limit");
+        assert_eq!(args[1].required, None);
+        assert_eq!(config.messages.len(), 2);
+    }
+
+    #[test]
+    fn parse_minimal_prompt_config() {
+        let yaml = r#"
+name: simple
+messages:
+  - content:
+      type: text
+      text: "Hello!"
+"#;
+        let config: PromptConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.name, "simple");
+        assert!(config.title.is_none());
+        assert!(config.description.is_none());
+        assert!(config.arguments.is_none());
+        assert_eq!(config.messages.len(), 1);
+    }
+
+    #[test]
+    fn parse_empty_prompts_vec() {
+        let yaml = "[]";
+        let configs: Vec<PromptConfig> = serde_yaml::from_str(yaml).unwrap();
+        assert!(configs.is_empty());
+    }
+
+    #[test]
+    fn deny_unknown_fields_rejects_invalid() {
+        let yaml = r#"
+name: test
+unknown_field: true
+messages: []
+"#;
+        let result = serde_yaml::from_str::<PromptConfig>(yaml);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("unknown field"));
+    }
+
+    #[test]
+    fn missing_name_produces_error() {
+        let yaml = r#"
+messages:
+  - content:
+      type: text
+      text: "Hello"
+"#;
+        let result = serde_yaml::from_str::<PromptConfig>(yaml);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("name"));
+    }
+
+    #[test]
+    fn role_defaults_to_user() {
+        let yaml = r#"
+name: test
+messages:
+  - content:
+      type: text
+      text: "Hello"
+"#;
+        let config: PromptConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.messages[0].role.is_none());
+    }
+
+    #[test]
+    fn parse_image_content() {
+        let yaml = r#"
+name: visual
+messages:
+  - role: user
+    content:
+      type: image
+      data: "base64data"
+      mimeType: "image/png"
+"#;
+        let config: PromptConfig = serde_yaml::from_str(yaml).unwrap();
+        match &config.messages[0].content {
+            PromptContentConfig::Image { data, mime_type } => {
+                assert_eq!(data, "base64data");
+                assert_eq!(mime_type, "image/png");
+            }
+            _ => panic!("Expected image content"),
+        }
+    }
+
+    #[test]
+    fn parse_resource_link_content() {
+        let yaml = r#"
+name: linked
+messages:
+  - content:
+      type: resource_link
+      uri: "file:///test.txt"
+      name: "test.txt"
+      description: "A test file"
+      mimeType: "text/plain"
+"#;
+        let config: PromptConfig = serde_yaml::from_str(yaml).unwrap();
+        match &config.messages[0].content {
+            PromptContentConfig::ResourceLink {
+                uri,
+                name,
+                description,
+                mime_type,
+            } => {
+                assert_eq!(uri, "file:///test.txt");
+                assert_eq!(name, "test.txt");
+                assert_eq!(description.as_deref(), Some("A test file"));
+                assert_eq!(mime_type.as_deref(), Some("text/plain"));
+            }
+            _ => panic!("Expected resource_link content"),
+        }
+    }
+
+    #[test]
+    fn parse_resource_link_minimal() {
+        let yaml = r#"
+name: linked_min
+messages:
+  - content:
+      type: resource_link
+      uri: "file:///test.txt"
+      name: "test.txt"
+"#;
+        let config: PromptConfig = serde_yaml::from_str(yaml).unwrap();
+        match &config.messages[0].content {
+            PromptContentConfig::ResourceLink {
+                description,
+                mime_type,
+                ..
+            } => {
+                assert!(description.is_none());
+                assert!(mime_type.is_none());
+            }
+            _ => panic!("Expected resource_link content"),
+        }
+    }
+
+    #[test]
+    fn parse_resource_text_content() {
+        let yaml = r#"
+name: res_text
+messages:
+  - content:
+      type: resource
+      resource:
+        type: text
+        uri: "file:///doc.txt"
+        text: "file contents"
+"#;
+        let config: PromptConfig = serde_yaml::from_str(yaml).unwrap();
+        match &config.messages[0].content {
+            PromptContentConfig::Resource { resource } => match resource {
+                ResourceContentConfig::Text { uri, text, .. } => {
+                    assert_eq!(uri, "file:///doc.txt");
+                    assert_eq!(text, "file contents");
+                }
+                _ => panic!("Expected text resource"),
+            },
+            _ => panic!("Expected resource content"),
+        }
+    }
+
+    #[test]
+    fn parse_resource_blob_content() {
+        let yaml = r#"
+name: res_blob
+messages:
+  - content:
+      type: resource
+      resource:
+        type: blob
+        uri: "file:///image.bin"
+        blob: "YmluYXJ5ZGF0YQ=="
+"#;
+        let config: PromptConfig = serde_yaml::from_str(yaml).unwrap();
+        match &config.messages[0].content {
+            PromptContentConfig::Resource { resource } => match resource {
+                ResourceContentConfig::Blob { uri, blob, .. } => {
+                    assert_eq!(uri, "file:///image.bin");
+                    assert_eq!(blob, "YmluYXJ5ZGF0YQ==");
+                }
+                _ => panic!("Expected blob resource"),
+            },
+            _ => panic!("Expected resource content"),
+        }
+    }
+
+    #[test]
+    fn parse_assistant_role() {
+        let yaml = r#"
+name: test
+messages:
+  - role: assistant
+    content:
+      type: text
+      text: "I'll help with that."
+"#;
+        let config: PromptConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            config.messages[0].role,
+            Some(PromptMessageRoleConfig::Assistant)
+        );
+    }
+
+    #[test]
+    fn argument_required_defaults_to_none() {
+        let yaml = r#"
+name: test
+arguments:
+  - name: opt_arg
+messages:
+  - content:
+      type: text
+      text: "hello"
+"#;
+        let config: PromptConfig = serde_yaml::from_str(yaml).unwrap();
+        let args = config.arguments.unwrap();
+        assert_eq!(args[0].required, None);
+        assert!(args[0].title.is_none());
+        assert!(args[0].description.is_none());
+    }
+}

--- a/crates/apollo-mcp-server/src/prompts/render.rs
+++ b/crates/apollo-mcp-server/src/prompts/render.rs
@@ -1,0 +1,220 @@
+use std::collections::HashMap;
+
+/// Perform single-pass `{{arg}}` replacement in a template string.
+///
+/// - Provided arguments replace `{{arg_name}}` with the supplied value.
+/// - Missing optional arguments (in `defined_arg_names` but not in `arguments`) are replaced with `""`.
+/// - Placeholders not matching any defined argument name are left as literal text.
+/// - Argument values are treated as literals: no re-evaluation (injection prevention).
+pub(crate) fn render_template(
+    template: &str,
+    arguments: &HashMap<String, String>,
+    defined_arg_names: &[&str],
+) -> String {
+    let mut result = String::with_capacity(template.len());
+    let mut rest = template;
+
+    while let Some(open) = rest.find("{{") {
+        result.push_str(&rest[..open]);
+
+        let after_open = &rest[open + 2..];
+        if let Some(close) = after_open.find("}}") {
+            let placeholder_name = &after_open[..close];
+
+            if defined_arg_names.contains(&placeholder_name) {
+                if let Some(value) = arguments.get(placeholder_name) {
+                    result.push_str(value);
+                }
+                // Missing optional: replace with empty string (push nothing)
+            } else {
+                // Not a defined argument — leave as literal text
+                result.push_str("{{");
+                result.push_str(placeholder_name);
+                result.push_str("}}");
+            }
+
+            rest = &after_open[close + 2..];
+        } else {
+            // No closing `}}` found — treat as literal
+            result.push_str("{{");
+            rest = after_open;
+        }
+    }
+
+    result.push_str(rest);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_substitution() {
+        let args = HashMap::from([("email".to_string(), "alice@example.com".to_string())]);
+        let defined = vec!["email"];
+        let result = render_template("Hello {{email}}", &args, &defined);
+        assert_eq!(result, "Hello alice@example.com");
+    }
+
+    #[test]
+    fn multiple_arguments() {
+        let args = HashMap::from([
+            ("name".to_string(), "Alice".to_string()),
+            ("age".to_string(), "30".to_string()),
+        ]);
+        let defined = vec!["name", "age"];
+        let result = render_template("{{name}} is {{age}} years old", &args, &defined);
+        assert_eq!(result, "Alice is 30 years old");
+    }
+
+    #[test]
+    fn missing_optional_argument_replaced_with_empty() {
+        let args = HashMap::new();
+        let defined = vec!["email"];
+        let result = render_template("User: {{email}}", &args, &defined);
+        assert_eq!(result, "User: ");
+    }
+
+    #[test]
+    fn injection_prevention() {
+        let args = HashMap::from([("email".to_string(), "{{malicious}}".to_string())]);
+        let defined = vec!["email"];
+        let result = render_template("Hello {{email}}", &args, &defined);
+        assert_eq!(result, "Hello {{malicious}}");
+    }
+
+    #[test]
+    fn no_defined_arguments_placeholder_left_as_literal() {
+        let args = HashMap::new();
+        let defined: Vec<&str> = vec![];
+        let result = render_template("Hello {{placeholder}}", &args, &defined);
+        assert_eq!(result, "Hello {{placeholder}}");
+    }
+
+    #[test]
+    fn empty_template_string() {
+        let args = HashMap::new();
+        let defined: Vec<&str> = vec![];
+        let result = render_template("", &args, &defined);
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn argument_not_in_template_no_error() {
+        let args = HashMap::from([("unused".to_string(), "value".to_string())]);
+        let defined = vec!["unused"];
+        let result = render_template("No placeholders here", &args, &defined);
+        assert_eq!(result, "No placeholders here");
+    }
+
+    #[test]
+    fn multiple_occurrences_of_same_arg() {
+        let args = HashMap::from([("x".to_string(), "1".to_string())]);
+        let defined = vec!["x"];
+        let result = render_template("{{x}} + {{x}} = 2", &args, &defined);
+        assert_eq!(result, "1 + 1 = 2");
+    }
+
+    #[test]
+    fn adjacent_placeholders() {
+        let args = HashMap::from([
+            ("a".to_string(), "X".to_string()),
+            ("b".to_string(), "Y".to_string()),
+        ]);
+        let defined = vec!["a", "b"];
+        let result = render_template("{{a}}{{b}}", &args, &defined);
+        assert_eq!(result, "XY");
+    }
+
+    #[test]
+    fn incomplete_placeholder_left_as_literal() {
+        let args = HashMap::new();
+        let defined: Vec<&str> = vec![];
+        let result = render_template("Hello {{unclosed", &args, &defined);
+        assert_eq!(result, "Hello {{unclosed");
+    }
+
+    #[test]
+    fn multibyte_characters_around_placeholder() {
+        let args = HashMap::from([("name".to_string(), "太郎".to_string())]);
+        let defined = vec!["name"];
+        let result = render_template("こんにちは {{name}} さん！", &args, &defined);
+        assert_eq!(result, "こんにちは 太郎 さん！");
+    }
+
+    #[test]
+    fn multibyte_characters_in_non_placeholder_text() {
+        let args = HashMap::new();
+        let defined: Vec<&str> = vec![];
+        let result = render_template("日本語テキスト 🚀 絵文字", &args, &defined);
+        assert_eq!(result, "日本語テキスト 🚀 絵文字");
+    }
+
+    #[test]
+    fn multibyte_undefined_placeholder_preserved() {
+        let args = HashMap::new();
+        let defined: Vec<&str> = vec![];
+        let result = render_template("前 {{未定義}} 後", &args, &defined);
+        assert_eq!(result, "前 {{未定義}} 後");
+    }
+
+    #[test]
+    fn empty_placeholder_name_left_as_literal() {
+        let args = HashMap::new();
+        let defined: Vec<&str> = vec![];
+        let result = render_template("before {{}} after", &args, &defined);
+        assert_eq!(result, "before {{}} after");
+    }
+
+    #[test]
+    fn triple_braces_around_arg() {
+        // {{ is consumed as open, so placeholder name becomes "{x", which is undefined
+        let args = HashMap::from([("x".to_string(), "val".to_string())]);
+        let defined = vec!["x"];
+        let result = render_template("{{{x}}}", &args, &defined);
+        assert_eq!(result, "{{{x}}}");
+    }
+
+    #[test]
+    fn only_closing_braces_no_crash() {
+        let args = HashMap::new();
+        let defined: Vec<&str> = vec![];
+        let result = render_template("no open }} here", &args, &defined);
+        assert_eq!(result, "no open }} here");
+    }
+
+    #[test]
+    fn whitespace_in_placeholder_name_not_matched() {
+        let args = HashMap::from([("name".to_string(), "val".to_string())]);
+        let defined = vec!["name"];
+        let result = render_template("{{ name }}", &args, &defined);
+        // " name " doesn't match defined arg "name", left as literal
+        assert_eq!(result, "{{ name }}");
+    }
+
+    #[test]
+    fn consecutive_open_braces() {
+        // First {{ consumed as open, placeholder name is "{{a", undefined -> left as literal
+        let args = HashMap::from([("a".to_string(), "X".to_string())]);
+        let defined = vec!["a"];
+        let result = render_template("{{{{a}}}}", &args, &defined);
+        assert_eq!(result, "{{{{a}}}}");
+    }
+
+    #[test]
+    fn template_with_only_placeholder() {
+        let args = HashMap::from([("val".to_string(), "result".to_string())]);
+        let defined = vec!["val"];
+        let result = render_template("{{val}}", &args, &defined);
+        assert_eq!(result, "result");
+    }
+
+    #[test]
+    fn special_chars_in_value_preserved() {
+        let args = HashMap::from([("x".to_string(), "<script>alert(1)</script>".to_string())]);
+        let defined = vec!["x"];
+        let result = render_template("content: {{x}}", &args, &defined);
+        assert_eq!(result, "content: <script>alert(1)</script>");
+    }
+}

--- a/crates/apollo-mcp-server/src/prompts/store.rs
+++ b/crates/apollo-mcp-server/src/prompts/store.rs
@@ -1,0 +1,728 @@
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+
+use rmcp::model::{
+    AnnotateAble, GetPromptResult, Prompt, PromptArgument, PromptMessage, PromptMessageContent,
+    PromptMessageRole, RawEmbeddedResource, RawImageContent, RawResource,
+};
+
+use crate::errors::PromptError;
+
+use super::config::{
+    PromptConfig, PromptContentConfig, PromptMessageRoleConfig, ResourceContentConfig,
+};
+use super::render::render_template;
+
+/// Holds prompt definitions and handles lookup, rendering, and rmcp conversion.
+#[derive(Debug, Clone)]
+pub(crate) struct Prompts {
+    prompts: Vec<Prompt>,
+    configs: HashMap<String, PromptConfig>,
+}
+
+impl Prompts {
+    /// Create a new Prompts from raw prompt configs.
+    ///
+    /// Validates non-empty names and unique names.
+    pub(crate) fn new(configs: Vec<PromptConfig>) -> Result<Self, PromptError> {
+        let mut prompts = Vec::with_capacity(configs.len());
+        let mut config_map = HashMap::with_capacity(configs.len());
+
+        for config in configs {
+            if config.name.is_empty() {
+                return Err(PromptError::EmptyName);
+            }
+            match config_map.entry(config.name.clone()) {
+                Entry::Occupied(_) => return Err(PromptError::DuplicateName(config.name)),
+                Entry::Vacant(e) => {
+                    let config_ref = e.insert(config);
+                    prompts.push(Prompt::from(&*config_ref));
+                }
+            }
+        }
+
+        Ok(Self {
+            prompts,
+            configs: config_map,
+        })
+    }
+
+    /// Returns rmcp prompt definitions for `list_prompts`.
+    pub(crate) fn list(&self) -> &[Prompt] {
+        &self.prompts
+    }
+
+    /// Retrieve and render a prompt by name, returning an rmcp `GetPromptResult` directly.
+    pub(crate) fn get(
+        &self,
+        name: &str,
+        arguments: &HashMap<String, String>,
+    ) -> Result<GetPromptResult, PromptError> {
+        let prompt = self
+            .configs
+            .get(name)
+            .ok_or_else(|| PromptError::NotFound(name.to_string()))?;
+
+        let defined_arg_names: Vec<&str> = prompt
+            .arguments
+            .as_ref()
+            .map(|args| args.iter().map(|a| a.name.as_str()).collect::<Vec<_>>())
+            .unwrap_or_default();
+
+        // Validate required arguments
+        if let Some(arg_defs) = &prompt.arguments {
+            for arg_def in arg_defs {
+                if arg_def.required == Some(true) && !arguments.contains_key(&arg_def.name) {
+                    return Err(PromptError::MissingRequiredArgument {
+                        prompt_name: name.to_string(),
+                        argument: arg_def.name.clone(),
+                    });
+                }
+            }
+        }
+
+        // Render messages and convert directly to rmcp types
+        let messages = prompt
+            .messages
+            .iter()
+            .map(|msg| {
+                let role =
+                    PromptMessageRole::from(msg.role.unwrap_or(PromptMessageRoleConfig::User));
+                let content = render_content(&msg.content, arguments, &defined_arg_names);
+                PromptMessage::new(role, content)
+            })
+            .collect();
+
+        let mut result = GetPromptResult::new(messages);
+        if let Some(desc) = &prompt.description {
+            result = result.with_description(desc);
+        }
+        Ok(result)
+    }
+}
+
+/// Render template placeholders in content and convert to rmcp `PromptMessageContent`.
+fn render_content(
+    content: &PromptContentConfig,
+    arguments: &HashMap<String, String>,
+    defined_arg_names: &[&str],
+) -> PromptMessageContent {
+    match content {
+        PromptContentConfig::Text { text } => {
+            let rendered = render_template(text, arguments, defined_arg_names);
+            PromptMessageContent::text(rendered)
+        }
+        PromptContentConfig::Image { data, mime_type } => PromptMessageContent::Image {
+            image: RawImageContent {
+                data: data.clone(),
+                mime_type: mime_type.clone(),
+                meta: None,
+            }
+            .no_annotation(),
+        },
+        PromptContentConfig::Resource { resource } => {
+            let contents = rmcp::model::ResourceContents::from(resource.clone());
+            let embedded = RawEmbeddedResource::new(contents).no_annotation();
+            PromptMessageContent::Resource { resource: embedded }
+        }
+        PromptContentConfig::ResourceLink {
+            uri,
+            name,
+            description,
+            mime_type,
+        } => {
+            let mut resource = RawResource::new(uri, name);
+            resource.description = description.clone();
+            resource.mime_type = mime_type.clone();
+            PromptMessageContent::resource_link(resource.no_annotation())
+        }
+    }
+}
+
+impl From<&PromptConfig> for Prompt {
+    fn from(config: &PromptConfig) -> Self {
+        let arguments = config.arguments.as_ref().map(|args| {
+            args.iter()
+                .map(|a| {
+                    let mut arg = PromptArgument::new(&a.name);
+                    if let Some(title) = &a.title {
+                        arg = arg.with_title(title);
+                    }
+                    if let Some(desc) = &a.description {
+                        arg = arg.with_description(desc);
+                    }
+                    if let Some(req) = a.required {
+                        arg = arg.with_required(req);
+                    }
+                    arg
+                })
+                .collect()
+        });
+
+        let mut prompt = Prompt::new(&config.name, config.description.as_deref(), arguments);
+        if let Some(title) = &config.title {
+            prompt = prompt.with_title(title);
+        }
+        prompt
+    }
+}
+
+impl From<PromptMessageRoleConfig> for PromptMessageRole {
+    fn from(role: PromptMessageRoleConfig) -> Self {
+        match role {
+            PromptMessageRoleConfig::User => PromptMessageRole::User,
+            PromptMessageRoleConfig::Assistant => PromptMessageRole::Assistant,
+        }
+    }
+}
+
+impl From<ResourceContentConfig> for rmcp::model::ResourceContents {
+    fn from(config: ResourceContentConfig) -> Self {
+        match config {
+            ResourceContentConfig::Text {
+                uri,
+                mime_type,
+                text,
+            } => Self::TextResourceContents {
+                uri,
+                mime_type,
+                text,
+                meta: None,
+            },
+            ResourceContentConfig::Blob {
+                uri,
+                mime_type,
+                blob,
+            } => Self::BlobResourceContents {
+                uri,
+                mime_type,
+                blob,
+                meta: None,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rmcp::model::PromptMessageContent;
+
+    use crate::prompts::{
+        PromptArgumentConfig, PromptContentConfig, PromptMessageConfig, ResourceContentConfig,
+    };
+
+    use super::*;
+
+    fn text_message(text: &str) -> PromptMessageConfig {
+        PromptMessageConfig {
+            role: None,
+            content: PromptContentConfig::Text {
+                text: text.to_string(),
+            },
+        }
+    }
+
+    fn make_config(name: &str, messages: Vec<PromptMessageConfig>) -> PromptConfig {
+        PromptConfig {
+            name: name.to_string(),
+            title: None,
+            description: None,
+            arguments: None,
+            messages,
+        }
+    }
+
+    fn args(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    fn get_text(result: &GetPromptResult, index: usize) -> &str {
+        match &result.messages[index].content {
+            PromptMessageContent::Text { text } => text.as_str(),
+            _ => panic!("Expected text content"),
+        }
+    }
+
+    // --- Validation Tests ---
+
+    #[test]
+    fn new_with_valid_configs() {
+        let store = Prompts::new(vec![make_config("test", vec![text_message("hello")])]).unwrap();
+        assert_eq!(store.list().len(), 1);
+        assert_eq!(store.list()[0].name, "test");
+    }
+
+    #[test]
+    fn duplicate_names_fail_validation() {
+        let result = Prompts::new(vec![
+            PromptConfig {
+                name: "dup".to_string(),
+                description: Some("first".to_string()),
+                ..make_config("dup", vec![text_message("first")])
+            },
+            PromptConfig {
+                name: "dup".to_string(),
+                description: Some("second".to_string()),
+                ..make_config("dup", vec![text_message("second")])
+            },
+        ]);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), PromptError::DuplicateName(name) if name == "dup"));
+    }
+
+    #[test]
+    fn empty_config_vec() {
+        let store = Prompts::new(vec![]).unwrap();
+        assert!(store.list().is_empty());
+    }
+
+    #[test]
+    fn list_returns_correct_metadata() {
+        let config = PromptConfig {
+            name: "check_order".to_string(),
+            title: Some("Check Order".to_string()),
+            description: Some("Look up orders".to_string()),
+            arguments: Some(vec![PromptArgumentConfig {
+                name: "email".to_string(),
+                title: Some("User Email".to_string()),
+                description: Some("The email".to_string()),
+                required: Some(true),
+            }]),
+            messages: vec![text_message("hello")],
+        };
+        let store = Prompts::new(vec![config]).unwrap();
+        let list = store.list();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].name, "check_order");
+        assert_eq!(list[0].title.as_deref(), Some("Check Order"));
+        assert_eq!(list[0].description.as_deref(), Some("Look up orders"));
+        let args = list[0].arguments.as_ref().unwrap();
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].name, "email");
+        assert_eq!(args[0].title.as_deref(), Some("User Email"));
+        assert_eq!(args[0].description.as_deref(), Some("The email"));
+        assert_eq!(args[0].required, Some(true));
+    }
+
+    #[test]
+    fn invalid_empty_name_fails() {
+        let result = Prompts::new(vec![make_config("", vec![text_message("hello")])]);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), PromptError::EmptyName));
+    }
+
+    #[test]
+    fn prompt_with_no_arguments() {
+        let store = Prompts::new(vec![make_config("simple", vec![text_message("hello")])]).unwrap();
+        let list = store.list();
+        assert!(list[0].arguments.is_none());
+    }
+
+    #[test]
+    fn prompt_name_with_special_characters() {
+        let store = Prompts::new(vec![make_config(
+            "my prompt/v2 (test)",
+            vec![text_message("hello")],
+        )])
+        .unwrap();
+        assert!(store.configs.contains_key("my prompt/v2 (test)"));
+    }
+
+    // --- get() Tests ---
+
+    #[test]
+    fn get_prompt_with_substitution() {
+        let config = PromptConfig {
+            name: "test".to_string(),
+            title: None,
+            description: Some("A test prompt".to_string()),
+            arguments: Some(vec![PromptArgumentConfig {
+                name: "email".to_string(),
+                title: None,
+                description: None,
+                required: Some(true),
+            }]),
+            messages: vec![text_message("User: {{email}}")],
+        };
+        let store = Prompts::new(vec![config]).unwrap();
+        let result = store
+            .get("test", &args(&[("email", "alice@example.com")]))
+            .unwrap();
+        assert_eq!(result.description.as_deref(), Some("A test prompt"));
+        assert_eq!(result.messages.len(), 1);
+        assert_eq!(get_text(&result, 0), "User: alice@example.com");
+    }
+
+    #[test]
+    fn get_prompt_not_found() {
+        let store = Prompts::new(vec![]).unwrap();
+        let result = store.get("nonexistent", &HashMap::new());
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            PromptError::NotFound(name) if name == "nonexistent"
+        ));
+    }
+
+    #[test]
+    fn get_prompt_missing_required_argument() {
+        let config = PromptConfig {
+            arguments: Some(vec![PromptArgumentConfig {
+                name: "email".to_string(),
+                required: Some(true),
+                ..Default::default()
+            }]),
+            ..make_config("test", vec![text_message("{{email}}")])
+        };
+        let store = Prompts::new(vec![config]).unwrap();
+        let result = store.get("test", &HashMap::new());
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            PromptError::MissingRequiredArgument { argument, .. } if argument == "email"
+        ));
+    }
+
+    #[test]
+    fn get_prompt_optional_argument_omitted() {
+        let config = PromptConfig {
+            arguments: Some(vec![PromptArgumentConfig {
+                name: "limit".to_string(),
+                required: None,
+                ..Default::default()
+            }]),
+            ..make_config("test", vec![text_message("Limit: {{limit}}")])
+        };
+        let store = Prompts::new(vec![config]).unwrap();
+        let result = store.get("test", &HashMap::new()).unwrap();
+        assert_eq!(get_text(&result, 0), "Limit: ");
+    }
+
+    #[test]
+    fn get_prompt_non_text_content_passthrough() {
+        let config = PromptConfig {
+            name: "img".to_string(),
+            title: None,
+            description: None,
+            arguments: Some(vec![PromptArgumentConfig {
+                name: "unused".to_string(),
+                ..Default::default()
+            }]),
+            messages: vec![PromptMessageConfig {
+                role: None,
+                content: PromptContentConfig::Image {
+                    data: "base64data".to_string(),
+                    mime_type: "image/png".to_string(),
+                },
+            }],
+        };
+        let store = Prompts::new(vec![config]).unwrap();
+        let result = store.get("img", &HashMap::new()).unwrap();
+        match &result.messages[0].content {
+            PromptMessageContent::Image { image } => {
+                assert_eq!(image.data, "base64data");
+                assert_eq!(image.mime_type, "image/png");
+            }
+            _ => panic!("Expected image content"),
+        }
+    }
+
+    #[test]
+    fn get_prompt_no_messages() {
+        let config = make_config("empty", vec![]);
+        let store = Prompts::new(vec![config]).unwrap();
+        let result = store.get("empty", &HashMap::new()).unwrap();
+        assert!(result.messages.is_empty());
+    }
+
+    #[test]
+    fn get_prompt_returns_description() {
+        let config = PromptConfig {
+            description: Some("My desc".to_string()),
+            ..make_config("test", vec![text_message("hello")])
+        };
+        let store = Prompts::new(vec![config]).unwrap();
+        let result = store.get("test", &HashMap::new()).unwrap();
+        assert_eq!(result.description.as_deref(), Some("My desc"));
+    }
+
+    #[test]
+    fn resource_content_passthrough() {
+        let config = PromptConfig {
+            name: "res".to_string(),
+            title: None,
+            description: None,
+            arguments: None,
+            messages: vec![PromptMessageConfig {
+                role: None,
+                content: PromptContentConfig::Resource {
+                    resource: ResourceContentConfig::Text {
+                        uri: "file:///test.txt".to_string(),
+                        mime_type: None,
+                        text: "hello".to_string(),
+                    },
+                },
+            }],
+        };
+
+        let store = Prompts::new(vec![config]).unwrap();
+        let result = store.get("res", &HashMap::new()).unwrap();
+        match &result.messages[0].content {
+            PromptMessageContent::Resource { resource } => {
+                assert!(matches!(
+                    &resource.resource,
+                    rmcp::model::ResourceContents::TextResourceContents { uri, text, .. }
+                        if uri == "file:///test.txt" && text == "hello"
+                ));
+            }
+            _ => panic!("Expected resource content"),
+        }
+    }
+
+    // --- Multi-message Tests ---
+
+    #[test]
+    fn multi_message_different_roles() {
+        let config = PromptConfig {
+            name: "multi".to_string(),
+            title: None,
+            description: None,
+            arguments: None,
+            messages: vec![
+                PromptMessageConfig {
+                    role: Some(PromptMessageRoleConfig::User),
+                    content: PromptContentConfig::Text {
+                        text: "Hello".to_string(),
+                    },
+                },
+                PromptMessageConfig {
+                    role: Some(PromptMessageRoleConfig::Assistant),
+                    content: PromptContentConfig::Text {
+                        text: "Hi there!".to_string(),
+                    },
+                },
+            ],
+        };
+        let store = Prompts::new(vec![config]).unwrap();
+        let result = store.get("multi", &HashMap::new()).unwrap();
+        assert_eq!(result.messages.len(), 2);
+        assert_eq!(result.messages[0].role, PromptMessageRole::User);
+        assert_eq!(result.messages[1].role, PromptMessageRole::Assistant);
+        assert_eq!(get_text(&result, 0), "Hello");
+        assert_eq!(get_text(&result, 1), "Hi there!");
+    }
+
+    #[test]
+    fn default_role_is_user() {
+        let config = make_config("test", vec![text_message("hello")]);
+        let store = Prompts::new(vec![config]).unwrap();
+        let result = store.get("test", &HashMap::new()).unwrap();
+        assert_eq!(result.messages[0].role, PromptMessageRole::User);
+    }
+
+    #[test]
+    fn three_messages_in_order() {
+        let config = PromptConfig {
+            name: "three".to_string(),
+            title: None,
+            description: None,
+            arguments: None,
+            messages: vec![
+                text_message("first"),
+                PromptMessageConfig {
+                    role: Some(PromptMessageRoleConfig::Assistant),
+                    content: PromptContentConfig::Text {
+                        text: "second".to_string(),
+                    },
+                },
+                text_message("third"),
+            ],
+        };
+        let store = Prompts::new(vec![config]).unwrap();
+        let result = store.get("three", &HashMap::new()).unwrap();
+        assert_eq!(result.messages.len(), 3);
+        let texts: Vec<&str> = (0..3).map(|i| get_text(&result, i)).collect();
+        assert_eq!(texts, vec!["first", "second", "third"]);
+    }
+
+    #[test]
+    fn all_messages_have_substitution() {
+        let config = PromptConfig {
+            arguments: Some(vec![PromptArgumentConfig {
+                name: "name".to_string(),
+                required: Some(true),
+                ..Default::default()
+            }]),
+            ..make_config(
+                "test",
+                vec![
+                    text_message("Hello {{name}}"),
+                    text_message("Goodbye {{name}}"),
+                ],
+            )
+        };
+        let store = Prompts::new(vec![config]).unwrap();
+        let result = store.get("test", &args(&[("name", "Alice")])).unwrap();
+        assert_eq!(get_text(&result, 0), "Hello Alice");
+        assert_eq!(get_text(&result, 1), "Goodbye Alice");
+    }
+
+    #[test]
+    fn blob_resource_content_passthrough() {
+        let config = PromptConfig {
+            name: "blob".to_string(),
+            title: None,
+            description: None,
+            arguments: None,
+            messages: vec![PromptMessageConfig {
+                role: None,
+                content: PromptContentConfig::Resource {
+                    resource: ResourceContentConfig::Blob {
+                        uri: "file:///data.bin".to_string(),
+                        mime_type: Some("application/octet-stream".to_string()),
+                        blob: "YmluYXJ5".to_string(),
+                    },
+                },
+            }],
+        };
+        let store = Prompts::new(vec![config]).unwrap();
+        let result = store.get("blob", &HashMap::new()).unwrap();
+        match &result.messages[0].content {
+            PromptMessageContent::Resource { resource } => {
+                assert!(matches!(
+                    &resource.resource,
+                    rmcp::model::ResourceContents::BlobResourceContents { uri, blob, .. }
+                        if uri == "file:///data.bin" && blob == "YmluYXJ5"
+                ));
+            }
+            _ => panic!("Expected resource content"),
+        }
+    }
+
+    #[test]
+    fn resource_link_content_passthrough() {
+        let config = PromptConfig {
+            name: "link".to_string(),
+            title: None,
+            description: None,
+            arguments: None,
+            messages: vec![PromptMessageConfig {
+                role: None,
+                content: PromptContentConfig::ResourceLink {
+                    uri: "file:///schema.graphql".to_string(),
+                    name: "schema.graphql".to_string(),
+                    description: Some("The GraphQL schema".to_string()),
+                    mime_type: Some("application/graphql".to_string()),
+                },
+            }],
+        };
+        let store = Prompts::new(vec![config]).unwrap();
+        let result = store.get("link", &HashMap::new()).unwrap();
+        match &result.messages[0].content {
+            PromptMessageContent::ResourceLink { link } => {
+                assert_eq!(link.uri, "file:///schema.graphql");
+                assert_eq!(link.name, "schema.graphql");
+                assert_eq!(link.description.as_deref(), Some("The GraphQL schema"));
+                assert_eq!(link.mime_type.as_deref(), Some("application/graphql"));
+            }
+            _ => panic!("Expected resource_link content"),
+        }
+    }
+
+    #[test]
+    fn multiple_prompts_stored_and_retrieved() {
+        let store = Prompts::new(vec![
+            make_config("alpha", vec![text_message("First")]),
+            make_config("beta", vec![text_message("Second")]),
+            make_config("gamma", vec![text_message("Third")]),
+        ])
+        .unwrap();
+
+        assert_eq!(store.list().len(), 3);
+
+        let r1 = store.get("alpha", &HashMap::new()).unwrap();
+        assert_eq!(get_text(&r1, 0), "First");
+
+        let r2 = store.get("beta", &HashMap::new()).unwrap();
+        assert_eq!(get_text(&r2, 0), "Second");
+
+        let r3 = store.get("gamma", &HashMap::new()).unwrap();
+        assert_eq!(get_text(&r3, 0), "Third");
+    }
+
+    #[test]
+    fn required_false_argument_not_enforced() {
+        let config = PromptConfig {
+            arguments: Some(vec![PromptArgumentConfig {
+                name: "opt".to_string(),
+                required: Some(false),
+                ..Default::default()
+            }]),
+            ..make_config("test", vec![text_message("val={{opt}}")])
+        };
+        let store = Prompts::new(vec![config]).unwrap();
+        // Omitting required=false argument should not error
+        let result = store.get("test", &HashMap::new()).unwrap();
+        assert_eq!(get_text(&result, 0), "val=");
+    }
+
+    #[test]
+    fn extra_arguments_ignored() {
+        let config = PromptConfig {
+            arguments: Some(vec![PromptArgumentConfig {
+                name: "known".to_string(),
+                required: Some(true),
+                ..Default::default()
+            }]),
+            ..make_config("test", vec![text_message("{{known}}")])
+        };
+        let store = Prompts::new(vec![config]).unwrap();
+        let result = store
+            .get("test", &args(&[("known", "val"), ("extra", "ignored")]))
+            .unwrap();
+        assert_eq!(get_text(&result, 0), "val");
+    }
+
+    #[test]
+    fn get_prompt_no_description_returns_none() {
+        let config = make_config("test", vec![text_message("hello")]);
+        let store = Prompts::new(vec![config]).unwrap();
+        let result = store.get("test", &HashMap::new()).unwrap();
+        assert!(result.description.is_none());
+    }
+
+    #[test]
+    fn text_template_in_resource_not_rendered() {
+        // Template placeholders in non-text content should not be rendered
+        let config = PromptConfig {
+            name: "img_tmpl".to_string(),
+            title: None,
+            description: None,
+            arguments: Some(vec![PromptArgumentConfig {
+                name: "data".to_string(),
+                ..Default::default()
+            }]),
+            messages: vec![PromptMessageConfig {
+                role: None,
+                content: PromptContentConfig::Image {
+                    data: "{{data}}".to_string(),
+                    mime_type: "image/png".to_string(),
+                },
+            }],
+        };
+        let store = Prompts::new(vec![config]).unwrap();
+        let result = store
+            .get("img_tmpl", &args(&[("data", "replaced")]))
+            .unwrap();
+        match &result.messages[0].content {
+            PromptMessageContent::Image { image } => {
+                // Image data should NOT be template-rendered
+                assert_eq!(image.data, "{{data}}");
+            }
+            _ => panic!("Expected image content"),
+        }
+    }
+}

--- a/crates/apollo-mcp-server/src/runtime.rs
+++ b/crates/apollo-mcp-server/src/runtime.rs
@@ -81,6 +81,7 @@ fn apollo_common_env() -> Env {
 #[cfg(test)]
 mod test {
     use super::read_config;
+    use apollo_mcp_server::prompts::PromptContentConfig;
 
     #[test]
     fn it_prioritizes_env_vars() {
@@ -320,6 +321,7 @@ mod test {
                 },
                 schema: Uplink,
                 transport: Stdio,
+                prompts: [],
             }
             "#);
             Ok(())
@@ -434,6 +436,51 @@ mod test {
                 config.overrides.descriptions.get("GetForecast").unwrap(),
                 "Get the 7-day forecast"
             );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn it_expands_env_vars_in_prompt_text() {
+        figment::Jail::expect_with(move |jail| {
+            let config = r#"
+                prompts:
+                  - name: env_prompt
+                    messages:
+                      - content:
+                          type: text
+                          text: ${env.TEST_PROMPT_TEXT}
+            "#;
+            let path = "config.yaml";
+
+            jail.create_file(path, config)?;
+            jail.set_env("TEST_PROMPT_TEXT", "Hello from env!");
+
+            let config = read_config(path)?;
+            assert_eq!(config.prompts.len(), 1);
+            assert_eq!(config.prompts[0].name, "env_prompt");
+            match &config.prompts[0].messages[0].content {
+                PromptContentConfig::Text { text } => {
+                    assert_eq!(text, "Hello from env!");
+                }
+                _ => panic!("Expected text content"),
+            }
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn it_parses_config_without_prompts_backward_compat() {
+        figment::Jail::expect_with(move |jail| {
+            let config = r#"
+                endpoint: http://localhost:4000/
+            "#;
+            let path = "config.yaml";
+
+            jail.create_file(path, config)?;
+
+            let config = read_config(path)?;
+            assert!(config.prompts.is_empty());
             Ok(())
         });
     }

--- a/crates/apollo-mcp-server/src/runtime/config.rs
+++ b/crates/apollo-mcp-server/src/runtime/config.rs
@@ -8,6 +8,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use url::Url;
 
+use apollo_mcp_server::prompts::PromptConfig;
 use apollo_mcp_server::server_info::ServerInfoConfig;
 
 use super::{
@@ -69,6 +70,10 @@ pub struct Config {
 
     /// The type of server transport to use
     pub transport: Transport,
+
+    /// Prompt definitions for MCP prompts support
+    #[serde(default)]
+    pub prompts: Vec<PromptConfig>,
 }
 
 mod parsers {
@@ -170,5 +175,35 @@ mod test {
         let result = serde_yaml::from_str::<Config>(yaml);
         let err = result.unwrap_err().to_string();
         assert!(err.contains("unknown field"));
+    }
+
+    #[test]
+    fn it_parses_config_with_no_prompts_section() {
+        let config = serde_json::from_str::<Config>("{}").unwrap();
+        assert!(config.prompts.is_empty());
+    }
+
+    #[test]
+    fn it_parses_config_with_empty_prompts() {
+        let yaml = r#"
+            prompts: []
+        "#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.prompts.is_empty());
+    }
+
+    #[test]
+    fn it_parses_config_with_prompts() {
+        let yaml = r#"
+            prompts:
+              - name: test_prompt
+                messages:
+                  - content:
+                      type: text
+                      text: "Hello"
+        "#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.prompts.len(), 1);
+        assert_eq!(config.prompts[0].name, "test_prompt");
     }
 }

--- a/crates/apollo-mcp-server/src/server.rs
+++ b/crates/apollo-mcp-server/src/server.rs
@@ -17,6 +17,7 @@ use crate::headers::ForwardHeaders;
 use crate::health::HealthCheckConfig;
 use crate::host_validation::HostValidationConfig;
 use crate::operations::{MutationMode, OperationSource};
+use crate::prompts::PromptConfig;
 use crate::server_info::ServerInfoConfig;
 
 mod states;
@@ -55,6 +56,7 @@ pub struct Server {
     health_check: HealthCheckConfig,
     cors: CorsConfig,
     server_info: ServerInfoConfig,
+    prompts: Vec<PromptConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default, JsonSchema)]
@@ -136,6 +138,7 @@ impl Server {
         health_check: HealthCheckConfig,
         cors: CorsConfig,
         server_info: ServerInfoConfig,
+        #[builder(default)] prompts: Vec<PromptConfig>,
     ) -> Self {
         let headers = {
             let mut headers = headers.clone();
@@ -173,6 +176,7 @@ impl Server {
             health_check,
             cors,
             server_info,
+            prompts,
         }
     }
 

--- a/crates/apollo-mcp-server/src/server/states.rs
+++ b/crates/apollo-mcp-server/src/server/states.rs
@@ -16,6 +16,7 @@ use crate::{
     headers::ForwardHeaders,
     health::HealthCheckConfig,
     operations::MutationMode,
+    prompts::PromptConfig,
     server_info::ServerInfoConfig,
 };
 
@@ -66,6 +67,7 @@ struct Config {
     health_check: HealthCheckConfig,
     cors: CorsConfig,
     server_info: ServerInfoConfig,
+    prompts: Vec<PromptConfig>,
 }
 
 impl StateMachine {
@@ -115,6 +117,7 @@ impl StateMachine {
                 health_check: server.health_check,
                 cors: server.cors,
                 server_info: server.server_info,
+                prompts: server.prompts,
             },
         });
 
@@ -400,6 +403,7 @@ mod tests {
             health_check: None,
             server_info: ServerInfoConfig::default(),
             rhai_engine: Arc::new(parking_lot::Mutex::new(RhaiEngine::new("rhai"))),
+            prompts: None,
         }
     }
 
@@ -439,6 +443,7 @@ mod tests {
             health_check: HealthCheckConfig::default(),
             cors: CorsConfig::default(),
             server_info: ServerInfoConfig::default(),
+            prompts: vec![],
         }
     }
 

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -6,16 +6,14 @@ use opentelemetry::KeyValue;
 use parking_lot::Mutex;
 use reqwest::header::HeaderMap;
 use rmcp::ErrorData;
-use rmcp::model::{
-    ClientCapabilities, Extensions, Implementation, ListResourcesResult, ReadResourceResult,
-    ResourcesCapability, ToolsCapability,
-};
 use rmcp::{
     Peer, RoleServer, ServerHandler, ServiceError,
     model::{
-        CallToolRequestParams, CallToolResult, Content, ErrorCode, InitializeRequestParams,
-        InitializeResult, ListToolsResult, PaginatedRequestParams, ProtocolVersion,
-        ServerCapabilities, ServerInfo,
+        CallToolRequestParams, CallToolResult, ClientCapabilities, Content, ErrorCode, Extensions,
+        GetPromptRequestParams, GetPromptResult, Implementation, InitializeRequestParams,
+        InitializeResult, JsonObject, ListPromptsResult, ListResourcesResult, ListToolsResult,
+        PaginatedRequestParams, PromptsCapability, ProtocolVersion, ReadResourceResult,
+        ResourcesCapability, ServerCapabilities, ServerInfo, ToolsCapability,
     },
     service::RequestContext,
 };
@@ -31,6 +29,7 @@ use crate::apps::tool::{attach_tool_metadata, find_and_execute_app_tool, make_to
 use crate::generated::telemetry::{TelemetryAttribute, TelemetryMetric};
 use crate::meter;
 use crate::operations::{execute_operation, find_and_execute_operation};
+use crate::prompts::Prompts;
 use crate::server::states::telemetry::get_parent_span;
 use crate::server_info::ServerInfoConfig;
 use crate::{
@@ -74,6 +73,7 @@ pub(super) struct Running {
     pub(super) health_check: Option<HealthCheck>,
     pub(super) server_info: ServerInfoConfig,
     pub(super) rhai_engine: Arc<Mutex<RhaiEngine>>,
+    pub(super) prompts: Option<Prompts>,
 }
 
 impl Running {
@@ -544,6 +544,64 @@ impl ServerHandler for Running {
         Ok(self.get_info())
     }
 
+    #[tracing::instrument(skip_all, fields(apollo.mcp.prompt_name = request.name.as_str()))]
+    async fn get_prompt(
+        &self,
+        request: GetPromptRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<GetPromptResult, McpError> {
+        let prompt = self.prompts.as_ref().ok_or_else(|| {
+            McpError::new(
+                ErrorCode::INVALID_PARAMS,
+                format!("Prompt not found: {}", request.name),
+                None,
+            )
+        })?;
+
+        let args = convert_prompt_arguments(request.arguments);
+        prompt
+            .get(&request.name, &args)
+            .map_err(|e| McpError::new(ErrorCode::INVALID_PARAMS, e.to_string(), None))
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn list_prompts(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListPromptsResult, McpError> {
+        let prompts = self
+            .prompts
+            .as_ref()
+            .map(|store| store.list().to_vec())
+            .unwrap_or_default();
+        Ok(ListPromptsResult {
+            prompts,
+            ..Default::default()
+        })
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn list_resources(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, ErrorData> {
+        self.list_resources_impl(&context.extensions)
+    }
+
+    #[tracing::instrument(skip_all, fields(apollo.mcp.resource_uri = request.uri.as_str(), apollo.mcp.request_id = %context.id.clone()))]
+    async fn read_resource(
+        &self,
+        request: rmcp::model::ReadResourceRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, ErrorData> {
+        let client_capabilities = context.peer.peer_info().map(|info| &info.capabilities);
+
+        self.read_resource_impl(request, context.extensions, client_capabilities)
+            .await
+    }
+
     #[tracing::instrument(skip_all, parent = get_parent_span(&context), fields(apollo.mcp.tool_name = request.name.as_ref(), apollo.mcp.request_id = %context.id.clone()))]
     async fn call_tool(
         &self,
@@ -571,27 +629,6 @@ impl ServerHandler for Running {
             .await
     }
 
-    #[tracing::instrument(skip_all)]
-    async fn list_resources(
-        &self,
-        _request: Option<PaginatedRequestParams>,
-        context: RequestContext<RoleServer>,
-    ) -> Result<ListResourcesResult, ErrorData> {
-        self.list_resources_impl(&context.extensions)
-    }
-
-    #[tracing::instrument(skip_all, fields(apollo.mcp.resource_uri = request.uri.as_str(), apollo.mcp.request_id = %context.id.clone()))]
-    async fn read_resource(
-        &self,
-        request: rmcp::model::ReadResourceRequestParams,
-        context: RequestContext<RoleServer>,
-    ) -> Result<ReadResourceResult, ErrorData> {
-        let client_capabilities = context.peer.peer_info().map(|info| &info.capabilities);
-
-        self.read_resource_impl(request, context.extensions, client_capabilities)
-            .await
-    }
-
     fn get_info(&self) -> ServerInfo {
         let meter = &meter::METER;
         meter
@@ -604,6 +641,11 @@ impl ServerHandler for Running {
             list_changed: Some(true),
         });
         capabilities.resources = (!self.apps.is_empty()).then(ResourcesCapability::default);
+        if self.prompts.is_some() {
+            capabilities.prompts = Some(PromptsCapability {
+                list_changed: Some(false),
+            });
+        }
 
         let protocol_version = if self.enable_output_schema {
             ProtocolVersion::default()
@@ -649,6 +691,23 @@ fn tool_not_found(name: &str) -> McpError {
     )
 }
 
+fn convert_prompt_arguments(arguments: Option<JsonObject>) -> HashMap<String, String> {
+    arguments
+        .map(|obj| {
+            obj.into_iter()
+                .filter(|(_, v)| !v.is_null())
+                .map(|(k, v)| {
+                    let value = match v {
+                        Value::String(s) => s,
+                        other => other.to_string(),
+                    };
+                    (k, value)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
     use rmcp::model::{JsonObject, Tool};
@@ -686,6 +745,7 @@ mod tests {
             health_check: None,
             server_info: ServerInfoConfig::default(),
             rhai_engine: Arc::new(parking_lot::Mutex::new(RhaiEngine::new("rhai"))),
+            prompts: None,
         }
     }
 
@@ -2105,6 +2165,7 @@ mod integration_tests {
                 health_check: None,
                 server_info: Default::default(),
                 rhai_engine: Arc::new(parking_lot::Mutex::new(RhaiEngine::new("rhai"))),
+                prompts: None,
             }
         }
 
@@ -2331,6 +2392,7 @@ mod integration_tests {
                 health_check: None,
                 server_info: Default::default(),
                 rhai_engine: Arc::new(parking_lot::Mutex::new(RhaiEngine::new("rhai"))),
+                prompts: None,
             }
         }
 
@@ -2560,6 +2622,7 @@ mod integration_tests {
                 health_check: None,
                 server_info: Default::default(),
                 rhai_engine: Arc::new(parking_lot::Mutex::new(RhaiEngine::new("rhai"))),
+                prompts: None,
             }
         }
 
@@ -2837,5 +2900,47 @@ mod integration_tests {
                 .unwrap();
             assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
         }
+    }
+
+    #[test]
+    fn convert_prompt_arguments_none_returns_empty() {
+        let result = convert_prompt_arguments(None);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn convert_prompt_arguments_empty_object() {
+        let obj = JsonObject::new();
+        let result = convert_prompt_arguments(Some(obj));
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn convert_prompt_arguments_string_values() {
+        let mut obj = JsonObject::new();
+        obj.insert("email".to_string(), Value::String("a@b.com".to_string()));
+        let result = convert_prompt_arguments(Some(obj));
+        assert_eq!(result.get("email").unwrap(), "a@b.com");
+    }
+
+    #[test]
+    fn convert_prompt_arguments_null_values_filtered() {
+        let mut obj = JsonObject::new();
+        obj.insert("present".to_string(), Value::String("val".to_string()));
+        obj.insert("absent".to_string(), Value::Null);
+        let result = convert_prompt_arguments(Some(obj));
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key("present"));
+        assert!(!result.contains_key("absent"));
+    }
+
+    #[test]
+    fn convert_prompt_arguments_non_string_types_stringified() {
+        let mut obj = JsonObject::new();
+        obj.insert("num".to_string(), Value::Number(42.into()));
+        obj.insert("bool".to_string(), Value::Bool(true));
+        let result = convert_prompt_arguments(Some(obj));
+        assert_eq!(result.get("num").unwrap(), "42");
+        assert_eq!(result.get("bool").unwrap(), "true");
     }
 }

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -11,8 +11,10 @@ use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 
+use super::{Config, Running, shutdown_signal};
 use crate::host_validation::{HostValidationState, validate_host};
 use crate::operations::apply_description_override;
+use crate::prompts::Prompts;
 use crate::server::states::telemetry::otel_context_middleware;
 use crate::{
     cors::CorsConfig,
@@ -26,8 +28,6 @@ use crate::{
     server::Transport,
 };
 use apollo_mcp_rhai::{RhaiEngine, checkpoints};
-
-use super::{Config, Running, shutdown_signal};
 
 pub(super) struct Starting {
     pub(super) config: Config,
@@ -160,6 +160,14 @@ impl Starting {
             })?;
         }
 
+        let prompts = if self.config.prompts.is_empty() {
+            None
+        } else {
+            Some(Prompts::new(self.config.prompts).inspect_err(|err| {
+                error!("Invalid prompt configuration: {err}");
+            })?)
+        };
+
         let running = Running {
             schema,
             operations: Arc::new(RwLock::new(operations)),
@@ -184,6 +192,7 @@ impl Starting {
             health_check: health_check.clone(),
             server_info: self.config.server_info.clone(),
             rhai_engine: engine,
+            prompts,
         };
 
         match self.config.transport {
@@ -325,6 +334,7 @@ mod tests {
                 },
                 cors: Default::default(),
                 server_info: Default::default(),
+                prompts: vec![],
             },
             schema: Schema::parse_and_validate("type Query { hello: String }", "test.graphql")
                 .expect("Valid schema"),


### PR DESCRIPTION
## Summary                                                                                                                                                                 

Issue [#699](https://github.com/apollographql/apollo-mcp-server/issues/699)
                                                                                                                                                                                                                                                                                 
- Add support for [MCP Prompts](https://modelcontextprotocol.io/docs/concepts/prompts) as the third MCP capability alongside Tools and Resources                           
- Prompts are defined in the YAML config under a new `prompts` key, with support for template arguments (`{{arg}}`), multiple content types (text, image, resource,
resource\_link), and role-based messages (user/assistant)                                                                                                                  
- Server advertises `PromptsCapability` and handles `list_prompts` / `get_prompt` requests when prompts are configured
                                                                                                                                                                           
## Example config
                                                                                                                                                                           
```yaml         
prompts:
  - name: check_order_history                                                                                                                                              
    description: "Look up a user's recent orders"
    arguments:                                                                                                                                                             
      - name: email
        required: true                                                                                                                                                     
    messages:   
      - role: user                                                                                                                                                         
        content:                                                                                                                                                           
          type: text                                                                                                                                                       
          text: |                                                                                                                                                          
            1. GetUserByEmail(email={{email}}) → get userId                                                                                                                
            2. GetUserOrders(userId, first=10) → cursor-paginated                                                                                                          
            3. GetOrderDetails(orderId) for each order if needed                                                                                                           
```
                                                                                                                                                      
Changes                                                                                                                                                                    
                                                                                                                                                                           
- prompts/config.rs — YAML-backed config types (PromptConfig, PromptMessageConfig, PromptContentConfig, etc.) with serde + JSON Schema support                             
- prompts/render.rs — Single-pass {{arg}} template engine with injection prevention (argument values are never re-evaluated)
- prompts/store.rs — Prompts store with validation (empty/duplicate name, required argument enforcement) and conversion to MCP protocol types                              
- errors.rs — PromptError variants for validation failures                                                                                                                 
- server/states/running.rs — list_prompts and get_prompt handler implementations; PromptsCapability advertised conditionally                                               
- runtime/config.rs — prompts field on Config with #[serde(default)]                                                                                                       
