### PR TITLE
fix: accept logging/setLevel as a no-op

### DIFF
--- a/.changeset/accept_logging_setlevel_as_noop.md
+++ b/.changeset/accept_logging_setlevel_as_noop.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Accept `logging/setLevel` requests as a no-op
+
+Apollo MCP Server now accepts `logging/setLevel` requests with an empty success response. Previously, clients that eagerly call `setLevel` immediately after `initialize` (notably the MCPJam inspector) received a `-32601 Method not found` response, which surfaced as a red error row in the inspector's logging panel and led users to believe their server was broken. The server does not advertise the `logging` capability and does not stream `notifications/message` to clients. The requested level has no effect on the existing stderr, file, and OpenTelemetry logging pipeline, which is the path recommended by the upcoming MCP [2026-07-28](https://modelcontextprotocol.io/specification/draft/server/utilities/logging) revision that deprecates this feature.

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -728,6 +728,20 @@ impl ServerHandler for Running {
         self.get_prompt_impl(request)
     }
 
+    #[tracing::instrument(skip_all)]
+    async fn set_level(
+        &self,
+        request: rmcp::model::SetLevelRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<(), McpError> {
+        // We do not advertise the `logging` capability and do not emit
+        // `notifications/message`. This override exists only to accept
+        // `logging/setLevel` from clients that send it without checking
+        // capabilities, so they see an empty success instead of `-32601`.
+        debug!(level = ?request.level, "received logging/setLevel; no-op");
+        Ok(())
+    }
+
     fn get_info(&self) -> ServerInfo {
         let meter = &meter::METER;
         meter
@@ -3446,6 +3460,188 @@ mod integration_tests {
                 0,
                 "closed peer should be removed after update_operations"
             );
+        }
+    }
+
+    mod logging_setlevel {
+        use std::sync::Arc;
+
+        use axum::body::Body;
+        use http::{Request, StatusCode};
+        use http_body_util::BodyExt;
+        use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+        use rmcp::transport::{StreamableHttpServerConfig, StreamableHttpService};
+        use serde_json::json;
+        use tokio::sync::RwLock;
+        use tower::ServiceExt;
+
+        use super::*;
+
+        fn create_test_running() -> Running {
+            let schema =
+                apollo_compiler::Schema::parse_and_validate("type Query { hello: String }", "test")
+                    .unwrap();
+            Running {
+                schema: Arc::new(RwLock::new(schema)),
+                operations: Arc::new(RwLock::new(vec![])),
+                apps: vec![],
+                prompts: vec![],
+                headers: http::HeaderMap::new(),
+                forward_headers: vec![],
+                endpoint: url::Url::parse("http://localhost:4000").unwrap(),
+                execute_tool: None,
+                introspect_tool: None,
+                search_tool: None,
+                explorer_tool: None,
+                validate_tool: None,
+                custom_scalar_map: None,
+                peers: Arc::new(RwLock::new(vec![])),
+                cancellation_token: CancellationToken::new(),
+                mutation_mode: MutationMode::None,
+                disable_type_description: false,
+                disable_schema_description: false,
+                enable_output_schema: false,
+                disable_auth_token_passthrough: false,
+                descriptions: HashMap::new(),
+                annotations: HashMap::new(),
+                health_check: None,
+                server_info: Default::default(),
+                instructions: None,
+                rhai_engine: Arc::new(parking_lot::Mutex::new(RhaiEngine::new("rhai"))),
+            }
+        }
+
+        fn create_service(
+            running: Running,
+            session_manager: Arc<LocalSessionManager>,
+        ) -> StreamableHttpService<Running, LocalSessionManager> {
+            StreamableHttpService::new(
+                move || Ok(running.clone()),
+                session_manager,
+                StreamableHttpServerConfig::default().with_stateful_mode(true),
+            )
+        }
+
+        fn build_initialize_request() -> Request<Body> {
+            let body = json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": { "name": "test-client", "version": "1.0.0" }
+                }
+            });
+            Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("Host", "localhost:8000")
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json, text/event-stream")
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        }
+
+        fn build_notification_request(session_id: &str) -> Request<Body> {
+            let body = json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized"
+            });
+            Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("Host", "localhost:8000")
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json, text/event-stream")
+                .header("Mcp-Session-Id", session_id)
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        }
+
+        fn build_set_level_request(session_id: &str, level: &str) -> Request<Body> {
+            let body = json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "logging/setLevel",
+                "params": { "level": level }
+            });
+            Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("Host", "localhost:8000")
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json, text/event-stream")
+                .header("Mcp-Session-Id", session_id)
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        }
+
+        fn extract_session_id<B>(response: &http::Response<B>) -> String {
+            response
+                .headers()
+                .get("mcp-session-id")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string()
+        }
+
+        async fn extract_json_body<B>(response: http::Response<B>) -> serde_json::Value
+        where
+            B: BodyExt,
+            B::Error: std::fmt::Debug,
+        {
+            let bytes = response.into_body().collect().await.unwrap().to_bytes();
+            let body_str = String::from_utf8_lossy(&bytes);
+            for line in body_str.lines() {
+                if let Some(data) = line.strip_prefix("data: ")
+                    && let Ok(val) = serde_json::from_str::<serde_json::Value>(data)
+                {
+                    return val;
+                }
+            }
+            panic!("no JSON data found in SSE response");
+        }
+
+        async fn initialize_session(
+            running: &Running,
+            session_manager: &Arc<LocalSessionManager>,
+        ) -> String {
+            let service = create_service(running.clone(), Arc::clone(session_manager));
+            let response = service.oneshot(build_initialize_request()).await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let session_id = extract_session_id(&response);
+
+            let service = create_service(running.clone(), Arc::clone(session_manager));
+            let response = service
+                .oneshot(build_notification_request(&session_id))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+            session_id
+        }
+
+        #[tokio::test]
+        async fn returns_empty_success_for_any_level() {
+            let running = create_test_running();
+            let session_manager: Arc<LocalSessionManager> = LocalSessionManager::default().into();
+            let session_id = initialize_session(&running, &session_manager).await;
+
+            let service = create_service(running, session_manager);
+            let response = service
+                .oneshot(build_set_level_request(&session_id, "debug"))
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = extract_json_body(response).await;
+            assert!(
+                body.get("error").is_none(),
+                "set_level should not return an error: {body}"
+            );
+            assert_eq!(body["result"], json!({}));
         }
     }
 }


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-499 -->

