### PR TITLE
feat: add trace_id to log output for OTel correlation

### DIFF
--- a/.changeset/add_trace_id_to_log_output.md
+++ b/.changeset/add_trace_id_to_log_output.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Add trace_id to log output for distributed trace correlation
+
+Log lines emitted within an OpenTelemetry-traced span now include a `trace_id=<hex>` prefix, allowing operators to correlate logs with distributed traces in observability tools such as Jaeger and Grafana. Startup messages and other events outside a span are unaffected.

--- a/crates/apollo-mcp-server/src/runtime/logging.rs
+++ b/crates/apollo-mcp-server/src/runtime/logging.rs
@@ -6,6 +6,7 @@
 mod defaults;
 mod log_rotation_kind;
 mod parsers;
+mod trace_id_format;
 
 use log_rotation_kind::LogRotationKind;
 use schemars::JsonSchema;
@@ -53,7 +54,7 @@ type LoggingLayerResult = (
     Layer<
         tracing_subscriber::Registry,
         tracing_subscriber::fmt::format::DefaultFields,
-        tracing_subscriber::fmt::format::Format,
+        trace_id_format::TraceIdFormat,
         BoxMakeWriter,
     >,
     Option<tracing_appender::non_blocking::WorkerGuard>,
@@ -101,11 +102,15 @@ impl Logging {
             None => (BoxMakeWriter::new(std::io::stdout), None, true),
         };
 
+        let inner_format = tracing_subscriber::fmt::format::Format::default()
+            .with_ansi(with_ansi)
+            .with_target(false);
+
         Ok((
             tracing_subscriber::fmt::layer()
                 .with_writer(writer)
                 .with_ansi(with_ansi)
-                .with_target(false),
+                .event_format(trace_id_format::TraceIdFormat::new(inner_format)),
             guard,
         ))
     }

--- a/crates/apollo-mcp-server/src/runtime/logging/trace_id_format.rs
+++ b/crates/apollo-mcp-server/src/runtime/logging/trace_id_format.rs
@@ -1,0 +1,224 @@
+//! Custom event format that prepends `trace_id=<hex>` to log lines
+//! when an OpenTelemetry trace context is active.
+
+use std::fmt;
+
+use opentelemetry::trace::TraceId;
+use tracing::Subscriber;
+use tracing_opentelemetry::OtelData;
+use tracing_subscriber::fmt::FmtContext;
+use tracing_subscriber::fmt::format::{Format, FormatEvent, FormatFields, Full, Writer};
+use tracing_subscriber::fmt::time::SystemTime;
+use tracing_subscriber::registry::LookupSpan;
+
+/// A [`FormatEvent`] wrapper that prepends `trace_id=<hex>` when the current
+/// span carries an OpenTelemetry trace context.
+pub struct TraceIdFormat {
+    inner: Format<Full, SystemTime>,
+}
+
+impl TraceIdFormat {
+    pub fn new(inner: Format<Full, SystemTime>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<S, N> FormatEvent<S, N> for TraceIdFormat
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &tracing::Event<'_>,
+    ) -> fmt::Result {
+        if let Some(trace_id) = extract_trace_id(ctx) {
+            write!(writer, "trace_id={trace_id} ")?;
+        }
+
+        self.inner.format_event(ctx, writer, event)
+    }
+}
+
+/// Walk the span ancestry looking for the first `OtelData` with a valid trace ID.
+fn extract_trace_id<S, N>(ctx: &FmtContext<'_, S, N>) -> Option<TraceId>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    ctx.event_scope()?.find_map(|span_ref| {
+        let extensions = span_ref.extensions();
+        let trace_id = extensions.get::<OtelData>()?.trace_id()?;
+        (trace_id != TraceId::INVALID).then_some(trace_id)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::sync::{Arc, Mutex};
+
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_sdk::trace::SdkTracerProvider;
+    use tracing_opentelemetry::OpenTelemetryLayer;
+    use tracing_subscriber::fmt::MakeWriter;
+    use tracing_subscriber::fmt::format::Format;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::registry;
+
+    use super::*;
+
+    /// A thread-safe in-memory writer for capturing log output.
+    #[derive(Clone)]
+    struct TestWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl TestWriter {
+        fn new() -> Self {
+            Self(Arc::new(Mutex::new(Vec::new())))
+        }
+
+        fn contents(&self) -> String {
+            let buf = self.0.lock().expect("lock poisoned");
+            String::from_utf8_lossy(&buf).to_string()
+        }
+    }
+
+    impl io::Write for TestWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().expect("lock poisoned").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for TestWriter {
+        type Writer = Self;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// Build a subscriber with our `TraceIdFormat` that writes to `writer`.
+    fn test_subscriber(
+        writer: TestWriter,
+    ) -> impl Subscriber + for<'a> LookupSpan<'a> + Send + Sync {
+        let provider = SdkTracerProvider::builder().build();
+        let tracer = provider.tracer("test");
+
+        let format = Format::default().with_ansi(false).with_target(false);
+
+        let fmt_layer = tracing_subscriber::fmt::layer()
+            .with_writer(writer)
+            .with_ansi(false)
+            .event_format(TraceIdFormat::new(format));
+
+        registry()
+            .with(fmt_layer)
+            .with(OpenTelemetryLayer::new(tracer))
+    }
+
+    #[test]
+    fn trace_id_appears_when_span_active() {
+        let writer = TestWriter::new();
+        let subscriber = test_subscriber(writer.clone());
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("test_span");
+            let _guard = span.enter();
+            tracing::info!("hello from span");
+        });
+
+        let output = writer.contents();
+        let re = regex::Regex::new(r"trace_id=[0-9a-f]{32} ").expect("valid regex");
+        assert!(
+            re.is_match(&output),
+            "expected trace_id=<32hex> in output, got: {output}"
+        );
+        assert!(
+            output.contains("hello from span"),
+            "expected message in output, got: {output}"
+        );
+    }
+
+    #[test]
+    fn no_trace_id_outside_span() {
+        let writer = TestWriter::new();
+        let subscriber = test_subscriber(writer.clone());
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!("no span here");
+        });
+
+        let output = writer.contents();
+        assert!(
+            !output.contains("trace_id="),
+            "expected no trace_id in output, got: {output}"
+        );
+        assert!(
+            output.contains("no span here"),
+            "expected message in output, got: {output}"
+        );
+    }
+
+    #[test]
+    fn child_span_inherits_parent_trace_id() {
+        let writer = TestWriter::new();
+        let subscriber = test_subscriber(writer.clone());
+
+        tracing::subscriber::with_default(subscriber, || {
+            let parent = tracing::info_span!("parent");
+            let _parent_guard = parent.enter();
+            tracing::info!("from parent");
+
+            let child = tracing::info_span!("child");
+            let _child_guard = child.enter();
+            tracing::info!("from child");
+        });
+
+        let output = writer.contents();
+        let re = regex::Regex::new(r"trace_id=([0-9a-f]{32})").expect("valid regex");
+        let ids: Vec<String> = re
+            .captures_iter(&output)
+            .map(|c| c[1].to_string())
+            .collect();
+
+        assert_eq!(
+            ids.len(),
+            2,
+            "expected 2 trace_id entries, got {}: {output}",
+            ids.len()
+        );
+        assert_eq!(
+            ids[0], ids[1],
+            "parent and child should share the same trace_id"
+        );
+    }
+
+    #[test]
+    fn inner_format_still_works() {
+        let writer = TestWriter::new();
+        let subscriber = test_subscriber(writer.clone());
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("fmt_test");
+            let _guard = span.enter();
+            tracing::info!("check format");
+        });
+
+        let output = writer.contents();
+        assert!(
+            output.contains("INFO"),
+            "expected log level in output, got: {output}"
+        );
+        assert!(
+            output.contains("check format"),
+            "expected message in output, got: {output}"
+        );
+    }
+}


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-439 -->

