### PR TITLE
ci: add one-off workflow to republish v1.13.0 binaries

### DIFF
--- a/.github/workflows/release-1.13.0-hotfix.yml
+++ b/.github/workflows/release-1.13.0-hotfix.yml
@@ -1,0 +1,24 @@
+name: Release 1.13.0 Hotfix
+
+# One-off workflow used to publish v1.13.0 binaries + GitHub Release after
+# the original release pipeline failed on aarch64-pc-windows-msvc due to a
+# latent `unused_variables` lint error under `-D warnings`. Builds from
+# `hotfix/1.13.0-windows-build`, which is v1.13.0's commit + the Windows fix.
+#
+# Delete this file (and the hotfix branch) once v1.13.0 has been published.
+
+on: workflow_dispatch
+
+permissions:
+  contents: write
+  packages: write
+  attestations: write
+  id-token: write
+
+jobs:
+  release:
+    uses: ./.github/workflows/release-bins.yml
+    with:
+      version: 1.13.0
+      ref: hotfix/1.13.0-windows-build
+    secrets: inherit


### PR DESCRIPTION
One-off `workflow_dispatch` wrapper around the reusable `release-bins.yml`. It builds from the `hotfix/1.13.0-windows-build` branch (v1.13.0 tip + the Windows unused-variable fix) to republish v1.13.0 with all 8 binaries + `config.schema.json`.

The original [v1.13.0 Release Binaries run](https://github.com/apollographql/apollo-mcp-server/actions/runs/24835822027) failed on `aarch64-pc-windows-msvc` from an `unused_variables` lint error under `-D warnings`, and matrix `fail-fast` cancelled the remaining platform jobs. The container was published but no GitHub Release or binaries exist for v1.13.0.

Merging this puts the workflow onto `main` so it can be dispatched. The underlying code fix + removal of this workflow will land in a later PR that ships with the next normal release.