Apollo MCP Server now accepts `logging/setLevel` requests with an empty success response. Previously, clients that eagerly call `setLevel` immediately after `initialize` (notably the MCPJam inspector) received a `-32601 Method not found` response, which surfaced as a red error row in the inspector's logging panel and led users to believe their server was broken. 

Per the [MCP spec](https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging), `logging/setLevel` is a MAY for clients ("clients MAY send a logging/setLevel request"), and the spec only explicitly requires that servers emitting log notifications MUST declare the logging capability. The spec does not directly forbid clients from calling `setLevel` against a server that did not declare the capability.

Just a heads up, this PR doesn't include any changes to advertise the logging capability or stream notifications/message to clients. The requested level doesn't affect the existing stderr, file, and OpenTelemetry logging pipeline. This is the path recommended by the upcoming MCP [2026-07-28](https://modelcontextprotocol.io/specification/draft/server/utilities/logging) revision, which will deprecate this feature.

## Testing

Before:

<img width="3024" height="1716" alt="2026-05-27 at 14 18 20" src="https://github.com/user-attachments/assets/833af6a3-af81-45f1-a8a2-e3561027fcd6" />

After:

<img width="3024" height="1716" alt="2026-05-27 at 14 17 06" src="https://github.com/user-attachments/assets/174c5af8-2ba9-4c35-8ca2-28d25404a79a" />

Log:

```
trace_id=5793a259595bfba611ffaaefb9faf95f 2026-05-27T17:00:44.257409Z DEBUG serve_inner: received logging/setLevel; no-op level=Debug
```
