### PR TITLE
feat: configurable MCP initialize instructions

### DIFF
--- a/.changeset/add_configurable_mcp_initialize_instructions.md
+++ b/.changeset/add_configurable_mcp_initialize_instructions.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Add optional `instructions` for MCP initialize
+
+Operators can set a top-level `instructions` value in the server configuration, or supply it through `APOLLO_MCP_INSTRUCTIONS`, to describe how models should use this server's tools and resources. The server returns that string in the MCP `initialize` response so clients can surface it to the model, consistent with the protocol's optional instructions field.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ cargo llvm-cov --all-features --workspace --codecov --output-path codecov.json
 
 ### Common Config Keys
 
-- Top-level keys: `endpoint`, `transport`, `operations`, `schema`, `introspection`, `graphos`, `overrides`, `headers`, `forward_headers`, `health_check`, `cors`, `telemetry`, `logging`, `server_info`, `custom_scalars`.
+- Top-level keys: `endpoint`, `transport`, `operations`, `schema`, `introspection`, `graphos`, `overrides`, `headers`, `forward_headers`, `health_check`, `cors`, `telemetry`, `logging`, `server_info`, `instructions`, `custom_scalars`.
 - `auth` must be nested under `transport` (not top-level).
 - `operations.source`: `infer` (default), `local`, `manifest`, `collection`, `introspect`, `uplink`.
 - `schema.source`: `local` or `uplink`.

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -198,6 +198,7 @@ fn build_server(config_path: Option<&std::path::Path>) -> anyhow::Result<Server>
         .cors(config.cors)
         .server_info(config.server_info)
         .maybe_config_validator(config_validator)
+        .maybe_instructions(config.instructions)
         .build())
 }
 

--- a/crates/apollo-mcp-server/src/runtime.rs
+++ b/crates/apollo-mcp-server/src/runtime.rs
@@ -200,6 +200,7 @@ mod test {
                     website_url: None,
                     description: None,
                 },
+                instructions: None,
                 custom_scalars: None,
                 endpoint: Endpoint(
                     Url {

--- a/crates/apollo-mcp-server/src/runtime/config.rs
+++ b/crates/apollo-mcp-server/src/runtime/config.rs
@@ -26,6 +26,11 @@ pub struct Config {
     #[serde(default)]
     pub server_info: ServerInfoConfig,
 
+    /// Optional instructions returned in the MCP `initialize` response (protocol 2025-06-18+).
+    /// Clients may inject this into the model context as server-level guidance.
+    #[serde(default)]
+    pub instructions: Option<String>,
+
     /// Path to a custom scalar map
     pub custom_scalars: Option<PathBuf>,
 
@@ -154,6 +159,19 @@ mod test {
         );
         let err = result.unwrap_err().to_string();
         assert!(err.contains("unknown field"));
+    }
+
+    #[test]
+    fn it_parses_instructions() {
+        let yaml = r#"
+            endpoint: http://localhost:4000/
+            instructions: "Use semantic search before listing."
+        "#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            config.instructions.as_deref(),
+            Some("Use semantic search before listing.")
+        );
     }
 
     #[test]

--- a/crates/apollo-mcp-server/src/server.rs
+++ b/crates/apollo-mcp-server/src/server.rs
@@ -73,6 +73,7 @@ pub struct Server {
     cors: CorsConfig,
     server_info: ServerInfoConfig,
     config_validator: Option<ConfigValidator>,
+    instructions: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default, JsonSchema)]
@@ -156,6 +157,7 @@ impl Server {
         cors: CorsConfig,
         server_info: ServerInfoConfig,
         config_validator: Option<ConfigValidator>,
+        instructions: Option<String>,
     ) -> Self {
         let headers = {
             let mut headers = headers.clone();
@@ -195,6 +197,7 @@ impl Server {
             cors,
             server_info,
             config_validator,
+            instructions,
         }
     }
 

--- a/crates/apollo-mcp-server/src/server/states.rs
+++ b/crates/apollo-mcp-server/src/server/states.rs
@@ -67,6 +67,7 @@ struct Config {
     health_check: HealthCheckConfig,
     cors: CorsConfig,
     server_info: ServerInfoConfig,
+    instructions: Option<String>,
 }
 
 impl StateMachine {
@@ -121,6 +122,7 @@ impl StateMachine {
                 health_check: server.health_check,
                 cors: server.cors,
                 server_info: server.server_info,
+                instructions: server.instructions,
             },
         });
 
