### PR TITLE
fix: validate config before restarting on hot reload

### DIFF
--- a/.changeset/fix_config_hot_reload_validation.md
+++ b/.changeset/fix_config_hot_reload_validation.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Fix config hot reload crashing server on invalid config
+
+The config hot-reload feature was supposed to keep the server running when an invalid config file was saved, but instead the server would crash because it cancelled the running instance before validating the new config. The new config is now validated before the server is stopped, and if validation fails, the error is logged and the server continues running with the previous configuration.

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use apollo_mcp_registry::platform_api::operation_collections::collection_poller::CollectionSource;
 use apollo_mcp_registry::uplink::persisted_queries::ManifestSource;
@@ -6,12 +7,12 @@ use apollo_mcp_registry::uplink::schema::SchemaSource;
 use apollo_mcp_server::custom_scalar_map::CustomScalarMap;
 use apollo_mcp_server::errors::ServerError;
 use apollo_mcp_server::operations::OperationSource;
-use apollo_mcp_server::server::{Server, ShutdownReason, Transport};
+use apollo_mcp_server::server::{ConfigValidator, Server, ShutdownReason, Transport};
 use clap::Parser;
 use clap::builder::Styles;
 use clap::builder::styling::{AnsiColor, Effects};
 use runtime::IdOrDefault;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 mod runtime;
 
@@ -86,6 +87,12 @@ fn load_config(config_path: Option<&std::path::Path>) -> anyhow::Result<runtime:
 /// Build a Server from the current configuration.
 fn build_server(config_path: Option<&std::path::Path>) -> anyhow::Result<Server> {
     let config = load_config(config_path)?;
+
+    let config_validator: Option<ConfigValidator> = config_path.map(|p| {
+        let path = p.to_path_buf();
+        Arc::new(move || load_config(Some(&path)).map(|_| ()).map_err(|e| e.into()))
+            as ConfigValidator
+    });
 
     #[cfg_attr(coverage_nightly, coverage(off))]
     debug!("Configuration: {config:#?}");
@@ -190,6 +197,7 @@ fn build_server(config_path: Option<&std::path::Path>) -> anyhow::Result<Server>
         .health_check(config.health_check)
         .cors(config.cors)
         .server_info(config.server_info)
+        .maybe_config_validator(config_validator)
         .build())
 }
 
@@ -205,9 +213,18 @@ fn spawn_stdio_config_watcher(config_path: PathBuf) {
         // Skip the initial event that files::watch always emits on startup,
         // then exit when a real file change is detected.
         let mut stream = std::pin::pin!(files::watch(&config_path).skip(1));
-        if stream.next().await.is_some() {
-            info!("Config file changed, exiting for process manager to restart");
-            std::process::exit(75);
+        while stream.next().await.is_some() {
+            match load_config(Some(&config_path)) {
+                Ok(_) => {
+                    info!("Config file changed, exiting for process manager to restart");
+                    std::process::exit(75);
+                }
+                Err(e) => {
+                    error!(
+                        "Config file changed but contains errors, keeping current configuration: {e}"
+                    );
+                }
+            }
         }
     });
 }

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -55,7 +55,7 @@ async fn main() -> anyhow::Result<()> {
         if let Some(ref path) = config_path {
             spawn_stdio_config_watcher(path.clone());
         }
-        spawn_stdio_sighup_handler();
+        spawn_stdio_sighup_handler(config_path.clone());
     }
 
     loop {
@@ -237,7 +237,7 @@ fn spawn_stdio_config_watcher(config_path: PathBuf) {
         reason = "process::exit used for stdio mode SIGHUP restart"
     )
 )]
