### PR TITLE
feat: expose trace_id to rhai graphql hook

### DIFF
--- a/.changeset/expose_trace_id_in_rhai_on_execute_graphql_operation.md
+++ b/.changeset/expose_trace_id_in_rhai_on_execute_graphql_operation.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Expose `trace_id` to the `on_execute_graphql_operation` Rhai hook
+
+The `on_execute_graphql_operation` Rhai hook now exposes a read-only `ctx.trace_id` property, allowing scripts to access the current OpenTelemetry trace ID for custom structured logging. The value is a 32-character lowercase hex string when an OpenTelemetry trace context is active and an empty string otherwise, matching the format already used for the `trace_id=<hex>` prefix on server log lines. This makes it possible to emit log lines from Rhai with `trace_id` as a discrete field that log aggregators (Splunk, ELK, etc.) can index for correlation with distributed traces.

--- a/crates/apollo-mcp-rhai/src/checkpoints/on_execute_graphql_operation.rs
+++ b/crates/apollo-mcp-rhai/src/checkpoints/on_execute_graphql_operation.rs
@@ -22,6 +22,7 @@ pub struct OnExecuteGraphqlOperationContext {
     pub headers: RhaiHeaderMap,
     pub incoming_request: RhaiHttpParts,
     pub tool_name: String,
+    pub trace_id: String,
 }
 
 impl OnExecuteGraphqlOperationContext {
@@ -57,6 +58,12 @@ impl OnExecuteGraphqlOperationContext {
                 |obj: &mut SharedMut<OnExecuteGraphqlOperationContext>| -> String {
                     obj.with_mut(|ctx| ctx.tool_name.clone())
                 },
+            )
+            .register_get(
+                "trace_id",
+                |obj: &mut SharedMut<OnExecuteGraphqlOperationContext>| -> String {
+                    obj.with_mut(|ctx| ctx.trace_id.clone())
+                },
             );
     }
 }
@@ -67,6 +74,7 @@ pub fn on_execute_graphql_operation(
     headers: &HeaderMap,
     axum_parts: Option<&Parts>,
     tool_name: &str,
+    trace_id: impl FnOnce() -> String,
 ) -> Result<(Url, HeaderMap), McpError> {
     let hook_name = "on_execute_graphql_operation";
     let mut engine_guard = engine.lock();
@@ -84,6 +92,7 @@ pub fn on_execute_graphql_operation(
             None => RhaiHttpParts::default(),
         },
         tool_name: tool_name.to_string(),
+        trace_id: trace_id(),
     };
 
     let shared_context = Arc::new(Mutex::new(context));