@@ -471,6 +473,7 @@ mod tests {
             descriptions: HashMap::new(),
             health_check: None,
             server_info: ServerInfoConfig::default(),
+            instructions: None,
             rhai_engine: Arc::new(parking_lot::Mutex::new(RhaiEngine::new("rhai"))),
         }
     }
@@ -511,6 +514,7 @@ mod tests {
             health_check: HealthCheckConfig::default(),
             cors: CorsConfig::default(),
             server_info: ServerInfoConfig::default(),
+            instructions: None,
         }
     }
 

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -73,6 +73,8 @@ pub(super) struct Running {
     pub(super) descriptions: HashMap<String, String>,
     pub(super) health_check: Option<HealthCheck>,
     pub(super) server_info: ServerInfoConfig,
+    /// MCP initialize-response instructions (optional).
+    pub(super) instructions: Option<String>,
     pub(super) rhai_engine: Arc<Mutex<RhaiEngine>>,
 }
 
@@ -662,9 +664,13 @@ impl ServerHandler for Running {
         if let Some(u) = self.server_info.website_url() {
             impl_ = impl_.with_website_url(u);
         }
-        InitializeResult::new(capabilities)
+        let mut result = InitializeResult::new(capabilities)
             .with_protocol_version(protocol_version)
-            .with_server_info(impl_)
+            .with_server_info(impl_);
+        if let Some(instructions) = self.instructions.as_deref() {
+            result = result.with_instructions(instructions);
+        }
+        result
     }
 }
 
@@ -723,6 +729,7 @@ mod tests {
             descriptions: HashMap::new(),
             health_check: None,
             server_info: ServerInfoConfig::default(),
+            instructions: None,
             rhai_engine: Arc::new(parking_lot::Mutex::new(RhaiEngine::new("rhai"))),
         }
     }
@@ -1829,6 +1836,26 @@ mod tests {
                 )
             );
             assert_eq!(info.server_info.icons, None);
+            assert_eq!(info.instructions, None);
+        }
+
+        #[test]
+        fn get_info_includes_instructions_when_configured() {
+            let schema = Schema::parse("type Query { id: String }", "schema.graphql")
+                .unwrap()
+                .validate()
+                .unwrap();
+
+            let running = Running {
+                instructions: Some("Prefer search before list.".to_string()),
+                ..test_running(Arc::new(RwLock::new(schema)))
+            };
+
+            let info = running.get_info();
+            assert_eq!(
+                info.instructions.as_deref(),
+                Some("Prefer search before list.")
+            );
         }
 
         #[test]
@@ -2142,6 +2169,7 @@ mod integration_tests {
                 descriptions: HashMap::new(),
                 health_check: None,
                 server_info: Default::default(),
+                instructions: None,
                 rhai_engine: Arc::new(parking_lot::Mutex::new(RhaiEngine::new("rhai"))),
             }
         }
@@ -2368,6 +2396,7 @@ mod integration_tests {
                 descriptions: HashMap::new(),
                 health_check: None,
                 server_info: Default::default(),
+                instructions: None,
                 rhai_engine: Arc::new(parking_lot::Mutex::new(RhaiEngine::new("rhai"))),
             }
         }
@@ -2597,6 +2626,7 @@ mod integration_tests {
                 descriptions: HashMap::new(),
                 health_check: None,
                 server_info: Default::default(),
+                instructions: None,
                 rhai_engine: Arc::new(parking_lot::Mutex::new(RhaiEngine::new("rhai"))),
             }
         }
