### PR TITLE
feat: capture tool and graphql in OTel spans

### DIFF
--- a/.changeset/capture_tool_arguments_and_results_in_otel_spans.md
+++ b/.changeset/capture_tool_arguments_and_results_in_otel_spans.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Capture tool call arguments and results in OpenTelemetry spans
+
+Tool execution spans now include `apollo.mcp.tool_arguments` and `apollo.mcp.tool_result` attributes on the `call_tool` span, and `apollo.mcp.graphql_query` and `apollo.mcp.graphql_response` on the nested GraphQL `execute` span. This makes it possible to correlate traces in observability dashboards with the actual queries and data that triggered them. Arguments and results are serialized as JSON strings. Users who need to scrub sensitive data from spans should use the [OTel Collector `redaction` processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/redactionprocessor) in their pipeline.

--- a/.changeset/capture_tool_arguments_and_results_in_otel_spans.md
+++ b/.changeset/capture_tool_arguments_and_results_in_otel_spans.md
@@ -4,4 +4,4 @@ default: minor
 
 # Capture tool call arguments and results in OpenTelemetry spans
 
-Tool execution spans now include `apollo.mcp.tool_arguments` and `apollo.mcp.tool_result` attributes on the `call_tool` span, and `apollo.mcp.graphql_query` and `apollo.mcp.graphql_response` on the nested GraphQL `execute` span. This makes it possible to correlate traces in observability dashboards with the actual queries and data that triggered them. Arguments and results are serialized as JSON strings. Users who need to scrub sensitive data from spans should use the [OTel Collector `redaction` processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/redactionprocessor) in their pipeline.
+Tool execution spans now include `apollo.mcp.tool_arguments` and `apollo.mcp.tool_result` attributes on the `call_tool` span, and `apollo.mcp.graphql_query` and `apollo.mcp.graphql_response` on the child `execute` span. This makes it possible to correlate traces in observability dashboards with the actual queries and data that triggered them.

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -55,7 +55,7 @@ pub trait Executable {
     fn headers(&self, default_headers: &HeaderMap<HeaderValue>) -> HeaderMap<HeaderValue>;
 
     /// Execute as a GraphQL operation using the endpoint and headers
-    #[tracing::instrument(skip(self, request))]
+    #[tracing::instrument(skip(self, request), fields(apollo.mcp.graphql_query = tracing::field::Empty, apollo.mcp.graphql_response = tracing::field::Empty))]
     async fn execute(&self, request: Request<'_>) -> Result<CallToolResult, McpError> {
         let meter = &meter::METER;
         let start = std::time::Instant::now();
@@ -84,6 +84,7 @@ pub trait Executable {
             }
         };
 
+        tracing::Span::current().record("apollo.mcp.graphql_query", query.as_str());
         request_body.insert(String::from("query"), Value::String(query));
         request_body.insert(
             String::from("extensions"),
@@ -114,6 +115,10 @@ pub trait Executable {
 
         let result = match response.json::<Value>().await {
             Ok(json) => {
+                if let Ok(s) = serde_json::to_string(&json) {
+                    tracing::Span::current().record("apollo.mcp.graphql_response", s.as_str());
+                }
+
                 let is_error = Some(
                     json.get("errors")
                         .filter(|value| !matches!(value, Value::Null))

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -179,6 +179,7 @@ pub trait Executable {
 mod test {
     use crate::generated::telemetry::TelemetryMetric;
     use crate::graphql::{Executable, OperationDetails, Request, ValidationError};
+    use crate::operations::private_fields::process_private_directives;
     use http::{HeaderMap, HeaderValue};
     use opentelemetry::global;
     use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
@@ -187,7 +188,42 @@ mod test {
     };
     use rmcp::model::RawContent;
     use serde_json::{Map, Value, json};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+    use tracing::Subscriber;
+    use tracing::field::{Field, Visit};
+    use tracing::span::{Id, Record};
+    use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
+    use tracing_subscriber::registry::LookupSpan;
     use url::Url;
+
+    type CapturedFields = Arc<Mutex<HashMap<String, String>>>;
+
+    struct CaptureVisitor<'a>(&'a Mutex<HashMap<String, String>>);
+    impl Visit for CaptureVisitor<'_> {
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.0
+                .lock()
+                .unwrap()
+                .insert(field.name().to_string(), value.to_string());
+        }
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            self.0
+                .lock()
+                .unwrap()
+                .insert(field.name().to_string(), format!("{value:?}"));
+        }
+    }
+
+    struct CaptureLayer(CapturedFields);
+    impl<S> Layer<S> for CaptureLayer
+    where
+        S: Subscriber + for<'a> LookupSpan<'a>,
+    {
+        fn on_record(&self, _id: &Id, values: &Record<'_>, _ctx: Context<'_, S>) {
+            values.record(&mut CaptureVisitor(&self.0));
+        }
+    }
 
     struct TestExecutable;
 
@@ -379,6 +415,63 @@ mod test {
 
         // then
         assert!(result.is_error == Some(true));
+    }
+
+    #[tokio::test]
+    async fn span_does_not_record_private_fields_in_graphql_response() {
+        use crate::operations::private_fields::PrivateFieldTree;
+
+        struct PrivateExecutable(PrivateFieldTree);
+        impl Executable for PrivateExecutable {
+            fn operation(&self, _input: Value) -> Result<OperationDetails, ValidationError> {
+                Ok(OperationDetails {
+                    query: "query Q { secret }".to_string(),
+                    operation_name: Some("Q".to_string()),
+                    private_fields: Some(self.0.clone()),
+                })
+            }
+            fn variables(&self, _input: Value) -> Result<Value, ValidationError> {
+                Ok(json!({}))
+            }
+            fn headers(&self, _: &HeaderMap<HeaderValue>) -> HeaderMap<HeaderValue> {
+                HeaderMap::new()
+            }
+        }
+
+        let (_stripped, tree) = process_private_directives("query Q { secret @private }")
+            .expect("query should have @private fields");
+
+        let mut server = mockito::Server::new_async().await;
+        let url = Url::parse(server.url().as_str()).unwrap();
+        server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({ "data": { "secret": "supersecret-pii" } }).to_string())
+            .create_async()
+            .await;
+
+        let captured: CapturedFields = Arc::new(Mutex::new(HashMap::new()));
+        let subscriber = tracing_subscriber::registry().with(CaptureLayer(captured.clone()));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        PrivateExecutable(tree)
+            .execute(Request {
+                input: json!({}),
+                endpoint: &url,
+                headers: &HeaderMap::new(),
+            })
+            .await
+            .unwrap();
+
+        let fields = captured.lock().unwrap();
+        let response = fields
+            .get("apollo.mcp.graphql_response")
+            .expect("apollo.mcp.graphql_response should be recorded");
+        assert!(
+            !response.contains("supersecret-pii"),
+            "span leaked @private value: {response}"
+        );
     }
 
     #[tokio::test]

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -115,10 +115,6 @@ pub trait Executable {
 
         let result = match response.json::<Value>().await {
             Ok(json) => {
-                if let Ok(s) = serde_json::to_string(&json) {
-                    tracing::Span::current().record("apollo.mcp.graphql_response", s.as_str());
-                }
-
                 let is_error = Some(
                     json.get("errors")
                         .filter(|value| !matches!(value, Value::Null))
@@ -136,6 +132,11 @@ pub trait Executable {
                 } else {
                     (json, None)
                 };
+
+                // Record the filtered view so @private fields never appear in spans.
+                if let Ok(s) = serde_json::to_string(&structured_content) {
+                    tracing::Span::current().record("apollo.mcp.graphql_response", s.as_str());
+                }
 
                 let result = if is_error == Some(true) {
                     CallToolResult::structured_error(structured_content)

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -662,10 +662,14 @@ impl ServerHandler for Running {
             .call_tool_impl(request, &context.extensions, protocol_version)
             .await;
 
-        if let Ok(r) = &result
-            && let Ok(json) = serde_json::to_string(r)
-        {
-            span.record("apollo.mcp.tool_result", json.as_str());
+        // Strip meta before serializing: _meta.structuredContent holds the unfiltered
+        // @private payload and must not be exported to the span.
+        if let Ok(r) = &result {
+            let mut stripped = r.clone();
+            stripped.meta = None;
+            if let Ok(json) = serde_json::to_string(&stripped) {
+                span.record("apollo.mcp.tool_result", json.as_str());
+            }
         }
 
         result

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -642,17 +642,33 @@ impl ServerHandler for Running {
         Ok(self.get_info())
     }
 
-    #[tracing::instrument(skip_all, parent = get_parent_span(&context), fields(apollo.mcp.tool_name = request.name.as_ref(), apollo.mcp.request_id = %context.id.clone()))]
+    #[tracing::instrument(skip_all, parent = get_parent_span(&context), fields(apollo.mcp.tool_name = request.name.as_ref(), apollo.mcp.request_id = %context.id.clone(), apollo.mcp.tool_arguments = tracing::field::Empty, apollo.mcp.tool_result = tracing::field::Empty))]
     async fn call_tool(
         &self,
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
+        let span = tracing::Span::current();
+        if let Some(args) = &request.arguments
+            && let Ok(json) = serde_json::to_string(args)
+        {
+            span.record("apollo.mcp.tool_arguments", json.as_str());
+        }
+
         let peer_info = context.peer.peer_info();
         let protocol_version = peer_info.map(|info| &info.protocol_version);
 
-        self.call_tool_impl(request, &context.extensions, protocol_version)
-            .await
+        let result = self
+            .call_tool_impl(request, &context.extensions, protocol_version)
+            .await;
+
+        if let Ok(r) = &result
+            && let Ok(json) = serde_json::to_string(r)
+        {
+            span.record("apollo.mcp.tool_result", json.as_str());
+        }
+
+        result
     }
 
     #[tracing::instrument(skip_all, parent = get_parent_span(&context))]

--- a/crates/apollo-mcp-server/src/telemetry_attributes.rs
+++ b/crates/apollo-mcp-server/src/telemetry_attributes.rs
@@ -29,6 +29,18 @@ impl TelemetryAttribute {
             TelemetryAttribute::ClientVersion => {
                 Key::from_static_str(TelemetryAttribute::ClientVersion.as_str())
             }
+            TelemetryAttribute::ToolArguments => {
+                Key::from_static_str(TelemetryAttribute::ToolArguments.as_str())
+            }
+            TelemetryAttribute::ToolResult => {
+                Key::from_static_str(TelemetryAttribute::ToolResult.as_str())
+            }
+            TelemetryAttribute::GraphqlQuery => {
+                Key::from_static_str(TelemetryAttribute::GraphqlQuery.as_str())
+            }
+            TelemetryAttribute::GraphqlResponse => {
+                Key::from_static_str(TelemetryAttribute::GraphqlResponse.as_str())
+            }
         }
     }
 

--- a/crates/apollo-mcp-server/telemetry.toml
+++ b/crates/apollo-mcp-server/telemetry.toml
@@ -7,6 +7,10 @@ success = "Sucess flag indicator"
 raw_operation = "Graphql operation text and metadata used for Tool generation"
 client_name = "The client name that initializes with the MCP Server"
 client_version = "The client version that initializes with the MCP Server"
+tool_arguments = "Tool call input arguments as a JSON string"
+tool_result = "Tool call output result as a JSON string"
+graphql_query = "GraphQL query string sent to the endpoint"
+graphql_response = "GraphQL response JSON received from the endpoint"
 
 [metrics.apollo.mcp]
 "initialize.count" = "Number of times initialize has been called"

--- a/docs/source/telemetry.mdx
+++ b/docs/source/telemetry.mdx
@@ -7,7 +7,7 @@ AI agents create unpredictable usage patterns and complex request flows that are
 ## What you can monitor
 
 - **Agent behavior**: Which tools and operations are used most frequently
-- **Performance**: Response times and bottlenecks across tool executions and GraphQL operations  
+- **Performance**: Response times and bottlenecks across tool executions and GraphQL operations
 - **Reliability**: Error rates, failed operations, and request success patterns
 - **Distributed request flows**: Complete traces from agent request through your Apollo Router and subgraphs, with automatic trace context propagation
 
@@ -22,8 +22,12 @@ The server exports metrics, traces, and events using the OpenTelemetry Protocol 
 The fastest way to see Apollo MCP Server telemetry in action is with a local setup that requires only Docker.
 
 #### 5-minute setup
-1. Start local observability stack: 
-<code>docker run -p 3000:3000 -p 4317:4317 -p 4318:4318 --rm -ti grafana/otel-lgtm</code>
+
+1. Start local observability stack:
+   <code>
+     docker run -p 3000:3000 -p 4317:4317 -p 4318:4318 --rm -ti
+     grafana/otel-lgtm
+   </code>
 1. Add telemetry config to your `config.yaml`:
    ```yaml
    telemetry:
@@ -34,7 +38,7 @@ The fastest way to see Apollo MCP Server telemetry in action is with a local set
            protocol: "http/protobuf"
        tracing:
          otlp:
-           endpoint: "http://localhost:4318/v1/traces" 
+           endpoint: "http://localhost:4318/v1/traces"
            protocol: "http/protobuf"
    ```
 1. Restart your MCP server with the updated config
@@ -48,15 +52,15 @@ For production environments, configure your MCP server to send telemetry to any 
 
 ```yaml
 telemetry:
-  service_name: "mcp-server-prod"      # Custom service name
+  service_name: "mcp-server-prod" # Custom service name
   exporters:
     metrics:
       otlp:
         endpoint: "https://your-metrics-endpoint"
-        protocol: "http/protobuf"       # or "grpc"
+        protocol: "http/protobuf" # or "grpc"
     tracing:
       otlp:
-        endpoint: "https://your-traces-endpoint" 
+        endpoint: "https://your-traces-endpoint"
         protocol: "http/protobuf"
 ```
 
@@ -86,6 +90,7 @@ Import these templates into your observability platform to get started quickly w
 #### Production configuration best practices
 
 ##### Environment and security
+
 ```yaml
 # Set via environment variable
 export ENVIRONMENT=production
@@ -101,12 +106,14 @@ telemetry:
 ```
 
 ##### Performance considerations
+
 - **Protocol choice**: `http/protobuf` is often more reliable through firewalls and load balancers than `grpc`
 - **Export interval**: Metrics are exported every 30 seconds by default. Adjust this interval time using the [`export_interval` config](/apollo-mcp-server/config-file#metrics) to balance freshness and network overhead.
 - **Batch export**: OpenTelemetry automatically batches telemetry data for efficiency
 - **Network timeouts**: Default timeouts are usually appropriate, but monitor for network issues
 
 ##### Resource correlation
+
 - The `ENVIRONMENT` variable automatically tags all telemetry with `deployment.environment.name`
 - Use consistent `service_name` across all your Apollo infrastructure (Router, subgraphs, MCP server)
 - Set `version` to track releases and correlate issues with deployments
@@ -114,12 +121,14 @@ telemetry:
 #### Troubleshooting
 
 ##### Common issues
+
 - **Connection refused**: Verify endpoint URL and network connectivity
 - **Authentication errors**: Check if your provider requires API keys or special headers
 - **Missing data**: Confirm your observability platform supports OTLP and is configured to receive data
 - **High memory usage**: Monitor telemetry export frequency and consider sampling for high-volume environments
 
 ##### Verification
+
 ```bash
 # Check if telemetry is being exported (look for connection attempts)
 curl -v https://your-endpoint/v1/metrics
@@ -136,27 +145,44 @@ The OpenTelemetry integration is configured via the `telemetry` section of the [
 
 The server emits the following metrics, which are invaluable for monitoring and alerting. All duration metrics are in milliseconds.
 
-| Metric Name | Type | Description | Attributes |
-|---|---|---|---|
-| `apollo.mcp.initialize.count` | Counter | Incremented for each `initialize` request. | `client_name`, `client_version` |
-| `apollo.mcp.list_tools.count` | Counter | Incremented for each `list_tools` request. | (none) |
-| `apollo.mcp.get_info.count` | Counter | Incremented for each `get_info` request. | (none) |
-| `apollo.mcp.tool.count` | Counter | Incremented for each tool call. | `tool_name`, `success` (bool) |
-| `apollo.mcp.tool.duration` | Histogram | Measures the execution duration of each tool call. | `tool_name`, `success` (bool) |
-| `apollo.mcp.operation.count`| Counter | Incremented for each downstream GraphQL operation executed by a tool. | `operation.id`, `operation.type`, `success` (bool) |
-| `apollo.mcp.operation.duration`| Histogram | Measures the round-trip duration of each downstream GraphQL operation. | `operation.id`, `operation.type`, `success` (bool) |
+| Metric Name                     | Type      | Description                                                            | Attributes                                         |
+| ------------------------------- | --------- | ---------------------------------------------------------------------- | -------------------------------------------------- |
+| `apollo.mcp.initialize.count`   | Counter   | Incremented for each `initialize` request.                             | `client_name`, `client_version`                    |
+| `apollo.mcp.list_tools.count`   | Counter   | Incremented for each `list_tools` request.                             | (none)                                             |
+| `apollo.mcp.get_info.count`     | Counter   | Incremented for each `get_info` request.                               | (none)                                             |
+| `apollo.mcp.tool.count`         | Counter   | Incremented for each tool call.                                        | `tool_name`, `success` (bool)                      |
+| `apollo.mcp.tool.duration`      | Histogram | Measures the execution duration of each tool call.                     | `tool_name`, `success` (bool)                      |
+| `apollo.mcp.operation.count`    | Counter   | Incremented for each downstream GraphQL operation executed by a tool.  | `operation.id`, `operation.type`, `success` (bool) |
+| `apollo.mcp.operation.duration` | Histogram | Measures the round-trip duration of each downstream GraphQL operation. | `operation.id`, `operation.type`, `success` (bool) |
 
 In addition to these metrics, the server also emits standard [HTTP server metrics](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/) (e.g., `http.server.duration`, `http.server.active_requests`) courtesy of the `axum-otel-metrics` library.
-
 
 ## Emitted Traces
 
 Spans are generated for the following actions:
 
--   **Incoming HTTP Requests**: A root span is created for every HTTP request to the MCP server.
--   **MCP Handler Methods**: Nested spans are created for each of the main MCP protocol methods (`initialize`, `call_tool`, `list_tools`).
--   **Tool Execution**: `call_tool` spans contain nested spans for the specific tool being executed (e.g., `introspect`, `search`, or a custom GraphQL operation).
--   **Downstream GraphQL Calls**: The `execute` tool and custom operation tools create child spans for their outgoing `reqwest` HTTP calls, capturing the duration of the downstream request. The `traceparent` and `tracestate` headers are propagated automatically, enabling distributed traces.
+- **Incoming HTTP Requests**: A root span is created for every HTTP request to the MCP server.
+- **MCP Handler Methods**: Nested spans are created for each of the main MCP protocol methods (`initialize`, `call_tool`, `list_tools`).
+- **Tool Execution**: `call_tool` spans contain nested spans for the specific tool being executed (e.g., `introspect`, `search`, or a custom GraphQL operation).
+- **Downstream GraphQL Calls**: The `execute` tool and custom operation tools create child spans for their outgoing `reqwest` HTTP calls, capturing the duration of the downstream request. The `traceparent` and `tracestate` headers are propagated automatically, enabling distributed traces.
+
+### Span Attributes
+
+The `call_tool` span includes the following attributes:
+
+| Attribute                   | Description                                     |
+| --------------------------- | ----------------------------------------------- |
+| `apollo.mcp.tool_name`      | The name of the tool that was called.           |
+| `apollo.mcp.request_id`     | The MCP request ID.                             |
+| `apollo.mcp.tool_arguments` | The tool call input arguments as a JSON string. |
+| `apollo.mcp.tool_result`    | The tool call output result as a JSON string.   |
+
+For tools that execute a downstream GraphQL operation, the child `execute` span includes:
+
+| Attribute                     | Description                                                                                                                                                                      |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apollo.mcp.graphql_query`    | The GraphQL query string sent to the endpoint.                                                                                                                                   |
+| `apollo.mcp.graphql_response` | The GraphQL response JSON received from the endpoint. |
 
 ### Cardinality Control
 


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-477 -->

Closes #725

Tool execution spans now include `apollo.mcp.tool_arguments` and `apollo.mcp.tool_result` attributes on the `call_tool` span, and `apollo.mcp.graphql_query` and `apollo.mcp.graphql_response` on the child `execute` span. This makes it possible to correlate traces in observability dashboards with the actual queries and data that triggered them.