### PR TITLE
ci: run clippy on Windows to catch cfg-gated warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,16 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo clippy --all-targets -- --deny warnings
 
+  clippy-windows:
+    # Catches Windows-only compile errors
+    name: Run Clippy checks (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo clippy --all-targets -- --deny warnings
+
   doc:
     name: Run Cargo Doc
     runs-on: ubuntu-latest

--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -52,6 +52,7 @@ jobs:
   build-artifacts:
     needs: [get-version]
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: aarch64-apple-darwin

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -239,6 +239,10 @@ fn spawn_stdio_config_watcher(config_path: PathBuf) {
         reason = "process::exit used for stdio mode SIGHUP restart"
     )
 )]
+#[cfg_attr(
+    not(unix),
+    allow(unused_variables, reason = "SIGHUP handling is unix-only")
+)]
 fn spawn_stdio_sighup_handler(config_path: Option<PathBuf>) {
     #[cfg(unix)]
     {


### PR DESCRIPTION
PR CI runs only on `ubuntu-latest`, so Windows-specific compile errors slip through review and only surface when the release-bins workflow tries to compile for Windows targets. This has now caused two broken release cuts in #719, #734 so it's worth closing the loop.

This PR fixes the latent Windows-only compile error found in the v1.13.0 release and adds a Windows clippy job to CI to detect this kind of issues earlier.