@@ -165,7 +174,7 @@ mod tests {
         headers.insert("authorization", "Bearer token123".parse().unwrap());
 
         let (result_url, result_headers) =
-            on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool")
+            on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool", String::new)
                 .expect("Should not error");
 
         assert_eq!(result_url, url);
@@ -186,7 +195,7 @@ mod tests {
         let headers = HeaderMap::new();
 
         let (result_url, _result_headers) =
-            on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool")
+            on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool", String::new)
                 .expect("Should not error");
 
         assert_eq!(result_url, url);
@@ -203,7 +212,7 @@ mod tests {
         let headers = HeaderMap::new();
 
         let (result_url, _) =
-            on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool")
+            on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool", String::new)
                 .expect("Should not error");
 
         assert_eq!(
@@ -225,7 +234,7 @@ mod tests {
         let headers = HeaderMap::new();
 
         let (_, result_headers) =
-            on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool")
+            on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool", String::new)
                 .expect("Should not error");
 
         assert_eq!(result_headers.get("x-custom").unwrap(), "custom-value");
@@ -244,8 +253,9 @@ mod tests {
         let url = Url::parse("https://example.com/graphql").expect("Valid URL");
         let headers = HeaderMap::new();
 
-        let err = on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool")
-            .expect_err("Should return error");
+        let err =
+            on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool", String::new)
+                .expect_err("Should return error");
 
         assert_eq!(err.code, ErrorCode::INVALID_REQUEST);
         assert_eq!(err.message, "unauthorized request");
@@ -263,8 +273,9 @@ mod tests {
         let url = Url::parse("https://example.com/graphql").expect("Valid URL");
         let headers = HeaderMap::new();
 
-        let err = on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool")
-            .expect_err("Should return error");
+        let err =
+            on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool", String::new)
+                .expect_err("Should return error");
 
         assert_eq!(err.message, "Internal error");
     }
@@ -279,8 +290,9 @@ mod tests {
         let url = Url::parse("https://example.com/graphql").expect("Valid URL");
         let headers = HeaderMap::new();
 
-        let err = on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool")
-            .expect_err("Should return error");
+        let err =
+            on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool", String::new)
+                .expect_err("Should return error");
 
         assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
         assert_eq!(err.message, "Internal error");
@@ -296,8 +308,9 @@ mod tests {
         let url = Url::parse("https://example.com/graphql").expect("Valid URL");
         let headers = HeaderMap::new();
 
-        let err = on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool")
-            .expect_err("Should return error");
+        let err =
+            on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool", String::new)
+                .expect_err("Should return error");
 
         assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
     }
@@ -315,7 +328,7 @@ mod tests {
         let headers = HeaderMap::new();
 
         let (_, result_headers) =
-            on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool")
+            on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool", String::new)
                 .expect("Should not error");
 
         assert_eq!(result_headers.get("x-tool-name").unwrap(), "my-tool");
@@ -334,9 +347,15 @@ mod tests {
         let headers = HeaderMap::new();
         let parts = create_parts("POST", "/mcp", HeaderMap::new());
 
-        let (_, result_headers) =
-            on_execute_graphql_operation(&engine, &url, &headers, Some(&parts), "my-tool")
-                .expect("Should not error");
+        let (_, result_headers) = on_execute_graphql_operation(
+            &engine,
+            &url,
+            &headers,
+            Some(&parts),
+            "my-tool",
+            String::new,
+        )
+        .expect("Should not error");
 
         assert_eq!(result_headers.get("x-method").unwrap(), "POST");
     }
@@ -354,9 +373,15 @@ mod tests {
         let headers = HeaderMap::new();
         let parts = create_parts("GET", "/mcp/sse", HeaderMap::new());
 
-        let (_, result_headers) =
-            on_execute_graphql_operation(&engine, &url, &headers, Some(&parts), "my-tool")
-                .expect("Should not error");
+        let (_, result_headers) = on_execute_graphql_operation(
+            &engine,
+            &url,
+            &headers,
+            Some(&parts),
+            "my-tool",
+            String::new,
+        )
+        .expect("Should not error");
 
         assert_eq!(result_headers.get("x-uri").unwrap(), "/mcp/sse");
     }
@@ -376,13 +401,84 @@ mod tests {
         incoming_headers.insert("authorization", "Bearer token123".parse().unwrap());
         let parts = create_parts("POST", "/mcp", incoming_headers);
 
-        let (_, result_headers) =
-            on_execute_graphql_operation(&engine, &url, &headers, Some(&parts), "my-tool")
-                .expect("Should not error");
+        let (_, result_headers) = on_execute_graphql_operation(
+            &engine,
+            &url,
+            &headers,
+            Some(&parts),
+            "my-tool",
+            String::new,
+        )
+        .expect("Should not error");
 
         assert_eq!(
             result_headers.get("x-forwarded").unwrap(),
             "Bearer token123"
         );
+    }
+
+    #[test]
+    fn should_read_trace_id() {
+        let engine = create_engine(
+            r#"fn on_execute_graphql_operation(ctx) {
+                let h = ctx.headers;
+                h["x-trace-id"] = ctx.trace_id;
+                ctx.headers = h;
+            }"#,
+        );
+        let url = Url::parse("https://example.com/graphql").expect("Valid URL");
+        let headers = HeaderMap::new();
+
+        let (_, result_headers) =
+            on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool", || {
+                "4bf92f3577b34da6a3ce929d0e0e4736".to_string()
+            })
+            .expect("Should not error");
+
+        assert_eq!(
+            result_headers.get("x-trace-id").unwrap(),
+            "4bf92f3577b34da6a3ce929d0e0e4736"
+        );
+    }
+
+    #[test]
+    fn should_read_empty_trace_id_when_no_active_span() {
+        let engine = create_engine(
+            r#"fn on_execute_graphql_operation(ctx) {
+                let h = ctx.headers;
+                if ctx.trace_id == "" {
+                    h["x-trace-id"] = "absent";
+                } else {
+                    h["x-trace-id"] = ctx.trace_id;
+                }
+                ctx.headers = h;
+            }"#,
+        );
+        let url = Url::parse("https://example.com/graphql").expect("Valid URL");
+        let headers = HeaderMap::new();
+
+        let (_, result_headers) =
+            on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool", String::new)
+                .expect("Should not error");
+
+        assert_eq!(result_headers.get("x-trace-id").unwrap(), "absent");
+    }
+
+    #[test]
+    fn should_not_allow_writing_trace_id() {
+        let engine = create_engine(
+            r#"fn on_execute_graphql_operation(ctx) {
+                ctx.trace_id = "tampered";
+            }"#,
+        );
+        let url = Url::parse("https://example.com/graphql").expect("Valid URL");
+        let headers = HeaderMap::new();
+
+        let err = on_execute_graphql_operation(&engine, &url, &headers, None, "my-tool", || {
+            "4bf92f3577b34da6a3ce929d0e0e4736".to_string()
+        })
+        .expect_err("Should return error because trace_id has no setter");
+
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
     }
 }

--- a/crates/apollo-mcp-server/src/apps/tool.rs
+++ b/crates/apollo-mcp-server/src/apps/tool.rs
@@ -15,6 +15,7 @@ use crate::apps::app::{AppTarget, AppTool};
 use crate::errors::McpError;
 use crate::graphql::{self, Executable};
 use crate::operations::Operation;
+use crate::server::states::telemetry::current_trace_id;
 use apollo_mcp_rhai::{RhaiEngine, checkpoints};
 
 use super::App;
@@ -66,6 +67,7 @@ async fn execute_app_tool(
         headers,
         axum_parts,
         &tool.tool.name,
+        current_trace_id,
     )?;
 
     let graphql_request = graphql::Request {

--- a/crates/apollo-mcp-server/src/operations/execution.rs
+++ b/crates/apollo-mcp-server/src/operations/execution.rs
@@ -11,6 +11,7 @@ use url::Url;
 
 use crate::errors::McpError;
 use crate::graphql::{self, Executable};
+use crate::server::states::telemetry::current_trace_id;
 use apollo_mcp_rhai::{RhaiEngine, checkpoints};
 
 use super::Operation;
@@ -54,6 +55,7 @@ pub(crate) async fn execute_operation(
         headers,
         axum_parts,
         tool_name,
+        current_trace_id,
     )?;
 
     let graphql_request = graphql::Request {

--- a/crates/apollo-mcp-server/src/server.rs
+++ b/crates/apollo-mcp-server/src/server.rs
@@ -21,7 +21,7 @@ use crate::host_validation::HostValidationConfig;
 use crate::operations::{AnnotationOverrides, MutationMode, OperationSource};
 use crate::server_info::ServerInfoConfig;
 
-mod states;
+pub(crate) mod states;
 
 use states::StateMachine;
 

--- a/crates/apollo-mcp-server/src/server/states.rs
+++ b/crates/apollo-mcp-server/src/server/states.rs
@@ -27,7 +27,7 @@ mod operations_configured;
 mod running;
 mod schema_configured;
 mod starting;
-mod telemetry;
+pub(crate) mod telemetry;
 
 use configuring::Configuring;
 use operations_configured::OperationsConfigured;

--- a/crates/apollo-mcp-server/src/server/states/telemetry.rs
+++ b/crates/apollo-mcp-server/src/server/states/telemetry.rs
@@ -3,6 +3,7 @@ use axum::middleware::Next;
 use axum::response::Response;
 use opentelemetry::global;
 use opentelemetry::propagation::Extractor;
+use opentelemetry::trace::{TraceContextExt, TraceId};
 use rmcp::RoleServer;
 use rmcp::service::RequestContext;
 use tracing::Instrument;
@@ -66,14 +67,37 @@ pub fn get_parent_span(context: &RequestContext<RoleServer>) -> tracing::Span {
         .unwrap_or_else(tracing::Span::none)
 }
 
+/// Returns the current OpenTelemetry trace ID as a lowercase 32-character
+/// hex string, or an empty string when no trace context is active.
+///
+/// The format matches the `trace_id=<hex>` prefix emitted by the logging
+/// layer, so callers (including Rhai scripts) can correlate the values they
+/// emit with the rest of the server's output.
+pub fn current_trace_id() -> String {
+    let trace_id = tracing::Span::current()
+        .context()
+        .span()
+        .span_context()
+        .trace_id();
+    if trace_id == TraceId::INVALID {
+        String::new()
+    } else {
+        trace_id.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use axum::{Router, body::Body, http::Request, routing::get};
     use http::HeaderName;
     use opentelemetry::Context as OtelContext;
-    use opentelemetry::trace::TraceContextExt;
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_sdk::trace::SdkTracerProvider;
     use tower::ServiceExt;
+    use tracing_opentelemetry::OpenTelemetryLayer;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::registry;
 
     #[tokio::test()]
     async fn middleware_stores_span_context_and_handler_works() {
@@ -143,6 +167,30 @@ mod tests {
         assert_eq!(extractor.get("traceparent"), Some("test-value"));
         assert_eq!(extractor.get("x-custom"), Some("custom-value"));
         assert_eq!(extractor.get("missing"), None);
+    }
+
+    #[test]
+    fn current_trace_id_is_empty_when_no_active_span() {
+        assert_eq!(current_trace_id(), "");
+    }
+
+    #[test]
+    fn current_trace_id_returns_hex_when_span_has_otel_data() {
+        let provider = SdkTracerProvider::builder().build();
+        let tracer = provider.tracer("test");
+        let subscriber = registry().with(OpenTelemetryLayer::new(tracer));
+
+        let captured = tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("test_span");
+            let _guard = span.enter();
+            current_trace_id()
+        });
+
+        let re = regex::Regex::new(r"^[0-9a-f]{32}$").expect("valid regex");
+        assert!(
+            re.is_match(&captured),
+            "expected 32-hex trace_id, got: {captured}"
+        );
     }
 
     #[test]

--- a/docs/source/rhai-lifecycle.mdx
+++ b/docs/source/rhai-lifecycle.mdx
@@ -21,12 +21,13 @@ fn on_execute_graphql_operation(ctx) {
 
 The `ctx` parameter provides these properties:
 
-| Property           | Type        | Access     | Description                                                                                     |
-| ------------------ | ----------- | ---------- | ----------------------------------------------------------------------------------------------- |
-| `endpoint`         | `String`    | read/write | The URL of the GraphQL endpoint for the request.                                                |
-| `headers`          | `HeaderMap` | read/write | The HTTP headers for the request.                                                               |
-| `incoming_request` | `HttpParts` | read-only  | The original HTTP request received by the MCP server. Only available when using HTTP transport. |
-| `tool_name`        | `String`    | read-only  | The name of the MCP tool that triggered this GraphQL operation.                                 |
+| Property           | Type        | Access     | Description                                                                                                                              |
+| ------------------ | ----------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `endpoint`         | `String`    | read/write | The URL of the GraphQL endpoint for the request.                                                                                         |
+| `headers`          | `HeaderMap` | read/write | The HTTP headers for the request.                                                                                                        |
+| `incoming_request` | `HttpParts` | read-only  | The original HTTP request received by the MCP server. Only available when using HTTP transport.                                          |
+| `tool_name`        | `String`    | read-only  | The name of the MCP tool that triggered this GraphQL operation.                                                                          |
+| `trace_id`         | `String`    | read-only  | The current OpenTelemetry trace ID as a 32-character hex string, or an empty string when no trace context is active. |
 
 ### Working with headers
 
@@ -85,6 +86,18 @@ fn on_execute_graphql_operation(ctx) {
     }
 }
 ```
+
+### Example: Emit structured logs with the current trace ID
+
+Use `ctx.trace_id` to include the current OpenTelemetry trace ID as a discrete field in your structured log lines so log aggregation platforms can correlate logs with distributed traces:
+
+```rhai
+fn on_execute_graphql_operation(ctx) {
+    print(`[MCP Request] trace_id=${ctx.trace_id} tool=${ctx.tool_name}`);
+}
+```
+
+`ctx.trace_id` is a 32-character lowercase hex string when an OpenTelemetry trace context is active, and an empty string otherwise (for example, when the MCP client did not propagate a `traceparent` header and tracing is not configured server-side). The same trace ID is also prefixed onto server log lines, so values emitted from Rhai can be correlated with the rest of the server's output.
 
 ## Error handling with throw
 


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-489 -->

Closes #737

The `on_execute_graphql_operation` Rhai hook now has a read-only `ctx.trace_id` property. This lets scripts access the current OpenTelemetry trace ID for custom structured logging. When an OpenTelemetry trace context is active, the value is a 32-character lowercase hex string. If it's not active, the value will be an empty string. This matches the format used for the `trace_id=<hex>` prefix in server log lines. Now, you can emit log lines from Rhai with `trace_id` as a separate field that log aggregators like Splunk and ELK can index for correlation with distributed traces.