@@ -2917,6 +2947,7 @@ mod integration_tests {
                 descriptions: HashMap::new(),
                 health_check: None,
                 server_info: Default::default(),
+                instructions: None,
                 rhai_engine: Arc::new(parking_lot::Mutex::new(RhaiEngine::new("rhai"))),
             }
         }

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -36,7 +36,7 @@ pub(super) struct Starting {
 }
 
 impl Starting {
-    pub(super) async fn start(self) -> Result<Running, ServerError> {
+    pub(super) async fn start(mut self) -> Result<Running, ServerError> {
         let peers = Arc::new(RwLock::new(Vec::new()));
 
         let operations: Vec<_> = self
@@ -160,6 +160,9 @@ impl Starting {
             })?;
         }
 
+        // Move into `Running` so we do not clone the full string (config is not read afterward).
+        let instructions = std::mem::take(&mut self.config.instructions);
+
         let running = Running {
             schema,
             operations: Arc::new(RwLock::new(operations)),
@@ -183,6 +186,7 @@ impl Starting {
             descriptions: self.config.descriptions,
             health_check: health_check.clone(),
             server_info: self.config.server_info.clone(),
+            instructions,
             rhai_engine: engine,
         };
 
@@ -334,6 +338,7 @@ mod tests {
                 },
                 cors: Default::default(),
                 server_info: Default::default(),
+                instructions: None,
             },
             schema: Schema::parse_and_validate("type Query { hello: String }", "test.graphql")
                 .expect("Valid schema"),

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -160,7 +160,7 @@ impl Starting {
             })?;
         }
 