Closes #686

Add `trace_id=<32-hex>` prefix to all log lines emitted within an OpenTelemetry-traced span, so operators can correlate logs with distributed traces. This is done via a custom `FormatEvent` wrapper that reads `OtelData::trace_id()` from the span chain before delegating to the default format.

- Before

```sh
❯ cargo run -p apollo-mcp-server -- ./examples/TheSpaceDevs/config.yaml
    Finished [`dev` profile [unoptimized + debuginfo]](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles) target(s) in 11.38s
     Running `target/debug/apollo-mcp-server ./examples/TheSpaceDevs/config.yaml`
2026-04-15T14:40:55.330847Z  INFO Apollo MCP Server v1.12.0 // (c) Apollo Graph, Inc. // Licensed under MIT
2026-04-15T14:40:55.362467Z  INFO load_tool: Tool SearchUpcomingLaunches loaded with a character count of 545. Estimated tokens: 136
2026-04-15T14:40:55.368403Z  INFO load_tool: Tool ExploreCelestialBodies loaded with a character count of 761. Estimated tokens: 190
2026-04-15T14:40:55.373605Z  INFO load_tool: Tool GetAstronautDetails loaded with a character count of 898. Estimated tokens: 224
2026-04-15T14:40:55.378868Z  INFO load_tool: Tool GetAstronautsCurrentlyInSpace loaded with a character count of 501. Estimated tokens: 125
2026-04-15T14:40:55.395239Z  INFO schema_index: Indexed 50 types in 16.00ms
2026-04-15T14:40:55.398053Z  INFO Starting MCP server in Streamable HTTP mode port=8000 address=127.0.0.1
```


- After

```sh
❯ cargo run -p apollo-mcp-server -- ./examples/TheSpaceDevs/config.yaml
    Finished [`dev` profile [unoptimized + debuginfo]](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles) target(s) in 0.60s
     Running `target/debug/apollo-mcp-server ./examples/TheSpaceDevs/config.yaml`
2026-04-15T14:36:32.060271Z  INFO Apollo MCP Server v1.12.0 // (c) Apollo Graph, Inc. // Licensed under MIT
trace_id=1b6ec242d9c61d3a49ae3d9a4abee507 2026-04-15T14:36:32.091848Z  INFO load_tool: Tool SearchUpcomingLaunches loaded with a character count of 545. Estimated tokens: 136
trace_id=50be2921f0ea177ceb4787b665e35369 2026-04-15T14:36:32.097931Z  INFO load_tool: Tool ExploreCelestialBodies loaded with a character count of 761. Estimated tokens: 190
trace_id=c9946787e06327ea3e883d6ffd33403e 2026-04-15T14:36:32.103155Z  INFO load_tool: Tool GetAstronautDetails loaded with a character count of 898. Estimated tokens: 224
trace_id=c293d31e37e814c80666dfc6515df595 2026-04-15T14:36:32.109268Z  INFO load_tool: Tool GetAstronautsCurrentlyInSpace loaded with a character count of 501. Estimated tokens: 125
trace_id=91e024fb2410f71cc8042bda55161cae 2026-04-15T14:36:32.126110Z  INFO schema_index: Indexed 50 types in 16.41ms
2026-04-15T14:36:32.128898Z  INFO Starting MCP server in Streamable HTTP mode port=8000 address=127.0.0.1
```