### PR TITLE
refactor: remove dead persisted_query support

### DIFF
--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -45,9 +45,6 @@ pub struct ValidationError(pub String);
 
 /// Able to be executed as a GraphQL operation
 pub trait Executable {
-    /// Get the persisted query ID to be executed, if any
-    fn persisted_query_id(&self) -> Option<String>;
-
     /// Get the operation to execute and its name
     fn operation(&self, input: Value) -> Result<OperationDetails, ValidationError>;
 
@@ -76,46 +73,29 @@ pub trait Executable {
         };
 
         let mut request_body = Map::from_iter([(String::from("variables"), variables)]);
-        let mut private_field_tree = None;
 
-        if let Some(id) = self.persisted_query_id() {
-            request_body.insert(
-                String::from("extensions"),
-                serde_json::json!({
-                    "persistedQuery": {
-                        "version": 1,
-                        "sha256Hash": id,
-                    },
-                    "clientLibrary": client_metadata,
-                }),
-            );
-            op_id = Some(id.to_string());
-        } else {
-            let OperationDetails {
-                query,
-                operation_name,
-                private_fields,
-            } = match self.operation(request.input) {
-                Ok(details) => details,
-                Err(ValidationError(msg)) => {
-                    return Ok(CallToolResult::error(vec![Content::text(msg)]));
-                }
-            };
-
-            private_field_tree = private_fields;
-
-            request_body.insert(String::from("query"), Value::String(query));
-            request_body.insert(
-                String::from("extensions"),
-                serde_json::json!({
-                    "clientLibrary": client_metadata,
-                }),
-            );
-
-            if let Some(op_name) = operation_name {
-                op_id = Some(op_name.clone());
-                request_body.insert(String::from("operationName"), Value::String(op_name));
+        let OperationDetails {
+            query,
+            operation_name,
+            private_fields,
+        } = match self.operation(request.input) {
+            Ok(details) => details,
+            Err(ValidationError(msg)) => {
+                return Ok(CallToolResult::error(vec![Content::text(msg)]));
             }
+        };
+
+        request_body.insert(String::from("query"), Value::String(query));
+        request_body.insert(
+            String::from("extensions"),
+            serde_json::json!({
+                "clientLibrary": client_metadata,
+            }),
+        );
+
+        if let Some(op_name) = operation_name {
+            op_id = Some(op_name.clone());
+            request_body.insert(String::from("operationName"), Value::String(op_name));
         }
 
         let response = match GRAPHQL_CLIENT
@@ -144,7 +124,7 @@ pub trait Executable {
                 // When the operation has @private fields, split the response:
                 // - restricted (without @private fields) goes to structured_content
                 // - full response is preserved in meta for the client to access
-                let (structured_content, meta) = if let Some(tree) = private_field_tree.as_ref() {
+                let (structured_content, meta) = if let Some(tree) = private_fields.as_ref() {
                     let restricted = filter_private_fields(&json, tree);
                     let mut meta = Meta::new();
                     meta.insert("structuredContent".into(), json);
@@ -175,13 +155,7 @@ pub trait Executable {
                 TelemetryAttribute::OperationId.to_key(),
                 op_id.unwrap_or("".to_string()),
             ),
-            KeyValue::new(
-                TelemetryAttribute::OperationSource.to_key(),
-                match self.persisted_query_id() {
-                    Some(_) => "persisted_query",
-                    None => "operation",
-                },
-            ),
+            KeyValue::new(TelemetryAttribute::OperationSource.to_key(), "operation"),
         ];
         meter
             .f64_histogram(TelemetryMetric::OperationDuration.as_str())
@@ -210,13 +184,9 @@ mod test {
     use serde_json::{Map, Value, json};
     use url::Url;
 
-    struct TestExecutableWithoutPersistedQueryId;
+    struct TestExecutable;
 
-    impl Executable for TestExecutableWithoutPersistedQueryId {
-        fn persisted_query_id(&self) -> Option<String> {
-            None
-        }
-
+    impl Executable for TestExecutable {
         fn operation(&self, _input: Value) -> Result<OperationDetails, ValidationError> {
             Ok(OperationDetails {
                 query: "query MockOp { mockOp { id } }".to_string(),
@@ -233,30 +203,6 @@ mod test {
                 _ => panic!("Expected a JSON object, but received a different type"),
             };
             Ok(Value::from(json_map))
-        }
-
-        fn headers(&self, _default_headers: &HeaderMap<HeaderValue>) -> HeaderMap<HeaderValue> {
-            HeaderMap::new()
-        }
-    }
-
-    struct TestExecutableWithPersistedQueryId;
-
-    impl Executable for TestExecutableWithPersistedQueryId {
-        fn persisted_query_id(&self) -> Option<String> {
-            Some("4f059505-fe13-4043-819a-461dd82dd5ed".to_string())
-        }
-
-        fn operation(&self, _input: Value) -> Result<OperationDetails, ValidationError> {
-            Ok(OperationDetails {
-                query: "query MockOp { mockOp { id } }".to_string(),
-                operation_name: Some("mock_operation".to_string()),
-                private_fields: None,
-            })
-        }
-
-        fn variables(&self, _input: Value) -> Result<Value, ValidationError> {
-            Ok(Value::String("mock_variables".to_string()))
         }
 
         fn headers(&self, _default_headers: &HeaderMap<HeaderValue>) -> HeaderMap<HeaderValue> {
@@ -298,52 +244,7 @@ mod test {
             .await;
 
         // when
-        let test_executable = TestExecutableWithoutPersistedQueryId {};
-        let result = test_executable.execute(mock_request).await.unwrap();
-
-        // then
-        mock.assert(); // verify that the mock http server route was invoked
-        assert!(!result.content.is_empty());
-        assert!(!result.is_error.unwrap());
-    }
-
-    #[tokio::test]
-    async fn calls_graphql_endpoint_with_expected_pq_extensions_in_request_body() {
-        // given
-        let mut server = mockito::Server::new_async().await;
-        let url = Url::parse(server.url().as_str()).unwrap();
-        let mock_request = Request {
-            input: json!({}),
-            endpoint: &url,
-            headers: &HeaderMap::new(),
-        };
-        let expected_request_body = json!({
-            "variables": "mock_variables",
-            "extensions": {
-                "persistedQuery": {
-                    "version": 1,
-                    "sha256Hash": "4f059505-fe13-4043-819a-461dd82dd5ed",
-                },
-                "clientLibrary": {
-                    "name":"mcp",
-                    "version": std::env!("CARGO_PKG_VERSION")
-                }
-            },
-        })
-        .to_string();
-
-        let mock = server
-            .mock("POST", "/")
-            .match_body(expected_request_body.as_str())
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(json!({ "data": {},  }).to_string())
-            .expect(1)
-            .create_async()
-            .await;
-
-        // when
-        let test_executable = TestExecutableWithPersistedQueryId {};
+        let test_executable = TestExecutable {};
         let result = test_executable.execute(mock_request).await.unwrap();
 
         // then
@@ -363,7 +264,7 @@ mod test {
         };
 
         // when
-        let test_executable = TestExecutableWithPersistedQueryId {};
+        let test_executable = TestExecutable {};
         let result = test_executable.execute(mock_request).await.unwrap();
 
         // then
@@ -397,7 +298,7 @@ mod test {
             .await;
 
         // when
-        let test_executable = TestExecutableWithPersistedQueryId {};
+        let test_executable = TestExecutable {};
         let result = test_executable.execute(mock_request).await.unwrap();
 
         // then
@@ -434,7 +335,7 @@ mod test {
             .await;
 
         // when
-        let test_executable = TestExecutableWithPersistedQueryId {};
+        let test_executable = TestExecutable {};
         let result = test_executable.execute(mock_request).await.unwrap();
 
         // then
@@ -468,7 +369,7 @@ mod test {
             .await;
 
         // when
-        let test_executable = TestExecutableWithPersistedQueryId {};
+        let test_executable = TestExecutable {};
         let result = test_executable.execute(mock_request).await.unwrap();
 
         // then
@@ -502,7 +403,7 @@ mod test {
             .await;
 
         // when
-        let test_executable = TestExecutableWithPersistedQueryId {};
+        let test_executable = TestExecutable {};
         let result = test_executable.execute(mock_request).await.unwrap();
 
         // then
@@ -534,7 +435,7 @@ mod test {
                             );
                             assert_eq!(
                                 attr_map.get("operation.type").map(|s| s.as_ref()),
-                                Some("persisted_query")
+                                Some("operation")
                             );
                             assert_eq!(
                                 attr_map.get("success"),

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -59,7 +59,6 @@ pub trait Executable {
     async fn execute(&self, request: Request<'_>) -> Result<CallToolResult, McpError> {
         let meter = &meter::METER;
         let start = std::time::Instant::now();
-        let mut op_id: Option<String> = None;
         let client_metadata = serde_json::json!({
             "name": "mcp",
             "version": std::env!("CARGO_PKG_VERSION")
@@ -93,8 +92,8 @@ pub trait Executable {
             }),
         );
 
+        let op_id = operation_name.clone();
         if let Some(op_name) = operation_name {
-            op_id = Some(op_name.clone());
             request_body.insert(String::from("operationName"), Value::String(op_name));
         }
 
@@ -153,7 +152,7 @@ pub trait Executable {
             ),
             KeyValue::new(
                 TelemetryAttribute::OperationId.to_key(),
-                op_id.unwrap_or("".to_string()),
+                op_id.unwrap_or_default(),
             ),
             KeyValue::new(TelemetryAttribute::OperationSource.to_key(), "operation"),
         ];

--- a/crates/apollo-mcp-server/src/introspection/tools/execute.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/execute.rs
@@ -47,10 +47,6 @@ impl Execute {
 }
 
 impl graphql::Executable for Execute {
-    fn persisted_query_id(&self) -> Option<String> {
-        None
-    }
-
     fn operation(&self, input: Value) -> Result<OperationDetails, ValidationError> {
         let input = serde_json::from_value::<Input>(input)
             .map_err(|e| ValidationError(format!("Invalid input: {e}")))?;

--- a/crates/apollo-mcp-server/src/operations/operation.rs
+++ b/crates/apollo-mcp-server/src/operations/operation.rs
@@ -354,11 +354,6 @@ impl Operation {
 }
 
 impl graphql::Executable for Operation {
-    // Always returns None: full source text is sent instead of a persisted query hash.
-    fn persisted_query_id(&self) -> Option<String> {
-        None
-    }
-
     fn operation(&self, _input: Value) -> Result<OperationDetails, ValidationError> {
         Ok(OperationDetails {
             query: self

--- a/crates/apollo-mcp-server/src/operations/operation.rs
+++ b/crates/apollo-mcp-server/src/operations/operation.rs
@@ -354,8 +354,8 @@ impl Operation {
 }
 
 impl graphql::Executable for Operation {
+    // Always returns None: full source text is sent instead of a persisted query hash.
     fn persisted_query_id(&self) -> Option<String> {
-        // TODO: id was being overridden, should we be returning? Should this be behind a flag? self.inner.persisted_query_id.clone()
         None
     }
 
@@ -768,7 +768,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($id: ID) { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -911,7 +910,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($id: ID!) { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -1058,7 +1056,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($id: [ID]!) { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -1225,7 +1222,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($id: [ID!]!) { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -1378,7 +1374,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($id: [ID]) { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -1539,7 +1534,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($id: [ID!]) { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -1686,7 +1680,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($id: [[ID]]) { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -1867,7 +1860,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($id: RealInputObject) { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -2016,7 +2008,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($id: RealEnum!) { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -2160,7 +2151,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName { id } query QueryName { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: Some("operation.graphql".to_string()),
@@ -2192,7 +2182,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: Some("operation.graphql".to_string()),
@@ -2225,7 +2214,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "fragment Test on Query { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: Some("operation.graphql".to_string()),
@@ -2255,7 +2243,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "type Query { id: String }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -2284,7 +2271,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($id: FakeType) { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -2424,7 +2410,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($id: RealCustomScalar) { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -2571,7 +2556,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($id: RealCustomScalar) { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -2724,7 +2708,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($id: RealCustomScalar) { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -2988,7 +2971,6 @@ mod tests {
             }
             "###
                 .to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -3078,7 +3060,6 @@ mod tests {
             }
             "###
                 .to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -3114,7 +3095,6 @@ mod tests {
             }
             "###
                 .to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -3142,7 +3122,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: r###"query GetABZ($state: String!) { id enum }"###.to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -3174,7 +3153,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: r###"query GetABZ($state: String!) { id enum }"###.to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -3211,7 +3189,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: r###"query GetABZ($state: String!) { id enum }"###.to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -3244,7 +3221,6 @@ mod tests {
                 }
             }"###
                     .to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -3411,7 +3387,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($id: ID, $name: String) { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: Some(HashMap::from([(
                     "id".to_string(),
@@ -3546,7 +3521,6 @@ mod tests {
             RawOperation {
                 source_text: "query QueryName($idArg: ID) { customQuery(id: $idArg) { id } }"
                     .to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -3583,7 +3557,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($idArg: ID, $flag: Boolean) { customQuery(id: $idArg, flag: $flag) { id @skip(if: $flag) } }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -3624,7 +3597,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($idArg: ID, $skipArg: Boolean) { customQuery(id: $idArg) { id @skip(if: $skipArg) } }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -3664,7 +3636,6 @@ mod tests {
         let source_text = "query GetUser($id: ID!) { user(id: $id) { name email } }";
         let raw_op = RawOperation {
             source_text: source_text.to_string(),
-            persisted_query_id: None,
             headers: None,
             variables: None,
             source_path: None,
@@ -3693,7 +3664,6 @@ mod tests {
             "mutation CreateUser($input: UserInput!) { createUser(input: $input) { id name } }";
         let raw_op = RawOperation {
             source_text: source_text.to_string(),
-            persisted_query_id: None,
             headers: None,
             variables: None,
             source_path: None,
@@ -3721,7 +3691,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "# operation description\nquery QueryName(# id comment override\n$idArg: ID) { customQuery(id: $idArg) { id } }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -3758,7 +3727,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "# operation description\nquery QueryName(# id comment override\n # multi-line comment \n$idArg: ID) { customQuery(id: $idArg) { id } }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -3795,7 +3763,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName # a comment (with parens)\n(# id comment override\n # multi-line comment \n$idArg: ID) { customQuery(id: $idArg) { id } }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -3832,7 +3799,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "#  operation comment\n\nquery QueryName # a comment \n#     extra space\n\n\n#  blank lines (with parens)\n\n# another (paren)\n(# id comment override\n # multi-line comment \n$idArg: ID\n, \n# a flag\n$flag: Boolean) { customQuery(id: $idArg, skip: $flag) { id } }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -3873,7 +3839,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName { customQuery(id: \"123\") { id } }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -3905,7 +3870,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName(# id arg\n $idArg: ID,,\n,,\n # a flag\n $flag: Boolean,  ,,) { customQuery(id: $idArg, flag: $flag) { id } }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -3946,7 +3910,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query TestOp { testOp { id } }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -3978,7 +3941,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($objects: [RealInputObject]) { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -4177,7 +4139,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($objects: [RealInputObject!]!) { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -4369,7 +4330,6 @@ mod tests {
             Operation::from_document(
                 RawOperation {
                     source_text: "subscription SubscriptionName { id }".to_string(),
-                    persisted_query_id: None,
                     headers: None,
                     variables: None,
                     source_path: None,
@@ -4394,7 +4354,6 @@ mod tests {
             Operation::from_document(
                 RawOperation {
                     source_text: "mutation MutationName { id }".to_string(),
-                    persisted_query_id: None,
                     headers: None,
                     variables: None,
                     source_path: None,
@@ -4419,7 +4378,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "mutation MutationName { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -4538,7 +4496,6 @@ mod tests {
             },
             inner: RawOperation {
                 source_text: "mutation MutationName { id }",
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -4556,7 +4513,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "mutation MutationName { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -4675,7 +4631,6 @@ mod tests {
             },
             inner: RawOperation {
                 source_text: "mutation MutationName { id }",
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -4693,7 +4648,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -4931,7 +4885,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($id: ID) { id }".to_string(),
-                persisted_query_id: Some("hash123".to_string()),
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -4960,7 +4913,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($id: ID) { id }".to_string(),
-                persisted_query_id: Some("hash123".to_string()),
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -4995,7 +4947,6 @@ mod tests {
             RawOperation {
                 source_text: "# Comment-based description\nquery QueryName($id: ID) { id }"
                     .to_string(),
-                persisted_query_id: Some("hash123".to_string()),
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -5197,7 +5148,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query GetId { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -5235,7 +5185,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query GetId { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -5269,7 +5218,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query GetId { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,
@@ -5295,7 +5243,6 @@ mod tests {
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query GetId { id }".to_string(),
-                persisted_query_id: None,
                 headers: None,
                 variables: None,
                 source_path: None,

--- a/crates/apollo-mcp-server/src/operations/operation_source.rs
+++ b/crates/apollo-mcp-server/src/operations/operation_source.rs
@@ -49,7 +49,10 @@ impl OperationSource {
                 .map(|event| {
                     let ManifestEvent::UpdateManifest(operations) = event;
                     Event::OperationsUpdated(
-                        operations.into_iter().map(RawOperation::from).collect(),
+                        operations
+                            .into_iter()
+                            .map(|(_hash, body)| RawOperation::from((body, None)))
+                            .collect(),
                     )
                 })
                 .boxed(),

--- a/crates/apollo-mcp-server/src/operations/operation_source.rs
+++ b/crates/apollo-mcp-server/src/operations/operation_source.rs
@@ -46,14 +46,8 @@ impl OperationSource {
             OperationSource::Manifest(source) => source
                 .into_stream()
                 .await
-                .map(|event| {
-                    let ManifestEvent::UpdateManifest(operations) = event;
-                    Event::OperationsUpdated(
-                        operations
-                            .into_iter()
-                            .map(|(_hash, body)| RawOperation::from((body, None)))
-                            .collect(),
-                    )
+                .map(|ManifestEvent::UpdateManifest(operations)| {
+                    Event::OperationsUpdated(raw_operations_from_manifest(operations))
                 })
                 .boxed(),
             OperationSource::Collection(collection_source) => collection_source
@@ -203,6 +197,14 @@ impl From<ManifestSource> for OperationSource {
     }
 }
 
+fn raw_operations_from_manifest(operations: Vec<(String, String)>) -> Vec<RawOperation> {
+    operations
+        .into_iter()
+        // No source_path: manifest entries are not loaded from disk.
+        .map(|(_hash, body)| RawOperation::from((body, None)))
+        .collect()
+}
+
 #[allow(clippy::expect_used)]
 static OP_NAME_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
     Regex::new(r"(?:query|mutation|subscription)\s+([A-Za-z_]\w*)")
@@ -319,5 +321,36 @@ mod tests {
             extract_operation_name("query { alerts { severity } }"),
             None
         );
+    }
+
+    #[test]
+    fn raw_operations_from_manifest_drops_hashes_and_preserves_bodies() {
+        let manifest = vec![
+            ("hash1".to_string(), "query A { a }".to_string()),
+            ("hash2".to_string(), "query B { b }".to_string()),
+        ];
+
+        let bodies: Vec<String> = raw_operations_from_manifest(manifest)
+            .into_iter()
+            .map(|op| op.source_text)
+            .collect();
+
+        assert_eq!(bodies, vec!["query A { a }", "query B { b }"]);
+    }
+
+    #[test]
+    fn raw_operations_from_manifest_does_not_set_source_path() {
+        let manifest = vec![("hash".to_string(), "query A { a }".to_string())];
+
+        let raw_ops = raw_operations_from_manifest(manifest);
+
+        assert!(raw_ops[0].source_path.is_none());
+    }
+
+    #[test]
+    fn raw_operations_from_manifest_handles_empty_input() {
+        let raw_ops = raw_operations_from_manifest(vec![]);
+
+        assert!(raw_ops.is_empty());
     }
 }

--- a/crates/apollo-mcp-server/src/operations/raw_operation.rs
+++ b/crates/apollo-mcp-server/src/operations/raw_operation.rs
@@ -14,7 +14,6 @@ use super::{AnnotationOverrides, MutationMode, operation::Operation};
 #[derive(Debug, Clone)]
 pub struct RawOperation {
     pub(crate) source_text: String,
-    pub(super) persisted_query_id: Option<String>,
     pub(super) headers: Option<HeaderMap<HeaderValue>>,
     pub(crate) variables: Option<HashMap<String, Value>>,
     pub(super) source_path: Option<String>,
@@ -51,24 +50,10 @@ impl RawOperation {
 impl From<(String, Option<String>)> for RawOperation {
     fn from((source_text, source_path): (String, Option<String>)) -> Self {
         Self {
-            persisted_query_id: None,
             source_text,
             headers: None,
             variables: None,
             source_path,
-            description: None,
-        }
-    }
-}
-
-impl From<(String, String)> for RawOperation {
-    fn from((persisted_query_id, source_text): (String, String)) -> Self {
-        Self {
-            persisted_query_id: Some(persisted_query_id),
-            source_text,
-            headers: None,
-            variables: None,
-            source_path: None,
             description: None,
         }
     }
@@ -105,7 +90,6 @@ impl TryFrom<&OperationData> for RawOperation {
         };
 
         Ok(Self {
-            persisted_query_id: None,
             source_text: operation_data.source_text.clone(),
             headers,
             variables,
@@ -125,11 +109,8 @@ impl serde::Serialize for RawOperation {
         S: serde::Serializer,
     {
         use serde::ser::SerializeStruct;
-        let mut state = serializer.serialize_struct("RawOperation", 4)?;
+        let mut state = serializer.serialize_struct("RawOperation", 3)?;
         state.serialize_field("source_text", &self.source_text)?;
-        if let Some(ref id) = self.persisted_query_id {
-            state.serialize_field("persisted_query_id", id)?;
-        }
         if let Some(ref variables) = self.variables {
             state.serialize_field("variables", variables)?;
         }
@@ -207,24 +188,12 @@ mod tests {
     }
 
     #[test]
-    fn from_manifest_tuple_has_no_description() {
-        let raw_op = RawOperation::from((
-            "hash123".to_string(),
-            "query GetUser { user { name } }".to_string(),
-        ));
-
-        assert_eq!(raw_op.persisted_query_id.as_deref(), Some("hash123"));
-        assert!(raw_op.description.is_none());
-    }
-
-    #[test]
     fn from_local_file_has_no_description() {
         let raw_op = RawOperation::from((
             "query GetUser { user { name } }".to_string(),
             None::<String>,
         ));
 
-        assert!(raw_op.persisted_query_id.is_none());
         assert!(raw_op.description.is_none());
     }
 }

--- a/docs/source/telemetry.mdx
+++ b/docs/source/telemetry.mdx
@@ -143,7 +143,7 @@ The server emits the following metrics, which are invaluable for monitoring and 
 | `apollo.mcp.get_info.count` | Counter | Incremented for each `get_info` request. | (none) |
 | `apollo.mcp.tool.count` | Counter | Incremented for each tool call. | `tool_name`, `success` (bool) |
 | `apollo.mcp.tool.duration` | Histogram | Measures the execution duration of each tool call. | `tool_name`, `success` (bool) |
-| `apollo.mcp.operation.count`| Counter | Incremented for each downstream GraphQL operation executed by a tool. | `operation.id`, `operation.type` ("persisted_query" or "operation"), `success` (bool) |
+| `apollo.mcp.operation.count`| Counter | Incremented for each downstream GraphQL operation executed by a tool. | `operation.id`, `operation.type`, `success` (bool) |
 | `apollo.mcp.operation.duration`| Histogram | Measures the round-trip duration of each downstream GraphQL operation. | `operation.id`, `operation.type`, `success` (bool) |
 
 In addition to these metrics, the server also emits standard [HTTP server metrics](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/) (e.g., `http.server.duration`, `http.server.active_requests`) courtesy of the `axum-otel-metrics` library.


### PR DESCRIPTION
Cleans up persisted-query infrastructure that was disabled but still wired through the codebase. The persisted-query branch in `graphql::execute()` was unreachable for both `Operation` and the introspection `Execute` tool. The companion `RawOperation::persisted_query_id` field was set during construction but its value never reached execution.