### PR TITLE
fix: preserve raw auth server URLs in metadata

### DIFF
--- a/.changeset/preserve_raw_auth_server_urls_in_metadata.md
+++ b/.changeset/preserve_raw_auth_server_urls_in_metadata.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Preserve raw authorization server URLs in protected-resource metadata
+
+Apollo MCP Server no longer normalizes the `transport.auth.servers` entries when it sets the `authorization_servers` field in `/.well-known/oauth-protected-resource`. Before, a scheme-authority-only configuration value, like `https://auth.example.com`, was re-parsed through `url::Url`, which added a trailing `/` to the empty path. This normalized form ended up in the metadata and caused mismatches in issuer claims for strict OAuth clients that compare `authorization_servers` with the auth server's discovery `issuer`. Now, server URLs are passed through exactly as they are, so users need to make sure each entry matches their auth server's `issuer` precisely.

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -139,6 +139,7 @@ pub struct Config {
     /// Not `Vec<Url>`: `Url::parse` appends `/` to bare-authority inputs,
     /// breaking issuer string-matching in clients.
     #[serde(deserialize_with = "deserialize_auth_servers")]
+    #[schemars(with = "Vec<Url>")]
     pub servers: Vec<String>,
 
     /// List of accepted audiences for the OAuth tokens

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -118,12 +118,28 @@ where
     Ok(headers)
 }
 
+fn deserialize_auth_servers<'de, D>(d: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+    let servers: Vec<String> = Vec::deserialize(d)?;
+    for s in &servers {
+        Url::parse(s)
+            .map_err(|e| D::Error::custom(format!("invalid auth server URL {s:?}: {e}")))?;
+    }
+    Ok(servers)
+}
+
 /// Auth configuration options
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
-    /// List of upstream OAuth servers to delegate auth
-    pub servers: Vec<Url>,
+    /// List of upstream OAuth servers to delegate auth.
+    /// Not `Vec<Url>`: `Url::parse` appends `/` to bare-authority inputs,
+    /// breaking issuer string-matching in clients.
+    #[serde(deserialize_with = "deserialize_auth_servers")]
+    pub servers: Vec<String>,
 
     /// List of accepted audiences for the OAuth tokens
     #[serde(default)]
