### PR TITLE
fix(registry): coalesce file watch notifications instead of blocking watcher thread

### DIFF
--- a/.changeset/fix_file_watcher_deadlock.md
+++ b/.changeset/fix_file_watcher_deadlock.md
@@ -1,0 +1,17 @@
+---
+default: patch
+---
+
+# Fix file-watcher self-sustaining log loop and watcher-thread starvation
+
+The file-change notifier in `apollo-mcp-registry` retried `mpsc::Sender::try_send`
+in a busy loop with `std::thread::sleep(50ms)` whenever the receiver had not yet
+drained the previous event. Because the retry runs on the `notify::PollWatcher`
+callback thread, a slow consumer can cause the callback to absorb itself in the
+sleep/log loop and emit a continuous ~20 Hz stream of `could not process file
+watch notification. no available capacity` warnings (issue #743).
+
+The channel has capacity 1 and the consumer only needs to know "something
+changed" — duplicate notifications are redundant. Replace the retry loop with a
+non-blocking `try_send` that drops a queued duplicate at trace level, and log
+the unrecoverable `Closed` case rather than panicking from the watcher thread.

--- a/crates/apollo-mcp-registry/src/files.rs
+++ b/crates/apollo-mcp-registry/src/files.rs
@@ -79,20 +79,21 @@ fn watch_inner(
                             watched_path
                         );
                     } else {
-                        loop {
-                            match watch_sender.try_send(()) {
-                                Ok(_) => break,
-                                Err(err) => {
-                                    tracing::warn!(
-                                        "could not process file watch notification. {}",
-                                        err.to_string()
-                                    );
-                                    if matches!(err, TrySendError::Full(_)) {
-                                        std::thread::sleep(Duration::from_millis(50));
-                                    } else {
-                                        panic!("event channel failed: {err}");
-                                    }
-                                }
+                        // Coalesce notifications: the channel has capacity 1 and the
+                        // consumer only needs to know "something changed", not how many
+                        // times. If the channel is full a notification is already queued,
+                        // so a duplicate is safe to drop. Looping with `std::thread::sleep`
+                        // here from inside the notify watcher thread could absorb the
+                        // thread under burst (issue #743).
+                        match watch_sender.try_send(()) {
+                            Ok(_) => {}
+                            Err(TrySendError::Full(_)) => {
+                                tracing::trace!(
+                                    "file watch notification coalesced (consumer falling behind)"
+                                );
+                            }
+                            Err(err @ TrySendError::Closed(_)) => {
+                                tracing::error!("file watch channel closed: {err}");
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

Fix the file-watcher self-sustaining log loop and watcher-thread starvation reported in #743.

`apollo-mcp-registry::files::watch_inner` retried `mpsc::Sender::try_send` in a busy loop with `std::thread::sleep(50ms)` when the consumer had not yet drained the previous event. Because the retry executes on the `notify::PollWatcher` callback thread, a slow consumer can pin that thread in the sleep/log loop and produce a continuous ~20 Hz stream of `could not process file watch notification. no available capacity` warnings indefinitely.

We've observed this in production: a single pod accumulated **~14k WARN/24h** of this message, sustained until manual restart, with the watcher effectively blocked from processing further events.

## Fix

The channel has capacity 1 and the consumer only needs to know *something changed*, not how many times — duplicate notifications are redundant. Replace the retry loop with a non-blocking `try_send` that:

- Drops queued duplicates at trace level (Full)
- Logs the unrecoverable case at error level instead of panicking from the watcher thread (Closed)

```rust
match watch_sender.try_send(()) {
    Ok(_) => {}
    Err(TrySendError::Full(_)) => {
        tracing::trace!("file watch notification coalesced (consumer falling behind)");
    }
    Err(err @ TrySendError::Closed(_)) => {
        tracing::error!("file watch channel closed: {err}");
    }
}
```

Net diff: +14/-13 lines (mostly comment).

## Test plan

- [x] `cargo test -p apollo-mcp-registry --lib files` — `basic_watch` and `recursive_watch_detects_subdir_changes` pass
- [x] `cargo clippy -p apollo-mcp-registry --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check -p apollo-mcp-registry` — clean
- [ ] (No new test added: the bug is timing-sensitive and a deterministic regression test would be flaky. Existing tests cover the happy path. Behavior on `Full` is now explicitly defined: drop. Open to writing one if maintainers prefer.)

Closes #743