-        // Move into `Running` so we do not clone the full string (config is not read afterward).
+        // Move into `Running` so we do not clone the full string (`config.instructions` is not read afterward).
         let instructions = std::mem::take(&mut self.config.instructions);
 
         let running = Running {

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -32,7 +32,7 @@ All fields are optional.
 | `graphos`         | `GraphOS`             |                          | Apollo-specific credential overrides                             |
 | `headers`         | `Map<string, string>` | `{}`                     | List of hard-coded headers to include in all GraphQL requests    |
 | `health_check`    | `HealthCheck`         |                          | Health check configuration                                       |
-| `instructions`    | `string`              |                          | Optional text for the MCP `initialize` response (see [below](#initialize-instructions)) |
+| `instructions`    | `string`              |                          | Optional text for the [MCP `initialize` response](#initialize-instructions)) |
 | `introspection`   | `Introspection`       |                          | Introspection configuration                                      |
 | `logging`         | `Logging`             |                          | Logging configuration                                            |
 | `operations`      | `OperationSource`     |                          | Operations configuration                                         |
@@ -523,9 +523,9 @@ server_info:
 
 ### Initialize instructions
 
-The optional top-level `instructions` field sets the MCP `instructions` value in the [`initialize` result](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle). Supporting clients can inject this string into the model context so the LLM gets domain-specific guidance (workflows, tool relationships, and constraints) alongside per-tool descriptions.
+The `instructions` field (optional) is a top-level field that sets the MCP `instructions` value in the [`initialize` result](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle). Supported clients can inject that string into the model context so the LLM receives domain-specific guidance (workflows, tool relationships, and constraints) alongside per-tool descriptions.
 
-You can set it in YAML (including a [block scalar](https://yaml.org/spec/1.2.2/#81-block-scalar-styles) for multiple lines) or with the `APOLLO_MCP_INSTRUCTIONS` environment variable.
+You can configure `instructions` with YAML (including a [block scalar](https://yaml.org/spec/1.2.2/#81-block-scalar-styles) for multiple lines) or with the `APOLLO_MCP_INSTRUCTIONS` environment variable.
 
 ```yaml title="config.yaml"
 instructions: |

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -32,6 +32,7 @@ All fields are optional.
 | `graphos`         | `GraphOS`             |                          | Apollo-specific credential overrides                             |
 | `headers`         | `Map<string, string>` | `{}`                     | List of hard-coded headers to include in all GraphQL requests    |
 | `health_check`    | `HealthCheck`         |                          | Health check configuration                                       |
+| `instructions`    | `string`              |                          | Optional text for the MCP `initialize` response (see [below](#initialize-instructions)) |
 | `introspection`   | `Introspection`       |                          | Introspection configuration                                      |
 | `logging`         | `Logging`             |                          | Logging configuration                                            |
 | `operations`      | `OperationSource`     |                          | Operations configuration                                         |
@@ -520,6 +521,17 @@ server_info:
   description: "MCP server for Acme Corp's GraphQL API"
 ```
 
+### Initialize instructions
+
+The optional top-level `instructions` field sets the MCP `instructions` value in the [`initialize` result](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle). Supporting clients can inject this string into the model context so the LLM gets domain-specific guidance (workflows, tool relationships, and constraints) alongside per-tool descriptions.
+
+You can set it in YAML (including a [block scalar](https://yaml.org/spec/1.2.2/#81-block-scalar-styles) for multiple lines) or with the `APOLLO_MCP_INSTRUCTIONS` environment variable.
+
+```yaml title="config.yaml"
+instructions: |
+  Prefer semantic search tools before listing. Check access tier rules before mutations.
+```
+
 ## Example config files
 
 The following example file sets your endpoint to `localhost:4001`, configures transport over Streamable HTTP, enables introspection, and provides two local MCP operations for the server to expose.
@@ -680,7 +692,7 @@ The server fails to start and tells you exactly which field is invalid and what 
 
 ```
 Error: unknown field: found `auth`, expected one of `cors`, `server_info`,
-`custom_scalars`, `endpoint`, `graphos`, `headers`, `forward_headers`,
+`instructions`, `custom_scalars`, `endpoint`, `graphos`, `headers`, `forward_headers`,
 `health_check`, `introspection`, `logging`, `telemetry`, `operations`,
 `overrides`, `schema`, `transport`
 ```

--- a/examples/TheSpaceDevs/config-stdio.yaml
+++ b/examples/TheSpaceDevs/config-stdio.yaml
@@ -2,6 +2,11 @@
 # MCP client (e.g. Claude Desktop, VS Code, Cursor).
 # Communication happens over stdin/stdout; no HTTP port is opened.
 endpoint: https://thespacedevs-production.up.railway.app/
+instructions: |
+  This server wraps The Space Devs public GraphQL API (launches, astronauts in space,
+  upcoming launches, celestial bodies). Use the search tool when you need to explore the
+  schema; prefer the named operations (e.g. GetAstronautsCurrentlyInSpace) when they match
+  the user's question.
 transport:
   type: stdio
 operations:

--- a/examples/TheSpaceDevs/config.yaml
+++ b/examples/TheSpaceDevs/config.yaml
@@ -1,4 +1,9 @@
 endpoint: https://thespacedevs-production.up.railway.app/
+instructions: |
+  This server wraps The Space Devs public GraphQL API (launches, astronauts in space,
+  upcoming launches, celestial bodies). Use the search tool when you need to explore the
+  schema; prefer the named operations (e.g. GetAstronautsCurrentlyInSpace) when they match
+  the user's question.
 transport:
   type: streamable_http
 operations:


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-464 -->

Closes #707

This change lets operators supply optional server-level guidance that MCP clients can pass through to the model. Configuration accepts a top-level `instructions` string in YAML or via `APOLLO_MCP_INSTRUCTIONS`. The server includes that text in the `initialize` result.

<img width="1802" height="1718" alt="2026-04-08 at 09 23 48" src="https://github.com/user-attachments/assets/61d9142e-38d0-4057-afe1-f25987c42728" />
