### PR TITLE
refactor: remove description from RawOperation

### DIFF
--- a/crates/apollo-mcp-server/src/apps/manifest.rs
+++ b/crates/apollo-mcp-server/src/apps/manifest.rs
@@ -79,7 +79,7 @@ pub(crate) fn load_from_path(
 
         for operation_def in manifest.operations {
             let raw = RawOperation::from((operation_def.body, path.to_str().map(String::from)));
-            let operation = match Operation::from_document(
+            let operation = match Operation::from_raw(
                 raw,
                 schema,
                 custom_scalar_map,

--- a/crates/apollo-mcp-server/src/apps/manifest.rs
+++ b/crates/apollo-mcp-server/src/apps/manifest.rs
@@ -88,6 +88,7 @@ pub(crate) fn load_from_path(
                 disable_schema_description,
                 enable_output_schema,
                 &HashMap::new(),
+                &HashMap::new(),
             ) {
                 Err(err) => {
                     return Err(format!(

--- a/crates/apollo-mcp-server/src/apps/tool.rs
+++ b/crates/apollo-mcp-server/src/apps/tool.rs
@@ -322,6 +322,7 @@ mod tests {
                 true,
                 true,
                 &HashMap::new(),
+                &HashMap::new(),
             )
             .unwrap()
             .unwrap(),
@@ -341,6 +342,7 @@ mod tests {
                 true,
                 true,
                 &HashMap::new(),
+                &HashMap::new(),
             )
             .unwrap()
             .unwrap(),
@@ -357,6 +359,7 @@ mod tests {
                 true,
                 true,
                 true,
+                &HashMap::new(),
                 &HashMap::new(),
             )
             .unwrap()
@@ -505,6 +508,7 @@ mod tests {
                             false,
                             true,
                             &HashMap::new(),
+                            &HashMap::new(),
                         )
                         .unwrap()
                         .unwrap(),
@@ -566,6 +570,7 @@ mod tests {
                             false,
                             true,
                             &HashMap::new(),
+                            &HashMap::new(),
                         )
                         .unwrap()
                         .unwrap(),
@@ -618,6 +623,7 @@ mod tests {
                             false,
                             false,
                             true,
+                            &HashMap::new(),
                             &HashMap::new(),
                         )
                         .unwrap()
@@ -690,6 +696,7 @@ mod tests {
                     true,
                     true,
                     true,
+                    &HashMap::new(),
                     &HashMap::new(),
                 )
                 .unwrap()

--- a/crates/apollo-mcp-server/src/operations.rs
+++ b/crates/apollo-mcp-server/src/operations.rs
@@ -12,26 +12,9 @@ pub(crate) mod private_fields;
 mod raw_operation;
 mod schema_walker;
 
-use std::collections::HashMap;
-
 pub use annotation_overrides::AnnotationOverrides;
 pub(crate) use execution::{execute_operation, find_and_execute_operation};
 pub use mutation_mode::MutationMode;
 pub(crate) use operation::{Operation, operation_defs, operation_name};
 pub use operation_source::OperationSource;
-pub(crate) use operation_source::extract_operation_name;
 pub(crate) use raw_operation::RawOperation;
-
-/// If an override description exists for this operation, set it on the raw
-/// operation so it takes priority over auto-generated descriptions.
-pub(crate) fn apply_description_override(
-    mut operation: RawOperation,
-    descriptions: &HashMap<String, String>,
-) -> RawOperation {
-    if let Some(desc) =
-        extract_operation_name(&operation.source_text).and_then(|name| descriptions.get(name))
-    {
-        operation.description = Some(desc.clone());
-    }
-    operation
-}

--- a/crates/apollo-mcp-server/src/operations/execution.rs
+++ b/crates/apollo-mcp-server/src/operations/execution.rs
@@ -93,6 +93,7 @@ mod tests {
                 true,
                 true,
                 &HashMap::new(),
+                &HashMap::new(),
             )
             .unwrap()
             .unwrap();
@@ -127,6 +128,7 @@ mod tests {
                     true,
                     true,
                     &HashMap::new(),
+                    &HashMap::new(),
                 )
                 .unwrap()
                 .unwrap(),
@@ -138,6 +140,7 @@ mod tests {
                     true,
                     true,
                     true,
+                    &HashMap::new(),
                     &HashMap::new(),
                 )
                 .unwrap()

--- a/crates/apollo-mcp-server/src/operations/operation.rs
+++ b/crates/apollo-mcp-server/src/operations/operation.rs
@@ -63,7 +63,7 @@ impl Operation {
 
     #[expect(clippy::too_many_arguments)]
     #[tracing::instrument(skip_all, name = "load_tool")]
-    pub fn from_document(
+    pub fn from_raw(
         raw_operation: RawOperation,
         graphql_schema: &GraphqlSchema,
         custom_scalar_map: Option<&CustomScalarMap>,
@@ -764,7 +764,7 @@ mod tests {
 
     #[test]
     fn nullable_named_type() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($id: ID) { id }".to_string(),
                 headers: None,
@@ -906,7 +906,7 @@ mod tests {
 
     #[test]
     fn non_nullable_named_type() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($id: ID!) { id }".to_string(),
                 headers: None,
@@ -1052,7 +1052,7 @@ mod tests {
 
     #[test]
     fn non_nullable_list_of_nullable_named_type() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($id: [ID]!) { id }".to_string(),
                 headers: None,
@@ -1218,7 +1218,7 @@ mod tests {
 
     #[test]
     fn non_nullable_list_of_non_nullable_named_type() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($id: [ID!]!) { id }".to_string(),
                 headers: None,
@@ -1370,7 +1370,7 @@ mod tests {
 
     #[test]
     fn nullable_list_of_nullable_named_type() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($id: [ID]) { id }".to_string(),
                 headers: None,
@@ -1530,7 +1530,7 @@ mod tests {
 
     #[test]
     fn nullable_list_of_non_nullable_named_type() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($id: [ID!]) { id }".to_string(),
                 headers: None,
@@ -1676,7 +1676,7 @@ mod tests {
 
     #[test]
     fn nullable_list_of_nullable_lists_of_nullable_named_types() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($id: [[ID]]) { id }".to_string(),
                 headers: None,
@@ -1856,7 +1856,7 @@ mod tests {
 
     #[test]
     fn nullable_input_object() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($id: RealInputObject) { id }".to_string(),
                 headers: None,
@@ -2004,7 +2004,7 @@ mod tests {
 
     #[test]
     fn non_nullable_enum() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($id: RealEnum!) { id }".to_string(),
                 headers: None,
@@ -2147,7 +2147,7 @@ mod tests {
 
     #[test]
     fn multiple_operations_should_error() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName { id } query QueryName { id }".to_string(),
                 headers: None,
@@ -2178,7 +2178,7 @@ mod tests {
     #[test]
     #[traced_test]
     fn unnamed_operations_should_be_skipped() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query { id }".to_string(),
                 headers: None,
@@ -2210,7 +2210,7 @@ mod tests {
 
     #[test]
     fn no_operations_should_error() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "fragment Test on Query { id }".to_string(),
                 headers: None,
@@ -2239,7 +2239,7 @@ mod tests {
 
     #[test]
     fn schema_should_error() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "type Query { id: String }".to_string(),
                 headers: None,
@@ -2267,7 +2267,7 @@ mod tests {
     #[test]
     #[traced_test]
     fn unknown_type_should_be_any() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($id: FakeType) { id }".to_string(),
                 headers: None,
@@ -2406,7 +2406,7 @@ mod tests {
     #[test]
     #[traced_test]
     fn custom_scalar_without_map_should_be_any() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($id: RealCustomScalar) { id }".to_string(),
                 headers: None,
@@ -2552,7 +2552,7 @@ mod tests {
     #[test]
     #[traced_test]
     fn custom_scalar_with_map_but_not_found_should_error() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($id: RealCustomScalar) { id }".to_string(),
                 headers: None,
@@ -2704,7 +2704,7 @@ mod tests {
         let custom_scalar_map =
             CustomScalarMap::from_str("{ \"RealCustomScalar\": { \"type\": \"string\" }}");
 
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($id: RealCustomScalar) { id }".to_string(),
                 headers: None,
@@ -2934,7 +2934,7 @@ mod tests {
         let document = Parser::new().parse_ast(SCHEMA, "schema.graphql").unwrap();
         let schema = document.to_schema().unwrap();
 
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: r###"
             query GetABZ($state: String!) {
@@ -3046,7 +3046,7 @@ mod tests {
 
     #[test]
     fn tool_comment_description() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: r###"
             # Overridden tool #description
@@ -3083,7 +3083,7 @@ mod tests {
 
     #[test]
     fn tool_empty_comment_description() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: r###"
             #
@@ -3118,7 +3118,7 @@ mod tests {
 
     #[test]
     fn no_schema_description() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: r###"query GetABZ($state: String!) { id enum }"###.to_string(),
                 headers: None,
@@ -3149,7 +3149,7 @@ mod tests {
 
     #[test]
     fn no_type_description() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: r###"query GetABZ($state: String!) { id enum }"###.to_string(),
                 headers: None,
@@ -3185,7 +3185,7 @@ mod tests {
 
     #[test]
     fn no_type_description_or_schema_description() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: r###"query GetABZ($state: String!) { id enum }"###.to_string(),
                 headers: None,
@@ -3212,7 +3212,7 @@ mod tests {
 
     #[test]
     fn recursive_inputs() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: r###"query Test($filter: Filter){
                 field(filter: $filter) {
@@ -3383,7 +3383,7 @@ mod tests {
 
     #[test]
     fn with_variable_overrides() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($id: ID, $name: String) { id }".to_string(),
                 headers: None,
@@ -3516,7 +3516,7 @@ mod tests {
 
     #[test]
     fn input_schema_includes_variable_descriptions() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($idArg: ID) { customQuery(id: $idArg) { id } }"
                     .to_string(),
@@ -3553,7 +3553,7 @@ mod tests {
 
     #[test]
     fn input_schema_includes_joined_variable_descriptions_if_multiple() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($idArg: ID, $flag: Boolean) { customQuery(id: $idArg, flag: $flag) { id @skip(if: $flag) } }".to_string(),
                 headers: None,
@@ -3593,7 +3593,7 @@ mod tests {
 
     #[test]
     fn input_schema_includes_directive_variable_descriptions() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($idArg: ID, $skipArg: Boolean) { customQuery(id: $idArg) { id @skip(if: $skipArg) } }".to_string(),
                 headers: None,
@@ -3639,7 +3639,7 @@ mod tests {
             variables: None,
             source_path: None,
         };
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             raw_op,
             &SCHEMA,
             None,
@@ -3667,7 +3667,7 @@ mod tests {
             variables: None,
             source_path: None,
         };
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             raw_op,
             &SCHEMA,
             None,
@@ -3687,7 +3687,7 @@ mod tests {
 
     #[test]
     fn operation_variable_comments_override_schema_descriptions() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "# operation description\nquery QueryName(# id comment override\n$idArg: ID) { customQuery(id: $idArg) { id } }".to_string(),
                 headers: None,
@@ -3723,7 +3723,7 @@ mod tests {
 
     #[test]
     fn operation_variable_comment_override_supports_multiline_comments() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "# operation description\nquery QueryName(# id comment override\n # multi-line comment \n$idArg: ID) { customQuery(id: $idArg) { id } }".to_string(),
                 headers: None,
@@ -3759,7 +3759,7 @@ mod tests {
 
     #[test]
     fn comment_with_parens_has_comments_extracted_correctly() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName # a comment (with parens)\n(# id comment override\n # multi-line comment \n$idArg: ID) { customQuery(id: $idArg) { id } }".to_string(),
                 headers: None,
@@ -3795,7 +3795,7 @@ mod tests {
 
     #[test]
     fn multiline_comment_with_odd_spacing_and_parens_has_comments_extracted_correctly() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "#  operation comment\n\nquery QueryName # a comment \n#     extra space\n\n\n#  blank lines (with parens)\n\n# another (paren)\n(# id comment override\n # multi-line comment \n$idArg: ID\n, \n# a flag\n$flag: Boolean) { customQuery(id: $idArg, skip: $flag) { id } }".to_string(),
                 headers: None,
@@ -3835,7 +3835,7 @@ mod tests {
 
     #[test]
     fn operation_with_no_variables_is_handled_properly() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName { customQuery(id: \"123\") { id } }".to_string(),
                 headers: None,
@@ -3866,7 +3866,7 @@ mod tests {
 
     #[test]
     fn commas_between_variables_are_ignored() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName(# id arg\n $idArg: ID,,\n,,\n # a flag\n $flag: Boolean,  ,,) { customQuery(id: $idArg, flag: $flag) { id } }".to_string(),
                 headers: None,
@@ -3906,7 +3906,7 @@ mod tests {
 
     #[test]
     fn input_schema_include_properties_field_even_when_operation_has_no_input_args() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query TestOp { testOp { id } }".to_string(),
                 headers: None,
@@ -3937,7 +3937,7 @@ mod tests {
 
     #[test]
     fn nullable_list_of_nullable_input_objects() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($objects: [RealInputObject]) { id }".to_string(),
                 headers: None,
@@ -4135,7 +4135,7 @@ mod tests {
 
     #[test]
     fn non_nullable_list_of_non_nullable_input_objects() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($objects: [RealInputObject!]!) { id }".to_string(),
                 headers: None,
@@ -4326,7 +4326,7 @@ mod tests {
     #[test]
     fn subscriptions() {
         assert!(
-            Operation::from_document(
+            Operation::from_raw(
                 RawOperation {
                     source_text: "subscription SubscriptionName { id }".to_string(),
                     headers: None,
@@ -4350,7 +4350,7 @@ mod tests {
     #[test]
     fn mutation_mode_none() {
         assert!(
-            Operation::from_document(
+            Operation::from_raw(
                 RawOperation {
                     source_text: "mutation MutationName { id }".to_string(),
                     headers: None,
@@ -4374,7 +4374,7 @@ mod tests {
 
     #[test]
     fn mutation_mode_explicit() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "mutation MutationName { id }".to_string(),
                 headers: None,
@@ -4508,7 +4508,7 @@ mod tests {
 
     #[test]
     fn mutation_mode_all() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "mutation MutationName { id }".to_string(),
                 headers: None,
@@ -4642,7 +4642,7 @@ mod tests {
 
     #[test]
     fn no_variables() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName { id }".to_string(),
                 headers: None,
@@ -4881,7 +4881,7 @@ mod tests {
         let explicit_desc = "My custom tool description from PQ manifest";
         let description_overrides =
             HashMap::from([("QueryName".to_string(), explicit_desc.to_string())]);
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($id: ID) { id }".to_string(),
                 headers: None,
@@ -4909,7 +4909,7 @@ mod tests {
 
     #[test]
     fn no_explicit_description_falls_back_to_auto_generated() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query QueryName($id: ID) { id }".to_string(),
                 headers: None,
@@ -4944,7 +4944,7 @@ mod tests {
         let explicit_desc = "Override from manifest";
         let description_overrides =
             HashMap::from([("QueryName".to_string(), explicit_desc.to_string())]);
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "# Comment-based description\nquery QueryName($id: ID) { id }"
                     .to_string(),
@@ -5152,7 +5152,7 @@ mod tests {
                 ..Default::default()
             },
         )]);
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query GetId { id }".to_string(),
                 headers: None,
@@ -5189,7 +5189,7 @@ mod tests {
                 ..Default::default()
             },
         )]);
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query GetId { id }".to_string(),
                 headers: None,
@@ -5222,7 +5222,7 @@ mod tests {
                 ..Default::default()
             },
         )]);
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query GetId { id }".to_string(),
                 headers: None,
@@ -5247,7 +5247,7 @@ mod tests {
 
     #[test]
     fn no_annotation_overrides_keeps_auto_detected() {
-        let operation = Operation::from_document(
+        let operation = Operation::from_raw(
             RawOperation {
                 source_text: "query GetId { id }".to_string(),
                 headers: None,

--- a/crates/apollo-mcp-server/src/operations/operation.rs
+++ b/crates/apollo-mcp-server/src/operations/operation.rs
@@ -72,6 +72,7 @@ impl Operation {
         disable_schema_description: bool,
         enable_output_schema: bool,
         annotation_overrides: &HashMap<String, AnnotationOverrides>,
+        description_overrides: &HashMap<String, String>,
     ) -> Result<Option<Self>, OperationError> {
         if let Some((document, operation, comments)) = operation_defs(
             &raw_operation.source_text,
@@ -99,16 +100,19 @@ impl Operation {
             let mut tree_shaker = SchemaTreeShaker::new(graphql_schema);
             tree_shaker.retain_operation(&operation, &document, DepthLimit::Unlimited);
 
-            let description = raw_operation.description.clone().unwrap_or_else(|| {
-                Self::tool_description(
-                    comments,
-                    &mut tree_shaker,
-                    graphql_schema,
-                    &operation,
-                    disable_type_description,
-                    disable_schema_description,
-                )
-            });
+            let description = description_overrides
+                .get(&operation_name)
+                .cloned()
+                .unwrap_or_else(|| {
+                    Self::tool_description(
+                        comments,
+                        &mut tree_shaker,
+                        graphql_schema,
+                        &operation,
+                        disable_type_description,
+                        disable_schema_description,
+                    )
+                });
 
             let mut object = serde_json::to_value(get_json_schema(
                 &operation,
@@ -766,7 +770,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -774,6 +777,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -908,7 +912,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -916,6 +919,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -1054,7 +1058,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -1062,6 +1065,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -1220,7 +1224,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -1228,6 +1231,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -1372,7 +1376,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -1380,6 +1383,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -1532,7 +1536,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -1540,6 +1543,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -1678,7 +1682,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -1686,6 +1689,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -1858,7 +1862,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -1866,6 +1869,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -2006,7 +2010,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -2014,6 +2017,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -2149,7 +2153,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: Some("operation.graphql".to_string()),
-                description: None,
             },
             &SCHEMA,
             None,
@@ -2157,6 +2160,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         );
         insta::assert_debug_snapshot!(operation, @r#"
@@ -2180,7 +2184,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: Some("operation.graphql".to_string()),
-                description: None,
             },
             &SCHEMA,
             None,
@@ -2188,6 +2191,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         );
         assert!(operation.unwrap().is_none());
@@ -2212,7 +2216,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: Some("operation.graphql".to_string()),
-                description: None,
             },
             &SCHEMA,
             None,
@@ -2220,6 +2223,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         );
         insta::assert_debug_snapshot!(operation, @r#"
@@ -2241,7 +2245,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -2249,6 +2252,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         );
         insta::assert_debug_snapshot!(operation, @r"
@@ -2269,7 +2273,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -2277,6 +2280,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -2408,7 +2412,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -2416,6 +2419,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -2554,7 +2558,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             Some(&CustomScalarMap::from_str("{}").unwrap()),
@@ -2562,6 +2565,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -2706,7 +2710,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             custom_scalar_map.ok().as_ref(),
@@ -2714,6 +2717,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -2969,7 +2973,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &schema,
             None,
@@ -2977,6 +2980,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -3058,7 +3062,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -3066,6 +3069,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -3093,7 +3097,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -3101,6 +3104,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -3120,7 +3124,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -3128,6 +3131,7 @@ mod tests {
             false,
             true,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -3151,7 +3155,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -3159,6 +3162,7 @@ mod tests {
             true,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -3187,7 +3191,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -3195,6 +3198,7 @@ mod tests {
             true,
             true,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -3219,7 +3223,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &Schema::parse(
                 r#"
@@ -3246,6 +3249,7 @@ mod tests {
             true,
             true,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -3388,7 +3392,6 @@ mod tests {
                     serde_json::Value::String("v".to_string()),
                 )])),
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -3396,6 +3399,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -3519,7 +3523,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -3527,6 +3530,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -3555,7 +3559,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -3563,6 +3566,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
             .unwrap()
@@ -3595,7 +3599,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -3603,6 +3606,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
             .unwrap()
@@ -3634,7 +3638,6 @@ mod tests {
             headers: None,
             variables: None,
             source_path: None,
-            description: None,
         };
         let operation = Operation::from_document(
             raw_op,
@@ -3644,6 +3647,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -3662,7 +3666,6 @@ mod tests {
             headers: None,
             variables: None,
             source_path: None,
-            description: None,
         };
         let operation = Operation::from_document(
             raw_op,
@@ -3672,6 +3675,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -3689,7 +3693,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -3697,6 +3700,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
             .unwrap()
@@ -3725,7 +3729,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -3733,6 +3736,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
             .unwrap()
@@ -3761,7 +3765,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -3769,6 +3772,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
             .unwrap()
@@ -3797,7 +3801,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -3805,6 +3808,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
             .unwrap()
@@ -3837,7 +3841,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -3845,6 +3848,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -3868,7 +3872,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -3876,6 +3879,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
             .unwrap()
@@ -3908,7 +3912,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -3916,6 +3919,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -3939,7 +3943,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -3947,6 +3950,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -4137,7 +4141,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -4145,6 +4148,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -4328,7 +4332,6 @@ mod tests {
                     headers: None,
                     variables: None,
                     source_path: None,
-                    description: None,
                 },
                 &SCHEMA,
                 None,
@@ -4336,6 +4339,7 @@ mod tests {
                 false,
                 false,
                 true,
+                &HashMap::new(),
                 &HashMap::new(),
             )
             .unwrap()
@@ -4352,7 +4356,6 @@ mod tests {
                     headers: None,
                     variables: None,
                     source_path: None,
-                    description: None,
                 },
                 &SCHEMA,
                 None,
@@ -4360,6 +4363,7 @@ mod tests {
                 false,
                 false,
                 true,
+                &HashMap::new(),
                 &HashMap::new(),
             )
             .ok()
@@ -4376,7 +4380,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -4384,6 +4387,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -4494,7 +4498,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             operation_name: "MutationName",
             stripped_source_text: None,
@@ -4511,7 +4514,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -4519,6 +4521,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -4629,7 +4632,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             operation_name: "MutationName",
             stripped_source_text: None,
@@ -4646,7 +4648,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -4654,6 +4655,7 @@ mod tests {
             false,
             false,
             true,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -4877,13 +4879,14 @@ mod tests {
     #[test]
     fn explicit_description_overrides_auto_generated() {
         let explicit_desc = "My custom tool description from PQ manifest";
+        let description_overrides =
+            HashMap::from([("QueryName".to_string(), explicit_desc.to_string())]);
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "query QueryName($id: ID) { id }".to_string(),
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: Some(explicit_desc.to_string()),
             },
             &SCHEMA,
             None,
@@ -4892,6 +4895,7 @@ mod tests {
             false,
             false,
             &HashMap::new(),
+            &description_overrides,
         )
         .unwrap()
         .unwrap();
@@ -4899,7 +4903,7 @@ mod tests {
         assert_eq!(
             operation.tool.description.as_deref(),
             Some(explicit_desc),
-            "tool description should use the explicit description from RawOperation"
+            "tool description should use the override keyed by operation name"
         );
     }
 
@@ -4911,7 +4915,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -4919,6 +4922,7 @@ mod tests {
             false,
             false,
             false,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()
@@ -4938,6 +4942,8 @@ mod tests {
     #[test]
     fn explicit_description_overrides_comments() {
         let explicit_desc = "Override from manifest";
+        let description_overrides =
+            HashMap::from([("QueryName".to_string(), explicit_desc.to_string())]);
         let operation = Operation::from_document(
             RawOperation {
                 source_text: "# Comment-based description\nquery QueryName($id: ID) { id }"
@@ -4945,7 +4951,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: Some(explicit_desc.to_string()),
             },
             &SCHEMA,
             None,
@@ -4954,6 +4959,7 @@ mod tests {
             false,
             false,
             &HashMap::new(),
+            &description_overrides,
         )
         .unwrap()
         .unwrap();
@@ -4975,6 +4981,7 @@ mod tests {
                 false,
                 false,
                 true,
+                &HashMap::new(),
                 &HashMap::new(),
             )
             .unwrap()
@@ -5006,6 +5013,7 @@ mod tests {
             false,
             true,
             &HashMap::new(),
+            &HashMap::new(),
         )
         .unwrap()
         .unwrap();
@@ -5036,6 +5044,7 @@ mod tests {
             false,
             true,
             &HashMap::new(),
+            &HashMap::new(),
         )
         .unwrap()
         .unwrap();
@@ -5065,6 +5074,7 @@ mod tests {
                     false,
                     true,
                     &HashMap::new(),
+                    &HashMap::new(),
                 )
                 .unwrap()
                 .unwrap();
@@ -5083,6 +5093,7 @@ mod tests {
                 false,
                 false,
                 true,
+                &HashMap::new(),
                 &HashMap::new(),
             )
             .unwrap()
@@ -5119,6 +5130,7 @@ mod tests {
                 false,
                 true,
                 &HashMap::new(),
+                &HashMap::new(),
             )
             .unwrap()
             .unwrap();
@@ -5146,7 +5158,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -5155,6 +5166,7 @@ mod tests {
             false,
             false,
             &overrides,
+            &HashMap::new(),
         )
         .unwrap()
         .unwrap();
@@ -5183,7 +5195,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -5192,6 +5203,7 @@ mod tests {
             false,
             false,
             &overrides,
+            &HashMap::new(),
         )
         .unwrap()
         .unwrap();
@@ -5216,7 +5228,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -5225,6 +5236,7 @@ mod tests {
             false,
             false,
             &overrides,
+            &HashMap::new(),
         )
         .unwrap()
         .unwrap();
@@ -5241,7 +5253,6 @@ mod tests {
                 headers: None,
                 variables: None,
                 source_path: None,
-                description: None,
             },
             &SCHEMA,
             None,
@@ -5249,6 +5260,7 @@ mod tests {
             false,
             false,
             false,
+            &HashMap::new(),
             &HashMap::new(),
         )
         .unwrap()

--- a/crates/apollo-mcp-server/src/operations/operation_source.rs
+++ b/crates/apollo-mcp-server/src/operations/operation_source.rs
@@ -13,7 +13,6 @@ use apollo_mcp_registry::{
     uplink::persisted_queries::{ManifestSource, event::Event as ManifestEvent},
 };
 use futures::{Stream, StreamExt as _};
-use regex::Regex;
 use tracing::warn;
 
 use crate::event::Event;
@@ -205,21 +204,6 @@ fn raw_operations_from_manifest(operations: Vec<(String, String)>) -> Vec<RawOpe
         .collect()
 }
 
-#[allow(clippy::expect_used)]
-static OP_NAME_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"(?:query|mutation|subscription)\s+([A-Za-z_]\w*)")
-        .expect("OP_NAME_RE is a valid regex")
-});
-
-/// Extract the operation name from a GraphQL operation body using a lightweight
-/// regex, avoiding a full parse. Returns `None` for anonymous operations.
-pub(crate) fn extract_operation_name(source_text: &str) -> Option<&str> {
-    OP_NAME_RE
-        .captures(source_text)
-        .and_then(|caps| caps.get(1))
-        .map(|m| m.as_str())
-}
-
 impl From<Vec<PathBuf>> for OperationSource {
     fn from(paths: Vec<PathBuf>) -> Self {
         OperationSource::Files(paths)
@@ -274,53 +258,6 @@ mod tests {
         }
 
         let _ = fs::remove_dir_all(&tools_dir);
-    }
-
-    #[test]
-    fn extract_name_from_query() {
-        assert_eq!(
-            extract_operation_name("query GetAlerts($state: String!) { alerts { severity } }"),
-            Some("GetAlerts")
-        );
-    }
-
-    #[test]
-    fn extract_name_from_mutation() {
-        assert_eq!(
-            extract_operation_name(
-                "mutation CreateUser($name: String!) { createUser(name: $name) { id } }"
-            ),
-            Some("CreateUser")
-        );
-    }
-
-    #[test]
-    fn extract_name_from_subscription() {
-        assert_eq!(
-            extract_operation_name("subscription OnMessage { messages { text } }"),
-            Some("OnMessage")
-        );
-    }
-
-    #[test]
-    fn extract_name_with_leading_comment() {
-        assert_eq!(
-            extract_operation_name("# Get alerts\nquery GetAlerts { alerts { severity } }"),
-            Some("GetAlerts")
-        );
-    }
-
-    #[test]
-    fn extract_name_returns_none_for_anonymous() {
-        assert_eq!(extract_operation_name("{ alerts { severity } }"), None);
-    }
-
-    #[test]
-    fn extract_name_returns_none_for_anonymous_query() {
-        assert_eq!(
-            extract_operation_name("query { alerts { severity } }"),
-            None
-        );
     }
 
     #[test]

--- a/crates/apollo-mcp-server/src/operations/raw_operation.rs
+++ b/crates/apollo-mcp-server/src/operations/raw_operation.rs
@@ -32,7 +32,7 @@ impl RawOperation {
         annotation_overrides: &HashMap<String, AnnotationOverrides>,
         description_overrides: &HashMap<String, String>,
     ) -> Result<Option<Operation>, OperationError> {
-        Operation::from_document(
+        Operation::from_raw(
             self,
             schema,
             custom_scalars,

--- a/crates/apollo-mcp-server/src/operations/raw_operation.rs
+++ b/crates/apollo-mcp-server/src/operations/raw_operation.rs
@@ -17,9 +17,6 @@ pub struct RawOperation {
     pub(super) headers: Option<HeaderMap<HeaderValue>>,
     pub(crate) variables: Option<HashMap<String, Value>>,
     pub(super) source_path: Option<String>,
-    /// An explicit tool description provided via config.
-    /// When present, this takes priority over auto-generated descriptions.
-    pub(crate) description: Option<String>,
 }
 
 impl RawOperation {
@@ -33,6 +30,7 @@ impl RawOperation {
         disable_schema_description: bool,
         enable_output_schema: bool,
         annotation_overrides: &HashMap<String, AnnotationOverrides>,
+        description_overrides: &HashMap<String, String>,
     ) -> Result<Option<Operation>, OperationError> {
         Operation::from_document(
             self,
@@ -43,6 +41,7 @@ impl RawOperation {
             disable_schema_description,
             enable_output_schema,
             annotation_overrides,
+            description_overrides,
         )
     }
 }
@@ -54,7 +53,6 @@ impl From<(String, Option<String>)> for RawOperation {
             headers: None,
             variables: None,
             source_path,
-            description: None,
         }
     }
 }
@@ -94,7 +92,6 @@ impl TryFrom<&OperationData> for RawOperation {
             headers,
             variables,
             source_path: None,
-            description: None,
         })
     }
 }
@@ -129,9 +126,6 @@ impl serde::Serialize for RawOperation {
         }
         if let Some(ref path) = self.source_path {
             state.serialize_field("source_path", path)?;
-        }
-        if let Some(ref description) = self.description {
-            state.serialize_field("description", description)?;
         }
 
         state.end()
@@ -185,15 +179,5 @@ mod tests {
             .collect();
 
         assert_eq!(recovered.len(), 2);
-    }
-
-    #[test]
-    fn from_local_file_has_no_description() {
-        let raw_op = RawOperation::from((
-            "query GetUser { user { name } }".to_string(),
-            None::<String>,
-        ));
-
-        assert!(raw_op.description.is_none());
     }
 }

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -46,9 +46,7 @@ use crate::{
         search::{SEARCH_TOOL_NAME, Search},
         validate::{VALIDATE_TOOL_NAME, Validate},
     },
-    operations::{
-        AnnotationOverrides, MutationMode, Operation, RawOperation, apply_description_override,
-    },
+    operations::{AnnotationOverrides, MutationMode, Operation, RawOperation},
 };
 use apollo_mcp_rhai::RhaiEngine;
 
@@ -116,6 +114,7 @@ impl Running {
                         self.disable_schema_description,
                         self.enable_output_schema,
                         &self.annotations,
+                        &self.descriptions,
                     )
                     .unwrap_or_else(|error| {
                         error!("Invalid operation: {}", error);
@@ -160,7 +159,6 @@ impl Running {
             let schema = &*self.schema.read().await;
             operations
                 .into_iter()
-                .map(|operation| apply_description_override(operation, &self.descriptions))
                 .filter_map(|operation| {
                     operation
                         .into_operation(
@@ -171,6 +169,7 @@ impl Running {
                             self.disable_schema_description,
                             self.enable_output_schema,
                             &self.annotations,
+                            &self.descriptions,
                         )
                         .unwrap_or_else(|error| {
                             error!("Invalid operation: {}", error);
@@ -840,6 +839,7 @@ mod tests {
                             false,
                             false,
                             true,
+                            &HashMap::new(),
                             &HashMap::new(),
                         )
                         .unwrap()
@@ -1925,6 +1925,7 @@ mod tests {
                     false,
                     true,
                     &HashMap::new(),
+                    &HashMap::new(),
                 )
                 .unwrap()
                 .expect("operation should be valid");
@@ -1969,6 +1970,7 @@ mod tests {
                     false,
                     false,
                     true,
+                    &HashMap::new(),
                     &HashMap::new(),
                 )
                 .unwrap()
@@ -2265,6 +2267,7 @@ mod tests {
                     false,
                     true,
                     &HashMap::new(),
+                    &HashMap::new(),
                 )
                 .unwrap()
                 .expect("operation should be valid");
@@ -2317,6 +2320,7 @@ mod tests {
                     false,
                     false,
                     true,
+                    &HashMap::new(),
                     &HashMap::new(),
                 )
                 .unwrap()
@@ -2390,6 +2394,7 @@ mod tests {
                     false,
                     true,
                     &HashMap::new(),
+                    &HashMap::new(),
                 )
                 .unwrap()
                 .expect("operation should be valid");
@@ -2403,6 +2408,7 @@ mod tests {
                     false,
                     false,
                     true,
+                    &HashMap::new(),
                     &HashMap::new(),
                 )
                 .unwrap()
@@ -2487,6 +2493,7 @@ mod integration_tests {
                     false,
                     false,
                     true,
+                    &HashMap::new(),
                     &HashMap::new(),
                 )
                 .unwrap()
@@ -2724,6 +2731,7 @@ mod integration_tests {
                     false,
                     false,
                     true,
+                    &HashMap::new(),
                     &HashMap::new(),
                 )
                 .unwrap()

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -12,7 +12,6 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 
 use crate::host_validation::{HostValidationState, validate_host};
-use crate::operations::apply_description_override;
 use crate::server::states::telemetry::otel_context_middleware;
 use crate::{
     cors::CorsConfig,
@@ -42,7 +41,6 @@ impl Starting {
         let operations: Vec<_> = self
             .operations
             .into_iter()
-            .map(|operation| apply_description_override(operation, &self.config.descriptions))
             .filter_map(|operation| {
                 operation
                     .into_operation(
@@ -53,6 +51,7 @@ impl Starting {
                         self.config.disable_schema_description,
                         self.config.enable_output_schema,
                         &self.config.annotations,
+                        &self.config.descriptions,
                     )
                     .unwrap_or_else(|error| {
                         error!("Invalid operation: {}", error);


### PR DESCRIPTION
The `description` field on `RawOperation` was just a temporary step between `apply_description_override`, which looked it up by operation name in the config map, and `Operation::from_document`, which preferred it over the auto-generated description. No data source ever filled it, so it was really just a lookup from the config pretending to be part of the operation's state. This PR removes the field and directly integrates the descriptions map into `from_raw`, which we renamed from `from_document` since it now takes a `RawOperation` instead of a parsed document. This way, the lookup is done against the operation name derived from the AST.