-fn spawn_stdio_sighup_handler() {
+fn spawn_stdio_sighup_handler(config_path: Option<PathBuf>) {
     #[cfg(unix)]
     {
         use tokio::signal::unix::SignalKind;
@@ -247,7 +247,18 @@ fn spawn_stdio_sighup_handler() {
                 tracing::error!("Failed to install SIGHUP handler");
                 return;
             };
-            if signal.recv().await.is_some() {
+            loop {
+                if signal.recv().await.is_none() {
+                    return;
+                }
+                if let Some(ref path) = config_path
+                    && let Err(e) = load_config(Some(path))
+                {
+                    error!(
+                        "SIGHUP received but config contains errors, keeping current configuration: {e}"
+                    );
+                    continue;
+                }
                 info!("Received SIGHUP, exiting for process manager to restart");
                 std::process::exit(75);
             }

--- a/crates/apollo-mcp-server/src/server.rs
+++ b/crates/apollo-mcp-server/src/server.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use apollo_mcp_registry::uplink::schema::SchemaSource;
 use bon::bon;
@@ -32,6 +33,11 @@ pub enum ShutdownReason {
     /// Config changed, server should restart with new config
     Restart,
 }
+
+/// A callback that validates the current config file before restarting the server.
+/// Returns `Ok(())` if the config is valid, or an error describing why it is not.
+pub type ConfigValidator =
+    Arc<dyn Fn() -> Result<(), Box<dyn std::error::Error + Send + Sync>> + Send + Sync>;
 
 /// An Apollo MCP Server
 pub struct Server {
@@ -66,6 +72,7 @@ pub struct Server {
     health_check: HealthCheckConfig,
     cors: CorsConfig,
     server_info: ServerInfoConfig,
+    config_validator: Option<ConfigValidator>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default, JsonSchema)]
@@ -148,6 +155,7 @@ impl Server {
         health_check: HealthCheckConfig,
         cors: CorsConfig,
         server_info: ServerInfoConfig,
+        config_validator: Option<ConfigValidator>,
     ) -> Self {
         let headers = {
             let mut headers = headers.clone();
@@ -186,6 +194,7 @@ impl Server {
             health_check,
             cors,
             server_info,
+            config_validator,
         }
     }
 

--- a/crates/apollo-mcp-server/src/server/states.rs
+++ b/crates/apollo-mcp-server/src/server/states.rs
@@ -20,7 +20,7 @@ use crate::{
     server_info::ServerInfoConfig,
 };
 
-use super::{Server, ServerEvent, ShutdownReason, Transport};
+use super::{ConfigValidator, Server, ServerEvent, ShutdownReason, Transport};
 
 mod configuring;
 mod operations_configured;
@@ -71,6 +71,7 @@ struct Config {
 
 impl StateMachine {
     pub(crate) async fn start(self, server: Server) -> Result<ShutdownReason, ServerError> {
+        let config_validator = server.config_validator;
         let schema_stream = server
             .schema_source
             .into_stream()
@@ -124,7 +125,7 @@ impl StateMachine {
         });
 
         while let Some(event) = stream.next().await {
-            state = Self::process_event(state, event).await?;
+            state = Self::process_event(state, event, &config_validator).await?;
             if let State::Starting(starting) = state {
                 state = starting.start().await.into();
             }
@@ -144,7 +145,11 @@ impl StateMachine {
 
     /// Process a single event against the current state, returning the new state.
     #[allow(clippy::result_large_err)]
-    async fn process_event(state: State, event: ServerEvent) -> Result<State, ServerError> {
+    async fn process_event(
+        state: State,
+        event: ServerEvent,
+        config_validator: &Option<ConfigValidator>,
+    ) -> Result<State, ServerError> {
         Ok(match event {
             ServerEvent::SchemaUpdated(registry_event) => match registry_event {
                 SchemaEvent::UpdateSchema(schema_state) => {
@@ -210,6 +215,14 @@ impl StateMachine {
                 other => other,
             },
             ServerEvent::ConfigChanged => {
+                if let Some(validate) = config_validator
+                    && let Err(e) = validate()
+                {
+                    tracing::error!(
+                        "Config file changed but contains errors, keeping current configuration: {e}"
+                    );
+                    return Ok(state);
+                }
                 info!("Config file changed, triggering server restart");
                 if let State::Running(ref running) = state {
                     running.cancellation_token.cancel();
@@ -502,7 +515,17 @@ mod tests {
     }
 
     async fn process_event(state: State, event: ServerEvent) -> State {
-        StateMachine::process_event(state, event)
+        StateMachine::process_event(state, event, &None)
+            .await
+            .unwrap_or_else(State::Error)
+    }
+
+    async fn process_event_with_validator(
+        state: State,
+        event: ServerEvent,
+        validator: &Option<super::ConfigValidator>,
+    ) -> State {
+        StateMachine::process_event(state, event, validator)
             .await
             .unwrap_or_else(State::Error)
     }
@@ -637,6 +660,49 @@ mod tests {
         assert!(
             matches!(new_state, State::Restarting),
             "expected Configuring to transition to Restarting after ConfigChanged"
+        );
+    }
+
+    #[tokio::test]
+    async fn config_changed_with_invalid_config_keeps_running() {
+        let running = create_running_server();
+        let token = running.cancellation_token.clone();
+        let state = State::Running(running);
+
+        let validator: super::ConfigValidator =
+            Arc::new(|| Err("invalid YAML: expected ':', got newline".into()));
+
+        let new_state =
+            process_event_with_validator(state, ServerEvent::ConfigChanged, &Some(validator)).await;
+
+        assert!(
+            matches!(new_state, State::Running(_)),
+            "expected server to remain Running when config is invalid"
+        );
+        assert!(
+            !token.is_cancelled(),
+            "cancellation token should NOT be cancelled when config is invalid"
+        );
+    }
+
+    #[tokio::test]
+    async fn config_changed_with_valid_config_transitions_to_restarting() {
+        let running = create_running_server();
+        let token = running.cancellation_token.clone();
+        let state = State::Running(running);
+
+        let validator: super::ConfigValidator = Arc::new(|| Ok(()));
+
+        let new_state =
+            process_event_with_validator(state, ServerEvent::ConfigChanged, &Some(validator)).await;
+
+        assert!(
+            matches!(new_state, State::Restarting),
+            "expected server to transition to Restarting when config is valid"
+        );
+        assert!(
+            token.is_cancelled(),
+            "cancellation token should be cancelled when config is valid"
         );
     }
 


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-172 -->

While I was updating the config, I noticed that saving an invalid config file crashes the server. This happens because the `ConfigChanged` handler cancels the running server before the new config is parsed. If parsing fails, the process exits without any fallback.

This PR adds a `ConfigValidator` callback that checks the config before the cancellation token is triggered. If the validation fails, the error is logged, and the server remains in its current `Running` state. The same pre-validation is also applied to the stdio config watcher, which prevents crash loops with process managers when a bad config is saved.