@@ -253,11 +269,13 @@ impl Config {
         required_scopes: HashMap<String, Vec<String>>,
     ) -> Result<Router, TlsConfigError> {
         // Validate server URLs have hosts (fail fast on config errors)
+        #[allow(clippy::expect_used)] // parseability validated at deserialize
         for (i, server) in self.servers.iter().enumerate() {
-            if server.host_str().is_none() {
+            let parsed = Url::parse(server).expect("validated by deserialize_auth_servers");
+            if parsed.host_str().is_none() {
                 return Err(TlsConfigError::ServerUrlMissingHost {
                     index: i,
-                    url: server.to_string(),
+                    url: server.clone(),
                 });
             }
         }
@@ -457,10 +475,16 @@ async fn oauth_validate(
         .discovery_timeout
         .unwrap_or(Duration::from_secs(5));
 
+    #[allow(clippy::expect_used)] // parseability validated at deserialize
+    let auth_servers: Vec<Url> = auth_config
+        .servers
+        .iter()
+        .map(|s| Url::parse(s).expect("validated by deserialize_auth_servers"))
+        .collect();
     let validator = NetworkedTokenValidator::new(
         &auth_config.audiences,
         auth_config.allow_any_audience,
-        &auth_config.servers,
+        &auth_servers,
         &auth_state.client,
         discovery_timeout,
     );
@@ -553,7 +577,7 @@ mod tests {
 
     fn test_config() -> Config {
         Config {
-            servers: vec![Url::parse("http://localhost:1234").unwrap()],
+            servers: vec!["http://localhost:1234".to_string()],
             audiences: vec!["test-audience".to_string()],
             allow_any_audience: false,
             resource: Url::parse("http://localhost:4000").unwrap(),
@@ -773,7 +797,7 @@ mod tests {
         fn rejects_server_url_without_host() {
             let mut config = test_config();
             // file:// URLs have no host
-            config.servers = vec![Url::parse("file:///some/path").unwrap()];
+            config.servers = vec!["file:///some/path".to_string()];
 
             let router = Router::new();
             let err = config
@@ -1035,6 +1059,28 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
             let resource_url = Url::parse(resource).unwrap();
             let result = build_resource_metadata_url(&resource_url);
             assert_eq!(result.as_str(), expected);
+        }
+    }
+
+    mod servers_field {
+        use super::*;
+
+        #[test]
+        fn rejects_unparseable_server_url_at_load() {
+            let yaml = r#"
+                servers:
+                  - "not a url"
+                audiences:
+                  - test-audience
+                resource: http://localhost:4000
+                scopes:
+                  - read
+            "#;
+            let err = serde_yaml::from_str::<Config>(yaml).unwrap_err();
+            assert!(
+                err.to_string().contains("invalid auth server URL"),
+                "got: {err}"
+            );
         }
     }
 

--- a/crates/apollo-mcp-server/src/auth/protected_resource.rs
+++ b/crates/apollo-mcp-server/src/auth/protected_resource.rs
@@ -10,8 +10,8 @@ pub(super) struct ProtectedResource {
     /// The URL of the resource
     resource: Url,
 
-    /// List of authorization servers protecting this resource
-    authorization_servers: Vec<Url>,
+    /// List of authorization servers protecting this resource.
+    authorization_servers: Vec<String>,
 
     /// List of authentication methods allowed
     bearer_methods_supported: Vec<String>,
@@ -33,5 +33,64 @@ impl From<Config> for ProtectedResource {
             scopes_supported: value.scopes,
             resource_documentation: value.resource_documentation,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::bare_authority_no_slash("https://auth.example.com")]
+    #[case::bare_authority_with_slash("https://auth.example.com/")]
+    #[case::path_no_slash("https://auth.example.com/realms/main")]
+    #[case::path_with_slash("https://auth.example.com/realms/main/")]
+    fn authorization_servers_preserves_raw_input(#[case] raw: &str) {
+        let yaml = format!(
+            r#"
+                servers:
+                  - "{raw}"
+                audiences:
+                  - test-audience
+                resource: https://mcp.example.com/mcp
+                scopes:
+                  - read
+            "#
+        );
+
+        let config: Config = serde_yaml::from_str(&yaml).expect("config parses");
+        let metadata = ProtectedResource::from(config);
+        let json = serde_json::to_value(&metadata).expect("metadata serializes");
+
+        assert_eq!(json["authorization_servers"], serde_json::json!([raw]));
+    }
+
+    #[test]
+    fn multiple_servers_all_preserved() {
+        let yaml = r#"
+            servers:
+              - https://issuer-a.example.com
+              - https://issuer-b.example.com/
+              - https://issuer-c.example.com/realms/main
+            audiences:
+              - test-audience
+            resource: https://mcp.example.com/mcp
+            scopes:
+              - read
+        "#;
+
+        let config: Config = serde_yaml::from_str(yaml).expect("config parses");
+        let metadata = ProtectedResource::from(config);
+        let json = serde_json::to_value(&metadata).expect("metadata serializes");
+
+        assert_eq!(
+            json["authorization_servers"],
+            serde_json::json!([
+                "https://issuer-a.example.com",
+                "https://issuer-b.example.com/",
+                "https://issuer-c.example.com/realms/main",
+            ])
+        );
     }
 }


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-485 -->

Apollo MCP Server no longer normalizes the `transport.auth.servers` entries when it sets the `authorization_servers` field in `/.well-known/oauth-protected-resource`. Before, a scheme-authority-only configuration value, like `https://auth.example.com`, was re-parsed through `url::Url`, which added a trailing `/` to the empty path. This normalized form ended up in the metadata and caused mismatches in issuer claims for strict OAuth clients that compare `authorization_servers` with the auth server's discovery `issuer`. Now, server URLs are passed through exactly as they are, so users need to make sure each entry matches their auth server's `issuer` precisely.