### PR TITLE
feat: add MCP prompts support via markdown files

### DIFF
--- a/.changeset/add_mcp_prompts_support.md
+++ b/.changeset/add_mcp_prompts_support.md
@@ -1,0 +1,9 @@
+---
+default: minor
+---
+
+# Add MCP prompts support via Markdown files
+
+Apollo MCP Server now supports [MCP prompts](https://modelcontextprotocol.io/docs/concepts/prompts). Prompts are reusable templates that guide AI models through multi-step workflows using your GraphQL tools.
+
+Each prompt is a Markdown file in a `prompts/` directory with YAML frontmatter for metadata (name, description, arguments) and a template body with `{{argument}}` placeholders. The server loads prompts at startup and serves them via the `prompts/list` and `prompts/get` MCP methods. No configuration changes are needed — the server automatically detects the `prompts/` directory.

--- a/crates/apollo-mcp-server/src/errors.rs
+++ b/crates/apollo-mcp-server/src/errors.rs
@@ -107,6 +107,9 @@ pub enum ServerError {
     #[error("Failed to load apps: {0}")]
     Apps(String),
 
+    #[error("Failed to load prompts: {0}")]
+    Prompts(String),
+
     #[error("TLS configuration error: {0}")]
     Tls(#[from] crate::auth::TlsConfigError),
 

--- a/crates/apollo-mcp-server/src/lib.rs
+++ b/crates/apollo-mcp-server/src/lib.rs
@@ -16,6 +16,7 @@ mod introspection;
 pub(crate) mod json_schema;
 pub(crate) mod meter;
 pub mod operations;
+pub(crate) mod prompts;
 pub(crate) mod schema_tree_shake;
 pub mod server;
 pub mod server_info;

--- a/crates/apollo-mcp-server/src/prompts/mod.rs
+++ b/crates/apollo-mcp-server/src/prompts/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod prompt_file;
+
+pub(crate) use prompt_file::{PromptFile, load_from_path};

--- a/crates/apollo-mcp-server/src/prompts/prompt_file.rs
+++ b/crates/apollo-mcp-server/src/prompts/prompt_file.rs
@@ -1,0 +1,293 @@
+use std::path::Path;
+
+use rmcp::model::{Prompt, PromptArgument};
+use serde::Deserialize;
+use serde_json::Map;
+use tracing::debug;
+
+/// A loaded prompt file, containing the MCP prompt metadata and the template body.
+#[derive(Clone, Debug)]
+pub(crate) struct PromptFile {
+    /// The MCP prompt definition (name, description, arguments).
+    pub(crate) prompt: Prompt,
+    /// The template body text with `{{arg}}` placeholders.
+    pub(crate) template: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PromptFrontmatter {
+    name: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    arguments: Vec<FrontmatterArgument>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FrontmatterArgument {
+    name: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    required: bool,
+}
+
+/// Parse YAML frontmatter and body from a Markdown string.
+///
+/// Expects the content to start with `---`, followed by YAML, then a closing `---`,
+/// and the remaining text is the prompt template body.
+fn parse_frontmatter(content: &str) -> Result<(PromptFrontmatter, String), String> {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return Err("Missing opening frontmatter delimiter '---'".to_string());
+    }
+
+    let after_opening = &trimmed[3..];
+    let closing_pos = after_opening
+        .find("\n---")
+        .ok_or_else(|| "Missing closing frontmatter delimiter '---'".to_string())?;
+
+    let yaml_str = &after_opening[..closing_pos];
+    let body_start = closing_pos + 4; // skip "\n---"
+    let body = after_opening
+        .get(body_start..)
+        .unwrap_or("")
+        .trim()
+        .to_string();
+
+    let frontmatter: PromptFrontmatter =
+        serde_yaml::from_str(yaml_str).map_err(|err| format!("Invalid frontmatter YAML: {err}"))?;
+
+    Ok((frontmatter, body))
+}
+
+/// Replace `{{name}}` placeholders in the template with argument values.
+pub(crate) fn substitute_args(
+    template: &str,
+    arguments: &Map<String, serde_json::Value>,
+) -> String {
+    let mut result = template.to_string();
+    for (key, value) in arguments {
+        let placeholder = format!("{{{{{key}}}}}");
+        if let Some(s) = value.as_str() {
+            result = result.replace(&placeholder, s);
+        } else {
+            let replacement = value.to_string();
+            result = result.replace(&placeholder, &replacement);
+        }
+    }
+    result
+}
+
+fn load_single_file(path: &Path) -> Result<PromptFile, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|err| format!("Failed to read {}: {err}", path.display()))?;
+
+    let (frontmatter, body) = parse_frontmatter(&content)
+        .map_err(|err| format!("Failed to parse {}: {err}", path.display()))?;
+
+    let arguments: Vec<PromptArgument> = frontmatter
+        .arguments
+        .into_iter()
+        .map(|arg| {
+            let mut pa = PromptArgument::new(&arg.name).with_required(arg.required);
+            if let Some(desc) = arg.description {
+                pa = pa.with_description(desc);
+            }
+            pa
+        })
+        .collect();
+
+    let prompt = Prompt::new(
+        &frontmatter.name,
+        frontmatter.description.as_deref(),
+        if arguments.is_empty() {
+            None
+        } else {
+            Some(arguments)
+        },
+    );
+
+    Ok(PromptFile {
+        prompt,
+        template: body,
+    })
+}
+
+/// Load all `.md` prompt files from the given directory.
+///
+/// Returns `Ok(vec![])` if the directory does not exist.
+pub(crate) fn load_from_path(path: &Path) -> Result<Vec<PromptFile>, String> {
+    let Ok(dir) = path.read_dir() else {
+        return Ok(Vec::new());
+    };
+
+    let mut prompts = Vec::new();
+    for entry in dir {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) => {
+                debug!("Failed to read prompts directory entry, ignoring: {err}");
+                continue;
+            }
+        };
+        let file_path = entry.path();
+        if !file_path.is_file() {
+            debug!("{} is not a file, ignoring", file_path.display());
+            continue;
+        }
+        if file_path.extension().and_then(|ext| ext.to_str()) != Some("md") {
+            debug!("{} is not a .md file, ignoring", file_path.display());
+            continue;
+        }
+
+        let prompt = load_single_file(&file_path)?;
+        debug!(
+            "Loaded prompt '{}' from {}",
+            prompt.prompt.name,
+            file_path.display()
+        );
+        prompts.push(prompt);
+    }
+
+    Ok(prompts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_fs::{TempDir, prelude::*};
+
+    #[test]
+    fn parse_valid_frontmatter() {
+        let content = r#"---
+name: check_order_history
+description: "Look up a user's recent orders"
+arguments:
+  - name: email
+    required: true
+---
+
+1. GetUserByEmail(email={{email}}) → get userId
+2. GetUserOrders(userId, first=10)
+"#;
+        let (fm, body) = parse_frontmatter(content).unwrap();
+        assert_eq!(fm.name, "check_order_history");
+        assert_eq!(
+            fm.description.as_deref(),
+            Some("Look up a user's recent orders")
+        );
+        assert_eq!(fm.arguments.len(), 1);
+        assert_eq!(fm.arguments[0].name, "email");
+        assert!(fm.arguments[0].required);
+        assert!(body.starts_with("1. GetUserByEmail"));
+    }
+
+    #[test]
+    fn parse_frontmatter_no_arguments() {
+        let content = "---\nname: simple\n---\nHello world";
+        let (fm, body) = parse_frontmatter(content).unwrap();
+        assert_eq!(fm.name, "simple");
+        assert!(fm.description.is_none());
+        assert!(fm.arguments.is_empty());
+        assert_eq!(body, "Hello world");
+    }
+
+    #[test]
+    fn parse_frontmatter_missing_opening() {
+        let content = "name: bad\n---\nBody";
+        let err = parse_frontmatter(content).unwrap_err();
+        assert!(err.contains("Missing opening frontmatter delimiter"));
+    }
+
+    #[test]
+    fn parse_frontmatter_missing_closing() {
+        let content = "---\nname: bad\nBody without closing";
+        let err = parse_frontmatter(content).unwrap_err();
+        assert!(err.contains("Missing closing frontmatter delimiter"));
+    }
+
+    #[test]
+    fn substitute_args_single() {
+        let mut args = Map::new();
+        args.insert(
+            "email".to_string(),
+            serde_json::Value::String("test@example.com".to_string()),
+        );
+        let result = substitute_args("GetUser(email={{email}})", &args);
+        assert_eq!(result, "GetUser(email=test@example.com)");
+    }
+
+    #[test]
+    fn substitute_args_multiple() {
+        let mut args = Map::new();
+        args.insert(
+            "name".to_string(),
+            serde_json::Value::String("Alice".to_string()),
+        );
+        args.insert("count".to_string(), serde_json::json!(10));
+        let result = substitute_args("Hello {{name}}, you have {{count}} items", &args);
+        assert_eq!(result, "Hello Alice, you have 10 items");
+    }
+
+    #[test]
+    fn substitute_args_unmatched_left_as_is() {
+        let args = Map::new();
+        let result = substitute_args("Hello {{unknown}}", &args);
+        assert_eq!(result, "Hello {{unknown}}");
+    }
+
+    #[test]
+    fn load_from_nonexistent_directory() {
+        let result = load_from_path(Path::new("nonexistent_prompts_dir"));
+        assert_eq!(result.unwrap().len(), 0);
+    }
+
+    #[test]
+    fn load_from_directory_with_prompt_files() {
+        let temp = TempDir::new().expect("Could not create temporary directory for test");
+        temp.child("greeting.md")
+            .write_str(
+                "---\nname: greeting\ndescription: \"A greeting prompt\"\narguments:\n  - name: name\n    required: true\n---\nHello {{name}}!",
+            )
+            .unwrap();
+        temp.child("simple.md")
+            .write_str("---\nname: simple\n---\nNo args needed.")
+            .unwrap();
+        // Non-md file should be ignored
+        temp.child("readme.txt").write_str("not a prompt").unwrap();
+
+        let prompts = load_from_path(temp.path()).unwrap();
+        assert_eq!(prompts.len(), 2);
+
+        let greeting = prompts
+            .iter()
+            .find(|p| p.prompt.name == "greeting")
+            .unwrap();
+        assert_eq!(
+            greeting.prompt.description.as_deref(),
+            Some("A greeting prompt")
+        );
+        assert_eq!(greeting.prompt.arguments.as_ref().unwrap().len(), 1);
+        assert_eq!(greeting.template, "Hello {{name}}!");
+
+        let simple = prompts.iter().find(|p| p.prompt.name == "simple").unwrap();
+        assert!(simple.prompt.arguments.is_none());
+        assert_eq!(simple.template, "No args needed.");
+    }
+
+    #[test]
+    fn load_single_file_with_argument_description() {
+        let temp = TempDir::new().expect("Could not create temporary directory for test");
+        let file = temp.child("with_desc.md");
+        file.write_str(
+            "---\nname: with_desc\narguments:\n  - name: email\n    description: \"The user email\"\n    required: true\n---\nLookup {{email}}",
+        )
+        .unwrap();
+
+        let prompt = super::load_single_file(file.path()).unwrap();
+        let args = prompt.prompt.arguments.unwrap();
+        assert_eq!(args[0].description.as_deref(), Some("The user email"));
+        assert_eq!(args[0].required, Some(true));
+    }
+}

--- a/crates/apollo-mcp-server/src/server/states.rs
+++ b/crates/apollo-mcp-server/src/server/states.rs
@@ -439,6 +439,7 @@ mod tests {
             schema: Arc::new(RwLock::new(schema)),
             operations: Arc::new(RwLock::new(vec![])),
             apps: vec![],
+            prompts: vec![],
             headers: HeaderMap::new(),
             forward_headers: vec![],
             endpoint: "http://localhost:4000".parse().unwrap(),

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -7,8 +7,9 @@ use parking_lot::Mutex;
 use reqwest::header::HeaderMap;
 use rmcp::ErrorData;
 use rmcp::model::{
-    ClientCapabilities, Extensions, Implementation, ListResourcesResult, ReadResourceResult,
-    ResourcesCapability, ToolsCapability,
+    ClientCapabilities, Extensions, GetPromptRequestParams, GetPromptResult, Implementation,
+    ListPromptsResult, ListResourcesResult, PromptMessage, PromptMessageRole, PromptsCapability,
+    ReadResourceResult, ResourcesCapability, ToolsCapability,
 };
 use rmcp::{
     Peer, RoleServer, ServerHandler, ServiceError,
@@ -54,6 +55,7 @@ pub(super) struct Running {
     pub(super) schema: Arc<RwLock<Valid<Schema>>>,
     pub(super) operations: Arc<RwLock<Vec<Operation>>>,
     pub(super) apps: Vec<crate::apps::App>,
+    pub(super) prompts: Vec<crate::prompts::PromptFile>,
     pub(super) headers: HeaderMap,
     pub(super) forward_headers: ForwardHeaders,
     pub(super) endpoint: Url,
@@ -552,6 +554,58 @@ impl Running {
             ))
         }
     }
+
+    fn list_prompts_impl(&self) -> Result<ListPromptsResult, McpError> {
+        Ok(ListPromptsResult::with_all_items(
+            self.prompts.iter().map(|p| p.prompt.clone()).collect(),
+        ))
+    }
+
+    fn get_prompt_impl(
+        &self,
+        request: GetPromptRequestParams,
+    ) -> Result<GetPromptResult, McpError> {
+        let prompt_file = self
+            .prompts
+            .iter()
+            .find(|p| p.prompt.name == request.name)
+            .ok_or_else(|| {
+                McpError::new(
+                    ErrorCode::INVALID_PARAMS,
+                    format!("Prompt '{}' not found", request.name),
+                    None,
+                )
+            })?;
+
+        // Validate required arguments are present
+        if let Some(args_def) = &prompt_file.prompt.arguments {
+            let provided = request.arguments.as_ref();
+            for arg in args_def {
+                if arg.required == Some(true)
+                    && !provided.is_some_and(|a| a.contains_key(&arg.name))
+                {
+                    return Err(McpError::new(
+                        ErrorCode::INVALID_PARAMS,
+                        format!("Missing required argument: '{}'", arg.name),
+                        None,
+                    ));
+                }
+            }
+        }
+
+        let text = if let Some(arguments) = &request.arguments {
+            crate::prompts::prompt_file::substitute_args(&prompt_file.template, arguments)
+        } else {
+            prompt_file.template.clone()
+        };
+
+        let mut result =
+            GetPromptResult::new(vec![PromptMessage::new_text(PromptMessageRole::User, text)]);
+        if let Some(desc) = &prompt_file.prompt.description {
+            result = result.with_description(desc);
+        }
+        Ok(result)
+    }
 }
 
 impl ServerHandler for Running {
@@ -630,6 +684,24 @@ impl ServerHandler for Running {
             .await
     }
 
+    #[tracing::instrument(skip_all)]
+    async fn list_prompts(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListPromptsResult, McpError> {
+        self.list_prompts_impl()
+    }
+
+    #[tracing::instrument(skip_all, fields(apollo.mcp.prompt_name = request.name))]
+    async fn get_prompt(
+        &self,
+        request: GetPromptRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<GetPromptResult, McpError> {
+        self.get_prompt_impl(request)
+    }
+
     fn get_info(&self) -> ServerInfo {
         let meter = &meter::METER;
         meter
@@ -642,6 +714,8 @@ impl ServerHandler for Running {
             list_changed: Some(true),
         });
         capabilities.resources = (!self.apps.is_empty()).then(ResourcesCapability::default);
+        capabilities.prompts =
+            (!self.prompts.is_empty()).then_some(PromptsCapability { list_changed: None });
 
         let protocol_version = if self.enable_output_schema {
             ProtocolVersion::default()
@@ -704,6 +778,7 @@ mod tests {
             schema,
             operations: Arc::new(RwLock::new(vec![])),
             apps: vec![],
+            prompts: vec![],
             headers: HeaderMap::new(),
             forward_headers: vec![],
             endpoint: "http://localhost:4000".parse().unwrap(),
@@ -1904,6 +1979,116 @@ mod tests {
         }
     }
 
+    mod prompts {
+        use super::*;
+        use rmcp::model::{GetPromptRequestParams, Prompt, PromptArgument, PromptMessageRole};
+
+        fn running_with_prompts(prompts: Vec<crate::prompts::PromptFile>) -> Running {
+            let schema = Schema::parse("type Query { id: String }", "schema.graphql")
+                .unwrap()
+                .validate()
+                .unwrap();
+            Running {
+                prompts,
+                ..test_running(Arc::new(RwLock::new(schema)))
+            }
+        }
+
+        #[test]
+        fn list_prompts_empty() {
+            let running = running_with_prompts(vec![]);
+            let result = running.list_prompts_impl().unwrap();
+            assert!(result.prompts.is_empty());
+        }
+
+        #[test]
+        fn list_prompts_returns_loaded_prompts() {
+            let prompts = vec![crate::prompts::PromptFile {
+                prompt: Prompt::new("greeting", Some("A greeting"), None),
+                template: "Hello {{name}}!".to_string(),
+            }];
+            let running = running_with_prompts(prompts);
+            let result = running.list_prompts_impl().unwrap();
+            assert_eq!(result.prompts.len(), 1);
+            assert_eq!(result.prompts[0].name, "greeting");
+            assert_eq!(result.prompts[0].description.as_deref(), Some("A greeting"));
+        }
+
+        #[test]
+        fn get_prompt_substitutes_arguments() {
+            let prompts = vec![crate::prompts::PromptFile {
+                prompt: Prompt::new(
+                    "greet",
+                    Some("Greet someone"),
+                    Some(vec![PromptArgument::new("name").with_required(true)]),
+                ),
+                template: "Hello {{name}}!".to_string(),
+            }];
+            let running = running_with_prompts(prompts);
+            let mut args = serde_json::Map::new();
+            args.insert("name".to_string(), serde_json::json!("Alice"));
+            let result = running
+                .get_prompt_impl(GetPromptRequestParams::new("greet").with_arguments(args))
+                .unwrap();
+            assert_eq!(result.messages.len(), 1);
+            assert_eq!(result.messages[0].role, PromptMessageRole::User);
+            assert!(
+                matches!(
+                    &result.messages[0].content,
+                    rmcp::model::PromptMessageContent::Text { text } if text == "Hello Alice!"
+                ),
+                "Expected Text content with 'Hello Alice!', got {:?}",
+                result.messages[0].content
+            );
+        }
+
+        #[test]
+        fn get_prompt_not_found() {
+            let running = running_with_prompts(vec![]);
+            let err = running
+                .get_prompt_impl(GetPromptRequestParams::new("nonexistent"))
+                .unwrap_err();
+            assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+            assert!(err.message.contains("not found"));
+        }
+
+        #[test]
+        fn get_prompt_missing_required_argument() {
+            let prompts = vec![crate::prompts::PromptFile {
+                prompt: Prompt::new(
+                    "greet",
+                    None::<String>,
+                    Some(vec![PromptArgument::new("name").with_required(true)]),
+                ),
+                template: "Hello {{name}}!".to_string(),
+            }];
+            let running = running_with_prompts(prompts);
+            let err = running
+                .get_prompt_impl(GetPromptRequestParams::new("greet"))
+                .unwrap_err();
+            assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+            assert!(err.message.contains("Missing required argument"));
+        }
+
+        #[test]
+        fn get_info_includes_prompts_capability_when_prompts_exist() {
+            let prompts = vec![crate::prompts::PromptFile {
+                prompt: Prompt::new("test", None::<String>, None),
+                template: "test".to_string(),
+            }];
+            let running = running_with_prompts(prompts);
+            let info = running.get_info();
+            assert!(info.capabilities.prompts.is_some());
+        }
+
+        #[test]
+        fn get_info_no_prompts_capability_when_empty() {
+            let running = running_with_prompts(vec![]);
+            let info = running.get_info();
+            assert!(info.capabilities.prompts.is_none());
+        }
+    }
+
     mod call_tool {
         use super::*;
         use crate::apps::app::{AppResource, AppResourceSource};
@@ -2123,6 +2308,7 @@ mod integration_tests {
                 schema: Arc::new(RwLock::new(schema)),
                 operations: Arc::new(RwLock::new(vec![operation])),
                 apps: vec![],
+                prompts: vec![],
                 headers: http::HeaderMap::new(),
                 forward_headers: vec![],
                 endpoint: url::Url::parse("http://localhost:4000").unwrap(),
@@ -2349,6 +2535,7 @@ mod integration_tests {
                 schema: Arc::new(RwLock::new(schema)),
                 operations: Arc::new(RwLock::new(vec![operation])),
                 apps: vec![],
+                prompts: vec![],
                 headers: http::HeaderMap::new(),
                 forward_headers: vec![],
                 endpoint,
@@ -2578,6 +2765,7 @@ mod integration_tests {
                 schema: Arc::new(RwLock::new(schema)),
                 operations: Arc::new(RwLock::new(vec![])),
                 apps: vec![],
+                prompts: vec![],
                 headers: http::HeaderMap::new(),
                 forward_headers: vec![],
                 endpoint: url::Url::parse("http://localhost:4000").unwrap(),
@@ -2898,6 +3086,7 @@ mod integration_tests {
                 schema: Arc::new(RwLock::new(schema)),
                 operations: Arc::new(RwLock::new(vec![])),
                 apps: vec![],
+                prompts: vec![],
                 headers: http::HeaderMap::new(),
                 forward_headers: vec![],
                 endpoint: url::Url::parse("http://localhost:4000").unwrap(),

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -107,6 +107,8 @@ impl Starting {
             self.config.enable_output_schema,
         )
         .map_err(ServerError::Apps)?;
+        let prompts =
+            crate::prompts::load_from_path(Path::new("prompts")).map_err(ServerError::Prompts)?;
         let schema = Arc::new(RwLock::new(self.schema));
         let introspect_tool = self.config.introspect_introspection.then(|| {
             Introspect::new(
@@ -164,6 +166,7 @@ impl Starting {
             schema,
             operations: Arc::new(RwLock::new(operations)),
             apps,
+            prompts,
             headers: self.config.headers,
             forward_headers: self.config.forward_headers.clone(),
             endpoint: self.config.endpoint,

--- a/docs/source/_sidebar.yaml
+++ b/docs/source/_sidebar.yaml
@@ -12,6 +12,8 @@ items:
     href: "./quickstart"
   - label: "Define tools"
     href: "./define-tools"
+  - label: "Define prompts"
+    href: "./prompts"
   - label: "Configuration"
     children:
       - label: "YAML Config Reference"

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -12,11 +12,11 @@ Apollo MCP Server provides a standard way for AI models to access and orchestrat
 
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) is an open protocol that standardizes how applications provide context to AI models like Large Language Models (LLM). MCP enables LLMs and AI agents to indirectly fetch data from external sources.
 
-MCP follows a client-server architecture. MCP servers expose functions, called _tools_, that MCP clients can invoke.
+MCP follows a client-server architecture. MCP servers expose functions, called _tools_, that MCP clients can invoke. MCP servers can also expose _prompts_—reusable templates that guide AI models through multi-step workflows.
 
 ## What is Apollo MCP Server? 
 
-Apollo MCP Server is an implementation of an MCP server. It makes GraphQL API operations available to AI clients as MCP tools. You can use Apollo MCP Server with any GraphQL API.
+Apollo MCP Server is an implementation of an MCP server. It makes GraphQL API operations available to AI clients as MCP tools, and supports MCP prompts for guided workflows. You can use Apollo MCP Server with any GraphQL API.
 
 The GraphQL operations can be configured from persisted queries, which are predefined, approved lists of operations that are registered with and maintained by a graph. The operations can also be determined by AI introspecting your graph schema.
 
@@ -130,5 +130,7 @@ With Apollo MCP Server, these GraphQL advantages become immediately accessible t
 ## Getting started
 
 Ready to connect AI to your GraphQL API? Follow our [5-minute quickstart](/apollo-mcp-server/quickstart) to see Apollo MCP Server in action, or explore the [config file reference](/apollo-mcp-server/config-file) for detailed configuration options.
+
+Want to guide AI models through multi-step workflows? Learn how to [define MCP prompts](/apollo-mcp-server/prompts).
 
 Want to build custom interactive experiences? Check out the [MCP Apps quickstart](/apollo-mcp-server/mcp-apps-quickstart) to create your first MCP App.

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -16,7 +16,7 @@ MCP follows a client-server architecture. MCP servers expose functions, called t
 
 ## What is Apollo MCP Server? 
 
-Apollo MCP Server is an implementation of an MCP server. It makes GraphQL API operations available to AI clients as MCP tools, and supports MCP prompts for guided workflows. You can use Apollo MCP Server with any GraphQL API.
+Apollo MCP Server is an implementation of an MCP server. It makes GraphQL API operations available to AI clients as MCP tools and supports MCP prompts for guided workflows. You can use Apollo MCP Server with any GraphQL API.
 
 The GraphQL operations can be configured from persisted queries, which are predefined, approved lists of operations that are registered with and maintained by a graph. The operations can also be determined by AI introspecting your graph schema.
 

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -12,7 +12,7 @@ Apollo MCP Server provides a standard way for AI models to access and orchestrat
 
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) is an open protocol that standardizes how applications provide context to AI models like Large Language Models (LLM). MCP enables LLMs and AI agents to indirectly fetch data from external sources.
 
-MCP follows a client-server architecture. MCP servers expose functions, called _tools_, that MCP clients can invoke. MCP servers can also expose _prompts_—reusable templates that guide AI models through multi-step workflows.
+MCP follows a client-server architecture. MCP servers expose functions, called tools, that MCP clients can invoke. MCP servers can also expose prompts—reusable templates that guide AI models through multi-step workflows.
 
 ## What is Apollo MCP Server? 
 

--- a/docs/source/prompts.mdx
+++ b/docs/source/prompts.mdx
@@ -2,24 +2,24 @@
 title: Define MCP Prompts
 ---
 
-Apollo MCP Server supports **[MCP prompts](https://modelcontextprotocol.io/docs/concepts/prompts)**, which are reusable prompt templates that AI clients can discover and use. Prompts provide guided workflows that help AI models use your GraphQL tools more effectively.
+Apollo MCP Server supports [MCP prompts](https://modelcontextprotocol.io/docs/concepts/prompts), which are reusable prompt templates that AI clients can discover and use. Prompts provide guided workflows that help AI models use your GraphQL tools more effectively.
 
 ## How prompts work
 
-Each prompt is a Markdown file with YAML frontmatter that defines its name, description, and arguments. The file body is the prompt template, which can include `{{argument}}` placeholders that are substituted with values provided by the AI client at runtime.
+Each prompt is a Markdown file with YAML frontmatter that defines its name, description, and arguments. The file body is the prompt template, which includes `{{argument}}` placeholders that the AI client substitutes with values at runtime.
 
 When the server starts, it loads all `.md` files from a `prompts/` directory in the working directory. If the directory exists and contains valid prompt files, the server advertises prompt support to MCP clients via the `prompts` capability.
 
-## Define prompts
+## Define your prompts
 
-Create a `prompts/` directory in the working directory where you start the server. Each `.md` file in this directory becomes an MCP prompt.
+Store your prompt files in a `prompts/` directory in your server's working directory. Each `.md` file in this directory becomes an MCP prompt.
 
 ### Prompt file format
 
 A prompt file has two parts separated by `---` delimiters:
 
-1. **YAML frontmatter** with the prompt metadata
-2. **Template body** with the prompt content
+1. YAML frontmatter with the prompt metadata
+2. Template body with the prompt content
 
 ```markdown title="prompts/check_orders.md"
 ---
@@ -42,23 +42,23 @@ arguments:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | string | Yes | Unique identifier for the prompt, used in `prompts/get` requests |
-| `description` | string | No | Human-readable description shown to AI clients |
+| `name` | `string` | Yes | Unique identifier for the prompt, used in `prompts/get` requests |
+| `description` | `string` | No | Human-readable description shown to AI clients |
 | `arguments` | list | No | Arguments the prompt accepts |
 
-Each argument in the `arguments` list supports:
+The `arguments` list supports the following fields:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `name` | string | — | Argument name, used as the `{{name}}` placeholder in the template |
-| `description` | string | — | Description shown to AI clients |
+| `name` | `string` | — | Argument name, used as the `{{name}}` placeholder in the template |
+| `description` | `string` | — | Description shown to AI clients |
 | `required` | boolean | `false` | Whether the argument must be provided |
 
 ### Template placeholders
 
 Use `{{argument_name}}` in the template body to reference arguments. When an AI client calls `prompts/get` with argument values, the server replaces each placeholder with the corresponding value.
 
-Placeholders that don't match any provided argument are left as-is in the output.
+Placeholders that don't match any provided argument are left unchanged in the output.
 
 ## Example
 
@@ -97,8 +97,8 @@ Receives a single user message:
 
 - **No configuration required.** The server automatically detects the `prompts/` directory. No changes to your YAML config file are needed.
 - **Graceful degradation.** If the `prompts/` directory doesn't exist, the server starts normally without advertising prompt support.
-- **Validation.** The server validates that required arguments are present when a prompt is requested. Missing required arguments return an error.
-- **Single message.** Each prompt returns a single user-role text message. Multi-message and non-text content types are not currently supported.
+- **Validation.** Apollo MCP Server validates that required arguments are present when a prompt is requested. Missing required arguments return an error.
+- **Single message.** Each prompt returns a single user-role text message. Multi-message and non-text content types aren't currently supported.
 
 ## See also
 

--- a/docs/source/prompts.mdx
+++ b/docs/source/prompts.mdx
@@ -1,0 +1,106 @@
+---
+title: Define MCP Prompts
+---
+
+Apollo MCP Server supports **[MCP prompts](https://modelcontextprotocol.io/docs/concepts/prompts)**, which are reusable prompt templates that AI clients can discover and use. Prompts provide guided workflows that help AI models use your GraphQL tools more effectively.
+
+## How prompts work
+
+Each prompt is a Markdown file with YAML frontmatter that defines its name, description, and arguments. The file body is the prompt template, which can include `{{argument}}` placeholders that are substituted with values provided by the AI client at runtime.
+
+When the server starts, it loads all `.md` files from a `prompts/` directory in the working directory. If the directory exists and contains valid prompt files, the server advertises prompt support to MCP clients via the `prompts` capability.
+
+## Define prompts
+
+Create a `prompts/` directory in the working directory where you start the server. Each `.md` file in this directory becomes an MCP prompt.
+
+### Prompt file format
+
+A prompt file has two parts separated by `---` delimiters:
+
+1. **YAML frontmatter** with the prompt metadata
+2. **Template body** with the prompt content
+
+```markdown title="prompts/check_orders.md"
+---
+name: check_orders
+description: "Look up a user's recent orders and summarize them"
+arguments:
+  - name: email
+    description: "The customer's email address"
+    required: true
+  - name: limit
+    description: "Maximum number of orders to return"
+---
+
+1. Use GetUserByEmail(email={{email}}) to find the user
+2. Use GetUserOrders to retrieve their recent orders{{limit}}
+3. Summarize each order with its status, total, and date
+```
+
+### Frontmatter fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Unique identifier for the prompt, used in `prompts/get` requests |
+| `description` | string | No | Human-readable description shown to AI clients |
+| `arguments` | list | No | Arguments the prompt accepts |
+
+Each argument in the `arguments` list supports:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | string | — | Argument name, used as the `{{name}}` placeholder in the template |
+| `description` | string | — | Description shown to AI clients |
+| `required` | boolean | `false` | Whether the argument must be provided |
+
+### Template placeholders
+
+Use `{{argument_name}}` in the template body to reference arguments. When an AI client calls `prompts/get` with argument values, the server replaces each placeholder with the corresponding value.
+
+Placeholders that don't match any provided argument are left as-is in the output.
+
+## Example
+
+Given this prompt file:
+
+```markdown title="prompts/astronaut_bio.md"
+---
+name: astronaut_bio
+description: "Look up an astronaut and write a short biography"
+arguments:
+  - name: name
+    description: "The astronaut's name to search for"
+    required: true
+---
+
+1. Search for an astronaut named "{{name}}"
+2. Use GetAstronautDetails to get their full profile
+3. Write a concise biography covering their background and missions
+```
+
+An AI client calling `prompts/get` with the following request:
+
+```json
+{"name": "astronaut_bio", "arguments": {"name": "Chris Hadfield"}}
+```
+
+Receives a single user message:
+
+```text
+1. Search for an astronaut named "Chris Hadfield"
+2. Use GetAstronautDetails to get their full profile
+3. Write a concise biography covering their background and missions
+```
+
+## Behavior
+
+- **No configuration required.** The server automatically detects the `prompts/` directory. No changes to your YAML config file are needed.
+- **Graceful degradation.** If the `prompts/` directory doesn't exist, the server starts normally without advertising prompt support.
+- **Validation.** The server validates that required arguments are present when a prompt is requested. Missing required arguments return an error.
+- **Single message.** Each prompt returns a single user-role text message. Multi-message and non-text content types are not currently supported.
+
+## See also
+
+- [Define MCP Tools](/apollo-mcp-server/define-tools) — Expose GraphQL operations as MCP tools
+- [YAML Config Reference](/apollo-mcp-server/config-file) — Full configuration options for Apollo MCP Server

--- a/docs/source/prompts.mdx
+++ b/docs/source/prompts.mdx
@@ -2,13 +2,13 @@
 title: Define MCP Prompts
 ---
 
-Apollo MCP Server supports [MCP prompts](https://modelcontextprotocol.io/docs/concepts/prompts), which are reusable prompt templates that AI clients can discover and use. Prompts provide guided workflows that help AI models use your GraphQL tools more effectively.
+Apollo MCP Server supports [MCP prompts](https://modelcontextprotocol.io/docs/concepts/prompts)—reusable prompt templates that AI clients can discover and use. These prompts operate as guided workflows that help AI models use your GraphQL tools more effectively.
 
 ## How prompts work
 
 Each prompt is a Markdown file with YAML frontmatter that defines its name, description, and arguments. The file body is the prompt template, which includes `{{argument}}` placeholders that the AI client substitutes with values at runtime.
 
-When the server starts, it loads all `.md` files from a `prompts/` directory in the working directory. If the directory exists and contains valid prompt files, the server advertises prompt support to MCP clients via the `prompts` capability.
+When the server starts, it loads all `.md` files from a `prompts/` directory, which is in the working directory. If that directory contains valid prompt files, the server advertises prompt support to MCP clients with the `prompts` feature.
 
 ## Define your prompts
 
@@ -62,7 +62,7 @@ Placeholders that don't match any provided argument are left unchanged in the ou
 
 ## Example
 
-Given this prompt file:
+If this prompt file is provided...
 
 ```markdown title="prompts/astronaut_bio.md"
 ---
@@ -85,7 +85,7 @@ An AI client calling `prompts/get` with the following request:
 {"name": "astronaut_bio", "arguments": {"name": "Chris Hadfield"}}
 ```
 
-Receives a single user message:
+...the client receives a single user message:
 
 ```text
 1. Search for an astronaut named "Chris Hadfield"
@@ -95,7 +95,7 @@ Receives a single user message:
 
 ## Behavior
 
-- **No configuration required.** The server automatically detects the `prompts/` directory. No changes to your YAML config file are needed.
+- **No configuration required.** The server automatically detects the `prompts/` directory.
 - **Graceful degradation.** If the `prompts/` directory doesn't exist, the server starts normally without advertising prompt support.
 - **Validation.** Apollo MCP Server validates that required arguments are present when a prompt is requested. Missing required arguments return an error.
 - **Single message.** Each prompt returns a single user-role text message. Multi-message and non-text content types aren't currently supported.

--- a/examples/TheSpaceDevs/README.md
+++ b/examples/TheSpaceDevs/README.md
@@ -26,3 +26,16 @@ cargo run -- examples/TheSpaceDevs/config.yaml
 | `operations/GetAstronautsCurrentlyInSpace.graphql` | `GetAstronautsCurrentlyInSpace` | Astronauts currently aboard the ISS |
 | `operations/SearchUpcomingLaunches.graphql` | `SearchUpcomingLaunches` | Search upcoming rocket launches |
 | `operations/ExploreCelestialBodies.graphql` | `ExploreCelestialBodies` | Browse planets, moons, and other bodies |
+
+## Available prompts
+
+To use the example prompts, copy them to the working directory where the server is started:
+
+```sh
+cp -r examples/TheSpaceDevs/prompts .
+```
+
+| File | Prompt | Description |
+|------|--------|-------------|
+| `prompts/astronaut_bio.md` | `astronaut_bio` | Look up an astronaut and write a short biography |
+| `prompts/explore_upcoming_launches.md` | `explore_upcoming_launches` | Research upcoming space launches and summarize key details |

--- a/examples/TheSpaceDevs/prompts/astronaut_bio.md
+++ b/examples/TheSpaceDevs/prompts/astronaut_bio.md
@@ -1,0 +1,17 @@
+---
+name: astronaut_bio
+description: "Look up an astronaut and write a short biography"
+arguments:
+  - name: name
+    description: "The astronaut's name to search for"
+    required: true
+---
+
+1. Use the SearchUpcomingLaunches or available search tools to find an astronaut named "{{name}}"
+2. Once you have their ID, use GetAstronautDetails to get their full profile
+3. Write a concise biography covering:
+   - Full name, nationality, and date of birth
+   - Agency and current status
+   - Number of spaceflights and total time in space
+   - Notable missions or achievements
+   - Current role or last known activity

--- a/examples/TheSpaceDevs/prompts/explore_upcoming_launches.md
+++ b/examples/TheSpaceDevs/prompts/explore_upcoming_launches.md
@@ -1,0 +1,21 @@
+---
+name: explore_upcoming_launches
+description: "Research upcoming space launches and summarize key details"
+arguments:
+  - name: search
+    description: "Search term to filter launches (e.g. rocket name, agency, mission)"
+    required: true
+  - name: limit
+    description: "Number of launches to return"
+---
+
+Use the SearchUpcomingLaunches tool to find upcoming launches matching "{{search}}"{{limit}}.
+
+For each launch found, summarize:
+- Launch name and status
+- Rocket and launch provider
+- Mission description and orbit
+- Launch window (net date)
+- Launch pad location
+
+If no launches match, suggest broadening the search term.


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-449 -->

Closes #699

This adds MCP prompts support to the server. Each prompt is an individual Markdown file in a `prompts/` directory with YAML frontmatter for metadata and the body as the prompt template. The server loads these at startup, advertises `PromptsCapability` when prompts are present, and handles `list_prompts` and `get_prompt` requests with `{{arg}}` placeholder substitution. No configuration changes are needed. The server automatically detects the `prompts/` directory and starts normally without prompts if the directory doesn't exist.

The initial scope is single text-based user messages. Multi-message prompts and non-text content types can be added later.

<img width="3024" height="1512" alt="2026-04-07 at 09 33 04" src="https://github.com/user-attachments/assets/08863548-dd8d-4c14-958f-6f1ced5cc753" />
