### PR TITLE
fix: correct env var in error when APOLLO_KEY is missing

### DIFF
--- a/.changeset/fix_misleading_apollo_key_error.md
+++ b/.changeset/fix_misleading_apollo_key_error.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Fix misleading error when APOLLO_KEY is missing
+
+When `APOLLO_KEY` was not set, the server incorrectly reported "Missing environment variable: APOLLO_GRAPH_REF" instead of `APOLLO_KEY`. This was a copy-paste bug in `GraphOSConfig::key()` that referenced the wrong constant in its error path.

--- a/crates/apollo-mcp-server/src/runtime/graphos.rs
+++ b/crates/apollo-mcp-server/src/runtime/graphos.rs
@@ -75,7 +75,7 @@ impl GraphOSConfig {
     fn key(&self) -> Result<SecretString, ServerError> {
         self.apollo_key
             .clone()
-            .ok_or_else(|| ServerError::EnvironmentVariable(APOLLO_GRAPH_REF_ENV.to_string()))
+            .ok_or_else(|| ServerError::EnvironmentVariable(APOLLO_KEY_ENV.to_string()))
     }
 
     /// Generate an uplink config based on configuration params
@@ -110,5 +110,36 @@ impl GraphOSConfig {
         );
 
         Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uplink_config_missing_key_reports_apollo_key() {
+        let config = GraphOSConfig {
+            apollo_graph_ref: Some("my-graph@main".to_string()),
+            ..Default::default()
+        };
+
+        let err = config.uplink_config().unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains(APOLLO_KEY_ENV));
+        assert!(!msg.contains(APOLLO_GRAPH_REF_ENV));
+    }
+
+    #[test]
+    fn uplink_config_missing_graph_ref_reports_apollo_graph_ref() {
+        let config = GraphOSConfig {
+            apollo_key: Some(SecretString::from("service:my-graph:secret")),
+            ..Default::default()
+        };
+
+        let err = config.uplink_config().unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains(APOLLO_GRAPH_REF_ENV));
+        assert!(!msg.contains(APOLLO_KEY_ENV));
     }
 }


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-469 -->

Fixes #717.

When the GraphOS API key was not configured, `GraphOSConfig::key()` reported the wrong variable name in the error (it referenced the graph ref env constant instead of `APOLLO_KEY`). This corrects the message and adds a regression test. Includes a Knope changeset.