### PR TITLE
feat: add issuer (iss) validation for OAuth tokens

### DIFF
--- a/.changeset/add_issuer_validation.md
+++ b/.changeset/add_issuer_validation.md
@@ -4,8 +4,13 @@ default: minor
 
 # Add issuer validation for OAuth tokens
 
-Apollo MCP Server can now validate the `iss` (issuer) claim of incoming JWTs. Set
-`transport.auth.issuers` to a list of accepted issuer URLs; a token's `iss` claim must
-match one of them or the request is rejected. When `issuers` is empty (the default),
-issuer validation is skipped, so existing configurations are unaffected. This brings the
-MCP Server to parity with Apollo Router's JWT issuer validation.
+Apollo MCP Server can now validate the `iss` (issuer) claim of incoming JWTs. Issuer
+validation is configured per authorization server: a `transport.auth.servers` entry may
+now be written as an object with a `url` and an optional `issuers` list, in addition to
+the existing bare URL string form. When a server lists `issuers`, a token whose signature
+is verified by that server's keys must carry an `iss` claim matching one of the listed
+values, or the request is rejected. Binding issuers to the signing server (rather than a
+single global list) mirrors Apollo Router's per-JWKS `issuers` semantics and prevents a
+token signed by one configured server from being accepted while claiming a different
+configured server's issuer. Server entries written as bare URL strings skip issuer
+validation, so existing configurations are unaffected.

--- a/.changeset/add_issuer_validation.md
+++ b/.changeset/add_issuer_validation.md
@@ -4,13 +4,11 @@ default: minor
 
 # Add issuer validation for OAuth tokens
 
-Apollo MCP Server can now validate the `iss` (issuer) claim of incoming JWTs. Issuer
-validation is configured per authorization server: a `transport.auth.servers` entry may
-now be written as an object with a `url` and an optional `issuers` list, in addition to
-the existing bare URL string form. When a server lists `issuers`, a token whose signature
-is verified by that server's keys must carry an `iss` claim matching one of the listed
-values, or the request is rejected. Binding issuers to the signing server (rather than a
-single global list) mirrors Apollo Router's per-JWKS `issuers` semantics and prevents a
-token signed by one configured server from being accepted while claiming a different
-configured server's issuer. Server entries written as bare URL strings skip issuer
-validation, so existing configurations are unaffected.
+Apollo MCP Server can now validate the `iss` (issuer) claim of incoming JWTs. Set
+`transport.auth.issuers` to a list of accepted issuer values; a token's `iss` claim must
+match one of them or the request is rejected. Issuer validation is also bound to the
+authorization server that signed the token: the `iss` claim must equal the issuer that
+server advertises in its discovery metadata, so a token signed by one configured server
+cannot be accepted while it claims a different configured server's issuer. When `issuers`
+is empty (the default), issuer validation is skipped, so existing configurations are
+unaffected.

--- a/.changeset/add_issuer_validation.md
+++ b/.changeset/add_issuer_validation.md
@@ -1,0 +1,11 @@
+---
+default: minor
+---
+
+# Add issuer validation for OAuth tokens
+
+Apollo MCP Server can now validate the `iss` (issuer) claim of incoming JWTs. Set
+`transport.auth.issuers` to a list of accepted issuer URLs; a token's `iss` claim must
+match one of them or the request is rejected. When `issuers` is empty (the default),
+issuer validation is skipped, so existing configurations are unaffected. This brings the
+MCP Server to parity with Apollo Router's JWT issuer validation.

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -146,6 +146,15 @@ pub struct Config {
     #[serde(default)]
     pub audiences: Vec<String>,
 
+    /// List of accepted token issuers (the JWT `iss` claim).
+    ///
+    /// When non-empty, a token's `iss` claim must exactly match one of these
+    /// values or the token is rejected. When empty (default), issuer validation
+    /// is skipped. Not `Vec<Url>`: like `servers`, `Url::parse` appends `/` to
+    /// bare-authority inputs, which would break exact `iss` string matching.
+    #[serde(default)]
+    pub issuers: Vec<String>,
+
     /// Allow any audience (skip validation) - use with caution
     #[serde(default)]
     pub allow_any_audience: bool,
@@ -484,6 +493,7 @@ async fn oauth_validate(
         .collect();
     let validator = NetworkedTokenValidator::new(
         &auth_config.audiences,
+        &auth_config.issuers,
         auth_config.allow_any_audience,
         &auth_servers,
         &auth_state.client,
@@ -580,6 +590,7 @@ mod tests {
         Config {
             servers: vec!["http://localhost:1234".to_string()],
             audiences: vec!["test-audience".to_string()],
+            issuers: vec![],
             allow_any_audience: false,
             resource: Url::parse("http://localhost:4000").unwrap(),
             resource_documentation: None,
@@ -1082,6 +1093,51 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
                 err.to_string().contains("invalid auth server URL"),
                 "got: {err}"
             );
+        }
+    }
+
+    mod issuers_field {
+        use super::*;
+
+        #[test]
+        fn yaml_deserialization_with_issuers() {
+            let yaml = r#"
+                servers:
+                  - http://localhost:1234
+                audiences:
+                  - test-audience
+                issuers:
+                  - https://auth.example.com
+                  - https://auth.other.com
+                resource: http://localhost:4000
+                scopes:
+                  - read
+            "#;
+
+            let config: Config = serde_yaml::from_str(yaml).unwrap();
+            assert_eq!(
+                config.issuers,
+                vec![
+                    "https://auth.example.com".to_string(),
+                    "https://auth.other.com".to_string()
+                ]
+            );
+        }
+
+        #[test]
+        fn yaml_deserialization_without_issuers_defaults_to_empty() {
+            let yaml = r#"
+                servers:
+                  - http://localhost:1234
+                audiences:
+                  - test-audience
+                resource: http://localhost:4000
+                scopes:
+                  - read
+            "#;
+
+            let config: Config = serde_yaml::from_str(yaml).unwrap();
+            assert!(config.issuers.is_empty());
         }
     }
 

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -118,17 +118,74 @@ where
     Ok(headers)
 }
 
-fn deserialize_auth_servers<'de, D>(d: D) -> Result<Vec<String>, D::Error>
+/// An upstream OAuth server to delegate authentication to, together with the
+/// token issuers accepted for tokens it signs.
+///
+/// Deserializes from either a bare URL string (issuer validation disabled for
+/// that server) or an object with explicit `issuers`:
+///
+/// ```yaml
+/// servers:
+///   - https://auth.example.com                 # bare form, no issuer check
+///   - url: https://auth.other.example.com       # object form
+///     issuers:
+///       - https://auth.other.example.com
+/// ```
+///
+/// `url` is kept as a `String` rather than `Url`: `Url::parse` appends `/` to
+/// bare-authority inputs, which would break exact `iss` string matching and
+/// alter the value advertised in the protected-resource metadata.
+#[derive(Debug, Clone, JsonSchema)]
+pub struct AuthServer {
+    /// The upstream OAuth server URL (used for OIDC/OAuth discovery).
+    pub url: String,
+
+    /// Accepted token issuers (the JWT `iss` claim) for tokens signed by this
+    /// server's JWKS. When non-empty, a token verified by this server's keys
+    /// must carry an `iss` claim matching one of these values, or it is
+    /// rejected. When empty (the default), issuer validation is skipped for
+    /// this server.
+    pub issuers: Vec<String>,
+}
+
+impl<'de> Deserialize<'de> for AuthServer {
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        /// Accepts either a bare URL string or the structured `{ url, issuers }`
+        /// object. The object arm uses `deny_unknown_fields` so typos surface
+        /// as errors rather than being silently dropped.
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            Bare(String),
+            Structured {
+                url: String,
+                #[serde(default)]
+                issuers: Vec<String>,
+            },
+        }
+
+        let (url, issuers) = match Repr::deserialize(d)? {
+            Repr::Bare(url) => (url, Vec::new()),
+            Repr::Structured { url, issuers } => (url, issuers),
+        };
+
+        Url::parse(&url)
+            .map_err(|e| D::Error::custom(format!("invalid auth server URL {url:?}: {e}")))?;
+
+        Ok(AuthServer { url, issuers })
+    }
+}
+
+fn deserialize_auth_servers<'de, D>(d: D) -> Result<Vec<AuthServer>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    use serde::de::Error;
-    let servers: Vec<String> = Vec::deserialize(d)?;
-    for s in &servers {
-        Url::parse(s)
-            .map_err(|e| D::Error::custom(format!("invalid auth server URL {s:?}: {e}")))?;
-    }
-    Ok(servers)
+    Vec::<AuthServer>::deserialize(d)
 }
 
 /// Auth configuration options
@@ -136,24 +193,18 @@ where
 #[serde(deny_unknown_fields)]
 pub struct Config {
     /// List of upstream OAuth servers to delegate auth.
-    /// Not `Vec<Url>`: `Url::parse` appends `/` to bare-authority inputs,
-    /// breaking issuer string-matching in clients.
+    ///
+    /// Each entry is either a bare URL string or an object with `url` and an
+    /// optional per-server `issuers` list (the accepted JWT `iss` values for
+    /// tokens that server signs). Issuer validation is bound to the server
+    /// whose JWKS verifies a token's signature, matching Apollo Router's
+    /// per-JWKS `issuers` semantics.
     #[serde(deserialize_with = "deserialize_auth_servers")]
-    #[schemars(with = "Vec<Url>")]
-    pub servers: Vec<String>,
+    pub servers: Vec<AuthServer>,
 
     /// List of accepted audiences for the OAuth tokens
     #[serde(default)]
     pub audiences: Vec<String>,
-
-    /// List of accepted token issuers (the JWT `iss` claim).
-    ///
-    /// When non-empty, a token's `iss` claim must exactly match one of these
-    /// values or the token is rejected. When empty (default), issuer validation
-    /// is skipped. Not `Vec<Url>`: like `servers`, `Url::parse` appends `/` to
-    /// bare-authority inputs, which would break exact `iss` string matching.
-    #[serde(default)]
-    pub issuers: Vec<String>,
 
     /// Allow any audience (skip validation) - use with caution
     #[serde(default)]
@@ -281,11 +332,11 @@ impl Config {
         // Validate server URLs have hosts (fail fast on config errors)
         #[allow(clippy::expect_used)] // parseability validated at deserialize
         for (i, server) in self.servers.iter().enumerate() {
-            let parsed = Url::parse(server).expect("validated by deserialize_auth_servers");
+            let parsed = Url::parse(&server.url).expect("validated by deserialize_auth_servers");
             if parsed.host_str().is_none() {
                 return Err(TlsConfigError::ServerUrlMissingHost {
                     index: i,
-                    url: server.clone(),
+                    url: server.url.clone(),
                 });
             }
         }
@@ -485,17 +536,10 @@ async fn oauth_validate(
         .discovery_timeout
         .unwrap_or(Duration::from_secs(5));
 
-    #[allow(clippy::expect_used)] // parseability validated at deserialize
-    let auth_servers: Vec<Url> = auth_config
-        .servers
-        .iter()
-        .map(|s| Url::parse(s).expect("validated by deserialize_auth_servers"))
-        .collect();
     let validator = NetworkedTokenValidator::new(
         &auth_config.audiences,
-        &auth_config.issuers,
         auth_config.allow_any_audience,
-        &auth_servers,
+        &auth_config.servers,
         &auth_state.client,
         discovery_timeout,
     );
@@ -588,9 +632,11 @@ mod tests {
 
     fn test_config() -> Config {
         Config {
-            servers: vec!["http://localhost:1234".to_string()],
+            servers: vec![AuthServer {
+                url: "http://localhost:1234".to_string(),
+                issuers: vec![],
+            }],
             audiences: vec!["test-audience".to_string()],
-            issuers: vec![],
             allow_any_audience: false,
             resource: Url::parse("http://localhost:4000").unwrap(),
             resource_documentation: None,
@@ -809,7 +855,10 @@ mod tests {
         fn rejects_server_url_without_host() {
             let mut config = test_config();
             // file:// URLs have no host
-            config.servers = vec!["file:///some/path".to_string()];
+            config.servers = vec![AuthServer {
+                url: "file:///some/path".to_string(),
+                issuers: vec![],
+            }];
 
             let router = Router::new();
             let err = config
@@ -1100,23 +1149,43 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
         use super::*;
 
         #[test]
-        fn yaml_deserialization_with_issuers() {
+        fn bare_string_server_has_no_issuers() {
             let yaml = r#"
                 servers:
                   - http://localhost:1234
                 audiences:
                   - test-audience
-                issuers:
-                  - https://auth.example.com
-                  - https://auth.other.com
                 resource: http://localhost:4000
                 scopes:
                   - read
             "#;
 
             let config: Config = serde_yaml::from_str(yaml).unwrap();
+            assert_eq!(config.servers.len(), 1);
+            assert_eq!(config.servers[0].url, "http://localhost:1234");
+            assert!(config.servers[0].issuers.is_empty());
+        }
+
+        #[test]
+        fn object_server_carries_its_own_issuers() {
+            let yaml = r#"
+                servers:
+                  - url: http://localhost:1234
+                    issuers:
+                      - https://auth.example.com
+                      - https://auth.other.com
+                audiences:
+                  - test-audience
+                resource: http://localhost:4000
+                scopes:
+                  - read
+            "#;
+
+            let config: Config = serde_yaml::from_str(yaml).unwrap();
+            assert_eq!(config.servers.len(), 1);
+            assert_eq!(config.servers[0].url, "http://localhost:1234");
             assert_eq!(
-                config.issuers,
+                config.servers[0].issuers,
                 vec![
                     "https://auth.example.com".to_string(),
                     "https://auth.other.com".to_string()
@@ -1125,10 +1194,10 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
         }
 
         #[test]
-        fn yaml_deserialization_without_issuers_defaults_to_empty() {
+        fn object_server_without_issuers_defaults_to_empty() {
             let yaml = r#"
                 servers:
-                  - http://localhost:1234
+                  - url: http://localhost:1234
                 audiences:
                   - test-audience
                 resource: http://localhost:4000
@@ -1137,7 +1206,53 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
             "#;
 
             let config: Config = serde_yaml::from_str(yaml).unwrap();
-            assert!(config.issuers.is_empty());
+            assert!(config.servers[0].issuers.is_empty());
+        }
+
+        #[test]
+        fn bare_and_object_forms_mix_in_one_list() {
+            let yaml = r#"
+                servers:
+                  - http://localhost:1234
+                  - url: https://auth.other.com
+                    issuers:
+                      - https://auth.other.com
+                audiences:
+                  - test-audience
+                resource: http://localhost:4000
+                scopes:
+                  - read
+            "#;
+
+            let config: Config = serde_yaml::from_str(yaml).unwrap();
+            assert_eq!(config.servers.len(), 2);
+            assert_eq!(config.servers[0].url, "http://localhost:1234");
+            assert!(config.servers[0].issuers.is_empty());
+            assert_eq!(config.servers[1].url, "https://auth.other.com");
+            assert_eq!(
+                config.servers[1].issuers,
+                vec!["https://auth.other.com".to_string()]
+            );
+        }
+
+        #[test]
+        fn invalid_server_url_is_rejected() {
+            let yaml = r#"
+                servers:
+                  - "not a url"
+                audiences:
+                  - test-audience
+                resource: http://localhost:4000
+                scopes:
+                  - read
+            "#;
+
+            let err = serde_yaml::from_str::<Config>(yaml)
+                .expect_err("invalid server URL should fail to parse");
+            assert!(
+                err.to_string().contains("invalid auth server URL"),
+                "unexpected error: {err}"
+            );
         }
     }
 

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -118,74 +118,17 @@ where
     Ok(headers)
 }
 
-/// An upstream OAuth server to delegate authentication to, together with the
-/// token issuers accepted for tokens it signs.
-///
-/// Deserializes from either a bare URL string (issuer validation disabled for
-/// that server) or an object with explicit `issuers`:
-///
-/// ```yaml
-/// servers:
-///   - https://auth.example.com                 # bare form, no issuer check
-///   - url: https://auth.other.example.com       # object form
-///     issuers:
-///       - https://auth.other.example.com
-/// ```
-///
-/// `url` is kept as a `String` rather than `Url`: `Url::parse` appends `/` to
-/// bare-authority inputs, which would break exact `iss` string matching and
-/// alter the value advertised in the protected-resource metadata.
-#[derive(Debug, Clone, JsonSchema)]
-pub struct AuthServer {
-    /// The upstream OAuth server URL (used for OIDC/OAuth discovery).
-    pub url: String,
-
-    /// Accepted token issuers (the JWT `iss` claim) for tokens signed by this
-    /// server's JWKS. When non-empty, a token verified by this server's keys
-    /// must carry an `iss` claim matching one of these values, or it is
-    /// rejected. When empty (the default), issuer validation is skipped for
-    /// this server.
-    pub issuers: Vec<String>,
-}
-
-impl<'de> Deserialize<'de> for AuthServer {
-    fn deserialize<D>(d: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        use serde::de::Error;
-
-        /// Accepts either a bare URL string or the structured `{ url, issuers }`
-        /// object. The object arm uses `deny_unknown_fields` so typos surface
-        /// as errors rather than being silently dropped.
-        #[derive(Deserialize)]
-        #[serde(untagged)]
-        enum Repr {
-            Bare(String),
-            Structured {
-                url: String,
-                #[serde(default)]
-                issuers: Vec<String>,
-            },
-        }
-
-        let (url, issuers) = match Repr::deserialize(d)? {
-            Repr::Bare(url) => (url, Vec::new()),
-            Repr::Structured { url, issuers } => (url, issuers),
-        };
-
-        Url::parse(&url)
-            .map_err(|e| D::Error::custom(format!("invalid auth server URL {url:?}: {e}")))?;
-
-        Ok(AuthServer { url, issuers })
-    }
-}
-
-fn deserialize_auth_servers<'de, D>(d: D) -> Result<Vec<AuthServer>, D::Error>
+fn deserialize_auth_servers<'de, D>(d: D) -> Result<Vec<String>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    Vec::<AuthServer>::deserialize(d)
+    use serde::de::Error;
+    let servers: Vec<String> = Vec::deserialize(d)?;
+    for s in &servers {
+        Url::parse(s)
+            .map_err(|e| D::Error::custom(format!("invalid auth server URL {s:?}: {e}")))?;
+    }
+    Ok(servers)
 }
 
 /// Auth configuration options
@@ -193,18 +136,24 @@ where
 #[serde(deny_unknown_fields)]
 pub struct Config {
     /// List of upstream OAuth servers to delegate auth.
-    ///
-    /// Each entry is either a bare URL string or an object with `url` and an
-    /// optional per-server `issuers` list (the accepted JWT `iss` values for
-    /// tokens that server signs). Issuer validation is bound to the server
-    /// whose JWKS verifies a token's signature, matching Apollo Router's
-    /// per-JWKS `issuers` semantics.
+    /// Not `Vec<Url>`: `Url::parse` appends `/` to bare-authority inputs,
+    /// breaking issuer string-matching in clients.
     #[serde(deserialize_with = "deserialize_auth_servers")]
-    pub servers: Vec<AuthServer>,
+    #[schemars(with = "Vec<Url>")]
+    pub servers: Vec<String>,
 
     /// List of accepted audiences for the OAuth tokens
     #[serde(default)]
     pub audiences: Vec<String>,
+
+    /// List of accepted token issuers (the JWT `iss` claim).
+    ///
+    /// When non-empty, a token's `iss` claim must exactly match one of these
+    /// values or the token is rejected. When empty (default), issuer validation
+    /// is skipped. Not `Vec<Url>`: like `servers`, `Url::parse` appends `/` to
+    /// bare-authority inputs, which would break exact `iss` string matching.
+    #[serde(default)]
+    pub issuers: Vec<String>,
 
     /// Allow any audience (skip validation) - use with caution
     #[serde(default)]
@@ -332,11 +281,11 @@ impl Config {
         // Validate server URLs have hosts (fail fast on config errors)
         #[allow(clippy::expect_used)] // parseability validated at deserialize
         for (i, server) in self.servers.iter().enumerate() {
-            let parsed = Url::parse(&server.url).expect("validated by deserialize_auth_servers");
+            let parsed = Url::parse(server).expect("validated by deserialize_auth_servers");
             if parsed.host_str().is_none() {
                 return Err(TlsConfigError::ServerUrlMissingHost {
                     index: i,
-                    url: server.url.clone(),
+                    url: server.clone(),
                 });
             }
         }
@@ -536,10 +485,17 @@ async fn oauth_validate(
         .discovery_timeout
         .unwrap_or(Duration::from_secs(5));
 
+    #[allow(clippy::expect_used)] // parseability validated at deserialize
+    let auth_servers: Vec<Url> = auth_config
+        .servers
+        .iter()
+        .map(|s| Url::parse(s).expect("validated by deserialize_auth_servers"))
+        .collect();
     let validator = NetworkedTokenValidator::new(
         &auth_config.audiences,
+        &auth_config.issuers,
         auth_config.allow_any_audience,
-        &auth_config.servers,
+        &auth_servers,
         &auth_state.client,
         discovery_timeout,
     );
@@ -632,11 +588,9 @@ mod tests {
 
     fn test_config() -> Config {
         Config {
-            servers: vec![AuthServer {
-                url: "http://localhost:1234".to_string(),
-                issuers: vec![],
-            }],
+            servers: vec!["http://localhost:1234".to_string()],
             audiences: vec!["test-audience".to_string()],
+            issuers: vec![],
             allow_any_audience: false,
             resource: Url::parse("http://localhost:4000").unwrap(),
             resource_documentation: None,
@@ -855,10 +809,7 @@ mod tests {
         fn rejects_server_url_without_host() {
             let mut config = test_config();
             // file:// URLs have no host
-            config.servers = vec![AuthServer {
-                url: "file:///some/path".to_string(),
-                issuers: vec![],
-            }];
+            config.servers = vec!["file:///some/path".to_string()];
 
             let router = Router::new();
             let err = config
@@ -1149,43 +1100,23 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
         use super::*;
 
         #[test]
-        fn bare_string_server_has_no_issuers() {
+        fn yaml_deserialization_with_issuers() {
             let yaml = r#"
                 servers:
                   - http://localhost:1234
                 audiences:
                   - test-audience
+                issuers:
+                  - https://auth.example.com
+                  - https://auth.other.com
                 resource: http://localhost:4000
                 scopes:
                   - read
             "#;
 
             let config: Config = serde_yaml::from_str(yaml).unwrap();
-            assert_eq!(config.servers.len(), 1);
-            assert_eq!(config.servers[0].url, "http://localhost:1234");
-            assert!(config.servers[0].issuers.is_empty());
-        }
-
-        #[test]
-        fn object_server_carries_its_own_issuers() {
-            let yaml = r#"
-                servers:
-                  - url: http://localhost:1234
-                    issuers:
-                      - https://auth.example.com
-                      - https://auth.other.com
-                audiences:
-                  - test-audience
-                resource: http://localhost:4000
-                scopes:
-                  - read
-            "#;
-
-            let config: Config = serde_yaml::from_str(yaml).unwrap();
-            assert_eq!(config.servers.len(), 1);
-            assert_eq!(config.servers[0].url, "http://localhost:1234");
             assert_eq!(
-                config.servers[0].issuers,
+                config.issuers,
                 vec![
                     "https://auth.example.com".to_string(),
                     "https://auth.other.com".to_string()
@@ -1194,29 +1125,10 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
         }
 
         #[test]
-        fn object_server_without_issuers_defaults_to_empty() {
-            let yaml = r#"
-                servers:
-                  - url: http://localhost:1234
-                audiences:
-                  - test-audience
-                resource: http://localhost:4000
-                scopes:
-                  - read
-            "#;
-
-            let config: Config = serde_yaml::from_str(yaml).unwrap();
-            assert!(config.servers[0].issuers.is_empty());
-        }
-
-        #[test]
-        fn bare_and_object_forms_mix_in_one_list() {
+        fn yaml_deserialization_without_issuers_defaults_to_empty() {
             let yaml = r#"
                 servers:
                   - http://localhost:1234
-                  - url: https://auth.other.com
-                    issuers:
-                      - https://auth.other.com
                 audiences:
                   - test-audience
                 resource: http://localhost:4000
@@ -1225,34 +1137,7 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
             "#;
 
             let config: Config = serde_yaml::from_str(yaml).unwrap();
-            assert_eq!(config.servers.len(), 2);
-            assert_eq!(config.servers[0].url, "http://localhost:1234");
-            assert!(config.servers[0].issuers.is_empty());
-            assert_eq!(config.servers[1].url, "https://auth.other.com");
-            assert_eq!(
-                config.servers[1].issuers,
-                vec!["https://auth.other.com".to_string()]
-            );
-        }
-
-        #[test]
-        fn invalid_server_url_is_rejected() {
-            let yaml = r#"
-                servers:
-                  - "not a url"
-                audiences:
-                  - test-audience
-                resource: http://localhost:4000
-                scopes:
-                  - read
-            "#;
-
-            let err = serde_yaml::from_str::<Config>(yaml)
-                .expect_err("invalid server URL should fail to parse");
-            assert!(
-                err.to_string().contains("invalid auth server URL"),
-                "unexpected error: {err}"
-            );
+            assert!(config.issuers.is_empty());
         }
     }
 

--- a/crates/apollo-mcp-server/src/auth/networked_token_validator.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_token_validator.rs
@@ -227,7 +227,7 @@ impl ValidateToken for NetworkedTokenValidator<'_> {
         }
         Some(VerificationKey {
             jwk,
-            issuer: Some(metadata.issuer),
+            issuer: metadata.issuer,
         })
     }
 }

--- a/crates/apollo-mcp-server/src/auth/networked_token_validator.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_token_validator.rs
@@ -13,6 +13,7 @@ use super::valid_token::ValidateToken;
 /// from the network.
 pub(super) struct NetworkedTokenValidator<'a> {
     audiences: &'a [String],
+    issuers: &'a [String],
     allow_any_audience: bool,
     upstreams: &'a Vec<Url>,
     client: &'a reqwest::Client,
@@ -22,6 +23,7 @@ pub(super) struct NetworkedTokenValidator<'a> {
 impl<'a> NetworkedTokenValidator<'a> {
     pub fn new(
         audiences: &'a [String],
+        issuers: &'a [String],
         allow_any_audience: bool,
         upstreams: &'a Vec<Url>,
         client: &'a reqwest::Client,
@@ -29,6 +31,7 @@ impl<'a> NetworkedTokenValidator<'a> {
     ) -> Self {
         Self {
             audiences,
+            issuers,
             allow_any_audience,
             upstreams,
             client,
@@ -194,6 +197,10 @@ impl ValidateToken for NetworkedTokenValidator<'_> {
 
     fn get_audiences(&self) -> &[String] {
         self.audiences
+    }
+
+    fn get_issuers(&self) -> &[String] {
+        self.issuers
     }
 
     fn get_servers(&self) -> &Vec<Url> {

--- a/crates/apollo-mcp-server/src/auth/networked_token_validator.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_token_validator.rs
@@ -2,23 +2,20 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use jsonwebtoken::jwk::KeyAlgorithm;
-use jwks::{Jwk, Jwks};
+use jwks::Jwks;
 use serde::Deserialize;
 use tracing::{error, info, trace, warn};
 use url::Url;
 
-use super::AuthServer;
-use super::valid_token::ValidateToken;
+use super::valid_token::{ValidateToken, VerificationKey};
 
 /// Implementation of the `ValidateToken` trait which fetches key information
 /// from the network.
 pub(super) struct NetworkedTokenValidator<'a> {
     audiences: &'a [String],
+    issuers: &'a [String],
     allow_any_audience: bool,
-    servers: &'a [AuthServer],
-    /// Parsed upstream URLs, owned so `get_servers` can hand out a slice. Index
-    /// alignment with `servers` is maintained by construction.
-    upstreams: Vec<Url>,
+    upstreams: &'a Vec<Url>,
     client: &'a reqwest::Client,
     discovery_timeout: Duration,
 }
@@ -26,20 +23,16 @@ pub(super) struct NetworkedTokenValidator<'a> {
 impl<'a> NetworkedTokenValidator<'a> {
     pub fn new(
         audiences: &'a [String],
+        issuers: &'a [String],
         allow_any_audience: bool,
-        servers: &'a [AuthServer],
+        upstreams: &'a Vec<Url>,
         client: &'a reqwest::Client,
         discovery_timeout: Duration,
     ) -> Self {
-        #[allow(clippy::expect_used)] // parseability validated at deserialize
-        let upstreams = servers
-            .iter()
-            .map(|s| Url::parse(&s.url).expect("validated by deserialize_auth_servers"))
-            .collect();
         Self {
             audiences,
+            issuers,
             allow_any_audience,
-            servers,
             upstreams,
             client,
             discovery_timeout,
@@ -136,6 +129,12 @@ fn build_discovery_urls(issuer: &Url) -> Result<Vec<Url>, DiscoveryUrlError> {
 /// as a proxy to fill in `alg` when a JWK omits it (RFC 7517 §4.4).
 #[derive(Debug, Deserialize)]
 struct DiscoveryMetadata {
+    /// The authorization server's issuer identifier. RFC 8414 and OpenID
+    /// Connect Discovery both require this field, and it must equal the `iss`
+    /// claim of tokens the server issues (OpenID Connect Core §2, RFC 9068
+    /// §2.2). Used to bind issuer validation to the server whose JWKS verified
+    /// the signature.
+    issuer: String,
     jwks_uri: String,
     #[serde(default)]
     id_token_signing_alg_values_supported: Vec<String>,
@@ -206,21 +205,12 @@ impl ValidateToken for NetworkedTokenValidator<'_> {
         self.audiences
     }
 
-    fn get_issuers_for(&self, server: &Url) -> &[String] {
-        // Bind issuer validation to the server whose JWKS is being tried, so a
-        // token's accepted issuers are exactly those configured for the signer.
-        // `upstreams` is the parsed, index-aligned view of `servers`; zipping
-        // them keeps that pairing explicit and avoids panicking indexing.
-        self.upstreams
-            .iter()
-            .zip(self.servers.iter())
-            .find(|(url, _)| *url == server)
-            .map(|(_, s)| s.issuers.as_slice())
-            .unwrap_or_default()
+    fn get_issuers(&self) -> &[String] {
+        self.issuers
     }
 
-    fn get_servers(&self) -> &[Url] {
-        &self.upstreams
+    fn get_servers(&self) -> &Vec<Url> {
+        self.upstreams
     }
 
     /// `discovery_timeout` bounds each network stage (metadata fetch and JWKS
@@ -228,14 +218,17 @@ impl ValidateToken for NetworkedTokenValidator<'_> {
     /// `discovery_timeout` on the happy path. The JWKS fetch does not fall
     /// back to alternate discovery URLs on failure; real providers advertise
     /// the same `jwks_uri` from every well-known path.
-    async fn get_key(&self, server: &Url, key_id: &str) -> Option<Jwk> {
+    async fn get_key(&self, server: &Url, key_id: &str) -> Option<VerificationKey> {
         let metadata = discover_metadata(self.client, server, self.discovery_timeout).await?;
         let mut jwks = fetch_jwks(self.client, &metadata.jwks_uri, self.discovery_timeout).await?;
         let mut jwk = jwks.keys.remove(key_id)?;
         if jwk.alg.is_none() {
             jwk.alg = resolve_alg(&metadata.id_token_signing_alg_values_supported, server);
         }
-        Some(jwk)
+        Some(VerificationKey {
+            jwk,
+            issuer: Some(metadata.issuer),
+        })
     }
 }
 

--- a/crates/apollo-mcp-server/src/auth/networked_token_validator.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_token_validator.rs
@@ -7,15 +7,18 @@ use serde::Deserialize;
 use tracing::{error, info, trace, warn};
 use url::Url;
 
+use super::AuthServer;
 use super::valid_token::ValidateToken;
 
 /// Implementation of the `ValidateToken` trait which fetches key information
 /// from the network.
 pub(super) struct NetworkedTokenValidator<'a> {
     audiences: &'a [String],
-    issuers: &'a [String],
     allow_any_audience: bool,
-    upstreams: &'a Vec<Url>,
+    servers: &'a [AuthServer],
+    /// Parsed upstream URLs, owned so `get_servers` can hand out a slice. Index
+    /// alignment with `servers` is maintained by construction.
+    upstreams: Vec<Url>,
     client: &'a reqwest::Client,
     discovery_timeout: Duration,
 }
@@ -23,16 +26,20 @@ pub(super) struct NetworkedTokenValidator<'a> {
 impl<'a> NetworkedTokenValidator<'a> {
     pub fn new(
         audiences: &'a [String],
-        issuers: &'a [String],
         allow_any_audience: bool,
-        upstreams: &'a Vec<Url>,
+        servers: &'a [AuthServer],
         client: &'a reqwest::Client,
         discovery_timeout: Duration,
     ) -> Self {
+        #[allow(clippy::expect_used)] // parseability validated at deserialize
+        let upstreams = servers
+            .iter()
+            .map(|s| Url::parse(&s.url).expect("validated by deserialize_auth_servers"))
+            .collect();
         Self {
             audiences,
-            issuers,
             allow_any_audience,
+            servers,
             upstreams,
             client,
             discovery_timeout,
@@ -199,12 +206,21 @@ impl ValidateToken for NetworkedTokenValidator<'_> {
         self.audiences
     }
 
-    fn get_issuers(&self) -> &[String] {
-        self.issuers
+    fn get_issuers_for(&self, server: &Url) -> &[String] {
+        // Bind issuer validation to the server whose JWKS is being tried, so a
+        // token's accepted issuers are exactly those configured for the signer.
+        // `upstreams` is the parsed, index-aligned view of `servers`; zipping
+        // them keeps that pairing explicit and avoids panicking indexing.
+        self.upstreams
+            .iter()
+            .zip(self.servers.iter())
+            .find(|(url, _)| *url == server)
+            .map(|(_, s)| s.issuers.as_slice())
+            .unwrap_or_default()
     }
 
-    fn get_servers(&self) -> &Vec<Url> {
-        self.upstreams
+    fn get_servers(&self) -> &[Url] {
+        &self.upstreams
     }
 
     /// `discovery_timeout` bounds each network stage (metadata fetch and JWKS

--- a/crates/apollo-mcp-server/src/auth/protected_resource.rs
+++ b/crates/apollo-mcp-server/src/auth/protected_resource.rs
@@ -28,7 +28,7 @@ impl From<Config> for ProtectedResource {
     fn from(value: Config) -> Self {
         Self {
             resource: value.resource,
-            authorization_servers: value.servers.into_iter().map(|s| s.url).collect(),
+            authorization_servers: value.servers,
             bearer_methods_supported: vec!["header".to_string()], // The spec only supports header auth
             scopes_supported: value.scopes,
             resource_documentation: value.resource_documentation,

--- a/crates/apollo-mcp-server/src/auth/protected_resource.rs
+++ b/crates/apollo-mcp-server/src/auth/protected_resource.rs
@@ -28,7 +28,7 @@ impl From<Config> for ProtectedResource {
     fn from(value: Config) -> Self {
         Self {
             resource: value.resource,
-            authorization_servers: value.servers,
+            authorization_servers: value.servers.into_iter().map(|s| s.url).collect(),
             bearer_methods_supported: vec!["header".to_string()], // The spec only supports header auth
             scopes_supported: value.scopes,
             resource_documentation: value.resource_documentation,

--- a/crates/apollo-mcp-server/src/auth/valid_token.rs
+++ b/crates/apollo-mcp-server/src/auth/valid_token.rs
@@ -33,11 +33,12 @@ pub(super) trait ValidateToken {
     /// Get the list of allowed audiences
     fn get_audiences(&self) -> &[String];
 
-    /// Get the list of accepted issuers (empty = skip issuer validation)
-    fn get_issuers(&self) -> &[String];
+    /// Get the accepted issuers for tokens verified by `server`'s JWKS
+    /// (empty = skip issuer validation for that server).
+    fn get_issuers_for(&self, server: &Url) -> &[String];
 
     /// Get the available upstream servers
-    fn get_servers(&self) -> &Vec<Url>;
+    fn get_servers(&self) -> &[Url];
 
     /// Fetch the key by its ID
     async fn get_key(&self, server: &Url, key_id: &str) -> Option<Jwk>;
@@ -125,6 +126,11 @@ pub(super) trait ValidateToken {
                 continue;
             };
 
+            // Issuers accepted for tokens this server signs. Bound to the server
+            // whose JWKS verifies the signature, so a token signed by one server
+            // cannot pass by claiming another configured server's issuer.
+            let issuers = self.get_issuers_for(server);
+
             let validation = {
                 let Some(alg) = jwk.alg else {
                     warn!("Skipping JWK with no algorithm specified");
@@ -157,8 +163,8 @@ pub(super) trait ValidateToken {
                     val.set_audience(self.get_audiences());
                 }
 
-                if !self.get_issuers().is_empty() {
-                    val.set_issuer(self.get_issuers());
+                if !issuers.is_empty() {
+                    val.set_issuer(issuers);
                 }
 
                 val
@@ -174,11 +180,11 @@ pub(super) trait ValidateToken {
                         warn!("Token is missing the required `aud` claim");
                         break;
                     }
-                    // When issuer validation is enabled, explicitly reject tokens
-                    // with a missing `iss` claim. The `jsonwebtoken` crate skips its
-                    // own issuer check when the claim is absent from the raw JWT,
-                    // so we enforce it here.
-                    if !self.get_issuers().is_empty() && token_data.claims.iss.is_none() {
+                    // When issuer validation is enabled for this server, explicitly
+                    // reject tokens with a missing `iss` claim. The `jsonwebtoken`
+                    // crate skips its own issuer check when the claim is absent from
+                    // the raw JWT, so we enforce it here.
+                    if !issuers.is_empty() && token_data.claims.iss.is_none() {
                         warn!("Token is missing the required `iss` claim");
                         break;
                     }
@@ -209,12 +215,53 @@ mod test {
 
     use super::ValidateToken;
 
+    /// A single upstream server in the test validator: its URL, the one
+    /// `(kid, jwk)` it will serve, and the issuers configured for it.
+    struct TestServer {
+        url: Url,
+        key_pair: (String, Jwk),
+        issuers: Vec<String>,
+    }
+
     struct TestTokenValidator {
         audiences: Vec<String>,
-        issuers: Vec<String>,
         allow_any_audience: bool,
-        key_pair: (String, Jwk),
-        servers: Vec<Url>,
+        servers: Vec<TestServer>,
+        /// Parsed server URLs, owned so `get_servers` can return a slice.
+        /// Kept index-aligned with `servers`.
+        server_urls: Vec<Url>,
+    }
+
+    impl TestTokenValidator {
+        /// Build a validator from `(server, key_pair, issuers)` tuples.
+        fn new(audiences: Vec<String>, allow_any_audience: bool, servers: Vec<TestServer>) -> Self {
+            let server_urls = servers.iter().map(|s| s.url.clone()).collect();
+            Self {
+                audiences,
+                allow_any_audience,
+                servers,
+                server_urls,
+            }
+        }
+
+        /// Convenience for the common single-server case.
+        fn single(
+            audiences: Vec<String>,
+            issuers: Vec<String>,
+            allow_any_audience: bool,
+            key_pair: (String, Jwk),
+            server: Url,
+        ) -> Self {
+            Self::new(
+                audiences,
+                allow_any_audience,
+                vec![TestServer {
+                    url: server,
+                    key_pair,
+                    issuers,
+                }],
+            )
+        }
     }
 
     impl ValidateToken for TestTokenValidator {
@@ -226,25 +273,27 @@ mod test {
             &self.audiences
         }
 
-        fn get_issuers(&self) -> &[String] {
-            &self.issuers
+        fn get_issuers_for(&self, server: &Url) -> &[String] {
+            self.server_urls
+                .iter()
+                .zip(self.servers.iter())
+                .find(|(url, _)| *url == server)
+                .map(|(_, s)| s.issuers.as_slice())
+                .unwrap_or_default()
         }
 
-        fn get_servers(&self) -> &Vec<url::Url> {
-            &self.servers
+        fn get_servers(&self) -> &[url::Url] {
+            &self.server_urls
         }
 
         async fn get_key(&self, server: &url::Url, key_id: &str) -> Option<jwks::Jwk> {
-            // Return nothing if the server is not known to us
-            if !self.get_servers().contains(server) {
-                return None;
-            }
-
-            // Only return the key if it is the one we know
-            self.key_pair
+            // Find the requested server, then return its key only if the `kid` matches.
+            let test_server = self.servers.iter().find(|s| &s.url == server)?;
+            test_server
+                .key_pair
                 .0
                 .eq(key_id)
-                .then_some(self.key_pair.1.clone())
+                .then_some(test_server.key_pair.1.clone())
         }
     }
 
@@ -307,13 +356,8 @@ mod test {
         let server =
             Url::from_str("https://auth.example.com").expect("should parse a valid example server");
 
-        let test_validator = TestTokenValidator {
-            audiences: vec![audience],
-            issuers: vec![],
-            allow_any_audience: false,
-            key_pair: (key_id, jwk),
-            servers: vec![server],
-        };
+        let test_validator =
+            TestTokenValidator::single(vec![audience], vec![], false, (key_id, jwk), server);
 
         let token = jwt.token().to_string();
         assert_eq!(
@@ -350,13 +394,8 @@ mod test {
         let server =
             Url::from_str("https://auth.example.com").expect("should parse a valid example server");
 
-        let test_validator = TestTokenValidator {
-            audiences: vec![audience],
-            issuers: vec![],
-            allow_any_audience: false,
-            key_pair: (key_id, jwk),
-            servers: vec![server],
-        };
+        let test_validator =
+            TestTokenValidator::single(vec![audience], vec![], false, (key_id, jwk), server);
 
         assert_eq!(test_validator.validate(jwt).await, None);
 
@@ -387,13 +426,8 @@ mod test {
         let server =
             Url::from_str("https://auth.example.com").expect("should parse a valid example server");
 
-        let test_validator = TestTokenValidator {
-            audiences: vec![audience],
-            issuers: vec![],
-            allow_any_audience: false,
-            key_pair: (key_id, jwk),
-            servers: vec![server],
-        };
+        let test_validator =
+            TestTokenValidator::single(vec![audience], vec![], false, (key_id, jwk), server);
 
         assert_eq!(test_validator.validate(jwt).await, None);
 
@@ -425,13 +459,8 @@ mod test {
         let server =
             Url::from_str("https://auth.example.com").expect("should parse a valid example server");
 
-        let test_validator = TestTokenValidator {
-            audiences: vec![audience],
-            issuers: vec![],
-            allow_any_audience: false,
-            key_pair: (key_id, jwk),
-            servers: vec![server],
-        };
+        let test_validator =
+            TestTokenValidator::single(vec![audience], vec![], false, (key_id, jwk), server);
 
         assert_eq!(test_validator.validate(jwt).await, None);
 
@@ -477,13 +506,8 @@ mod test {
         let server =
             Url::from_str("https://auth.example.com").expect("should parse a valid example server");
 
-        let test_validator = TestTokenValidator {
-            audiences: vec![audience],
-            issuers: vec![],
-            allow_any_audience: false,
-            key_pair: (key_id, jwk),
-            servers: vec![server],
-        };
+        let test_validator =
+            TestTokenValidator::single(vec![audience], vec![], false, (key_id, jwk), server);
 
         assert_eq!(
             test_validator
@@ -513,13 +537,8 @@ mod test {
             Url::from_str("https://auth.example.com").expect("should parse a valid example server");
 
         // allow_any_audience should skip audience validation entirely
-        let test_validator = TestTokenValidator {
-            audiences: vec![],
-            issuers: vec![],
-            allow_any_audience: true,
-            key_pair: (key_id, jwk),
-            servers: vec![server],
-        };
+        let test_validator =
+            TestTokenValidator::single(vec![], vec![], true, (key_id, jwk), server);
 
         let token = jwt.token().to_string();
         assert_eq!(test_validator.validate(jwt).await.unwrap().0.token(), token);
@@ -556,13 +575,8 @@ mod test {
         let server =
             Url::from_str("https://auth.example.com").expect("should parse a valid example server");
 
-        let test_validator = TestTokenValidator {
-            audiences: vec![],
-            issuers: vec![],
-            allow_any_audience: true,
-            key_pair: (key_id, jwk),
-            servers: vec![server],
-        };
+        let test_validator =
+            TestTokenValidator::single(vec![], vec![], true, (key_id, jwk), server);
 
         assert_eq!(
             test_validator
@@ -608,13 +622,13 @@ mod test {
             Url::from_str("https://auth.example.com").expect("should parse a valid example server");
 
         // With allow_any_audience=false and configured audiences, missing aud should fail
-        let test_validator = TestTokenValidator {
-            audiences: vec!["expected-audience".to_string()],
-            issuers: vec![],
-            allow_any_audience: false,
-            key_pair: (key_id, jwk),
-            servers: vec![server],
-        };
+        let test_validator = TestTokenValidator::single(
+            vec!["expected-audience".to_string()],
+            vec![],
+            false,
+            (key_id, jwk),
+            server,
+        );
 
         assert_eq!(test_validator.validate(jwt).await, None);
 
@@ -661,13 +675,13 @@ mod test {
         let server =
             Url::from_str("https://auth.example.com").expect("should parse a valid example server");
 
-        let test_validator = TestTokenValidator {
-            audiences: vec![expected_audience],
-            issuers: vec![],
-            allow_any_audience: false,
-            key_pair: (key_id, jwk),
-            servers: vec![server],
-        };
+        let test_validator = TestTokenValidator::single(
+            vec![expected_audience],
+            vec![],
+            false,
+            (key_id, jwk),
+            server,
+        );
 
         assert_eq!(test_validator.validate(jwt).await, None);
 
@@ -715,13 +729,8 @@ mod test {
         let server =
             Url::from_str("https://auth.example.com").expect("should parse a valid example server");
 
-        let test_validator = TestTokenValidator {
-            audiences: vec![audience],
-            issuers: vec![issuer],
-            allow_any_audience: false,
-            key_pair: (key_id, jwk),
-            servers: vec![server],
-        };
+        let test_validator =
+            TestTokenValidator::single(vec![audience], vec![issuer], false, (key_id, jwk), server);
 
         assert_eq!(
             test_validator
@@ -769,13 +778,8 @@ mod test {
         let server =
             Url::from_str("https://auth.example.com").expect("should parse a valid example server");
 
-        let test_validator = TestTokenValidator {
-            audiences: vec![audience],
-            issuers: vec![issuer],
-            allow_any_audience: false,
-            key_pair: (key_id, jwk),
-            servers: vec![server],
-        };
+        let test_validator =
+            TestTokenValidator::single(vec![audience], vec![issuer], false, (key_id, jwk), server);
 
         assert_eq!(test_validator.validate(jwt).await, None);
 
@@ -809,8 +813,9 @@ mod test {
             h
         };
 
-        // Token's `iss` matches the SECOND configured issuer, exercising the
-        // allowlist (any-match) semantics rather than just the first entry.
+        // The signing server has TWO issuers configured; the token's `iss`
+        // matches the second, exercising the per-server allowlist (any-match)
+        // semantics rather than just the first entry.
         let claims = json!({
             "aud": "test-audience",
             "iss": "https://auth.other.com",
@@ -824,16 +829,16 @@ mod test {
         let server =
             Url::from_str("https://auth.example.com").expect("should parse a valid example server");
 
-        let test_validator = TestTokenValidator {
-            audiences: vec![audience],
-            issuers: vec![
+        let test_validator = TestTokenValidator::single(
+            vec![audience],
+            vec![
                 "https://auth.example.com".to_string(),
                 "https://auth.other.com".to_string(),
             ],
-            allow_any_audience: false,
-            key_pair: (key_id, jwk),
-            servers: vec![server],
-        };
+            false,
+            (key_id, jwk),
+            server,
+        );
 
         assert_eq!(
             test_validator
@@ -882,13 +887,8 @@ mod test {
             Url::from_str("https://auth.example.com").expect("should parse a valid example server");
 
         // With configured issuers, a missing iss claim should fail
-        let test_validator = TestTokenValidator {
-            audiences: vec![audience],
-            issuers: vec![issuer],
-            allow_any_audience: false,
-            key_pair: (key_id, jwk),
-            servers: vec![server],
-        };
+        let test_validator =
+            TestTokenValidator::single(vec![audience], vec![issuer], false, (key_id, jwk), server);
 
         assert_eq!(test_validator.validate(jwt).await, None);
 
@@ -936,13 +936,161 @@ mod test {
             Url::from_str("https://auth.example.com").expect("should parse a valid example server");
 
         // Empty issuers list - issuer validation is skipped (backward compatible)
-        let test_validator = TestTokenValidator {
-            audiences: vec![audience],
-            issuers: vec![],
-            allow_any_audience: false,
-            key_pair: (key_id, jwk),
-            servers: vec![server],
+        let test_validator =
+            TestTokenValidator::single(vec![audience], vec![], false, (key_id, jwk), server);
+
+        assert_eq!(
+            test_validator
+                .validate(jwt)
+                .await
+                .expect("valid token")
+                .token
+                .token(),
+            token
+        );
+    }
+
+    // --- Multi-server issuer binding ---------------------------------------
+    //
+    // These exercise the case Dale flagged in review: with more than one
+    // configured server, issuer validation must be bound to the server whose
+    // JWKS verified the signature, not applied as one global allowlist.
+
+    #[traced_test]
+    #[tokio::test]
+    async fn it_rejects_token_signed_by_one_server_claiming_another_servers_issuer() {
+        use serde_json::json;
+
+        // Two servers share the same `kid` but use different signing secrets —
+        // the realistic collision that made a global issuer list exploitable.
+        let shared_kid = "shared-kid".to_string();
+        let (server_a_encode, server_a_decode) = create_key("DEADBEEF");
+        let (_server_b_encode, server_b_decode) = create_key("CAFED00D");
+
+        let server_a_url = Url::from_str("https://auth-a.example.com").expect("valid server A URL");
+        let server_b_url = Url::from_str("https://auth-b.example.com").expect("valid server B URL");
+
+        let in_the_future = chrono::Utc::now().timestamp() + 1000;
+
+        // Token is signed by SERVER A's key, but claims SERVER B's issuer.
+        let header = {
+            let mut h = Header::new(Algorithm::HS512);
+            h.kid = Some(shared_kid.clone());
+            h
         };
+        let claims = json!({
+            "aud": "test-audience",
+            "iss": "https://auth-b.example.com",
+            "exp": in_the_future,
+            "sub": "test user"
+        });
+        let token = encode(&header, &claims, &server_a_encode).expect("encode JWT");
+        let jwt = Authorization::bearer(&token).expect("create bearer token");
+
+        // Each server accepts only its own issuer.
+        let test_validator = TestTokenValidator::new(
+            vec!["test-audience".to_string()],
+            false,
+            vec![
+                TestServer {
+                    url: server_a_url,
+                    key_pair: (
+                        shared_kid.clone(),
+                        Jwk {
+                            alg: Some(KeyAlgorithm::HS512),
+                            decoding_key: server_a_decode,
+                        },
+                    ),
+                    issuers: vec!["https://auth-a.example.com".to_string()],
+                },
+                TestServer {
+                    url: server_b_url,
+                    key_pair: (
+                        shared_kid,
+                        Jwk {
+                            alg: Some(KeyAlgorithm::HS512),
+                            decoding_key: server_b_decode,
+                        },
+                    ),
+                    issuers: vec!["https://auth-b.example.com".to_string()],
+                },
+            ],
+        );
+
+        // Server A verifies the signature but rejects `iss=B` (InvalidIssuer);
+        // Server B would accept `iss=B` but its key fails the signature. So the
+        // token is rejected overall — exactly the cross-server leak being closed.
+        assert_eq!(test_validator.validate(jwt).await, None);
+
+        logs_assert(|lines: &[&str]| {
+            lines
+                .iter()
+                .filter(|line| line.contains("WARN"))
+                .any(|line| line.contains("InvalidIssuer"))
+                .then_some(())
+                .ok_or("Expected InvalidIssuer warning from the signing server".to_string())
+        });
+    }
+
+    #[tokio::test]
+    async fn it_validates_token_against_its_own_servers_issuer_with_multiple_servers() {
+        use serde_json::json;
+
+        // Two servers, distinct keys and issuers. A token signed by server B's
+        // key and claiming server B's issuer must validate, even though server A
+        // is also configured with a different issuer.
+        let kid_a = "kid-a".to_string();
+        let kid_b = "kid-b".to_string();
+        let (_server_a_encode, server_a_decode) = create_key("DEADBEEF");
+        let (server_b_encode, server_b_decode) = create_key("CAFED00D");
+
+        let server_a_url = Url::from_str("https://auth-a.example.com").expect("valid server A URL");
+        let server_b_url = Url::from_str("https://auth-b.example.com").expect("valid server B URL");
+
+        let in_the_future = chrono::Utc::now().timestamp() + 1000;
+
+        let header = {
+            let mut h = Header::new(Algorithm::HS512);
+            h.kid = Some(kid_b.clone());
+            h
+        };
+        let claims = json!({
+            "aud": "test-audience",
+            "iss": "https://auth-b.example.com",
+            "exp": in_the_future,
+            "sub": "test user"
+        });
+        let token = encode(&header, &claims, &server_b_encode).expect("encode JWT");
+        let jwt = Authorization::bearer(&token).expect("create bearer token");
+
+        let test_validator = TestTokenValidator::new(
+            vec!["test-audience".to_string()],
+            false,
+            vec![
+                TestServer {
+                    url: server_a_url,
+                    key_pair: (
+                        kid_a,
+                        Jwk {
+                            alg: Some(KeyAlgorithm::HS512),
+                            decoding_key: server_a_decode,
+                        },
+                    ),
+                    issuers: vec!["https://auth-a.example.com".to_string()],
+                },
+                TestServer {
+                    url: server_b_url,
+                    key_pair: (
+                        kid_b,
+                        Jwk {
+                            alg: Some(KeyAlgorithm::HS512),
+                            decoding_key: server_b_decode,
+                        },
+                    ),
+                    issuers: vec!["https://auth-b.example.com".to_string()],
+                },
+            ],
+        );
 
         assert_eq!(
             test_validator
@@ -972,13 +1120,8 @@ mod test {
         let server =
             Url::from_str("https://auth.example.com").expect("should parse a valid example server");
 
-        let test_validator = TestTokenValidator {
-            audiences: vec![audience],
-            issuers: vec![],
-            allow_any_audience: false,
-            key_pair: (key_id, jwk),
-            servers: vec![server],
-        };
+        let test_validator =
+            TestTokenValidator::single(vec![audience], vec![], false, (key_id, jwk), server);
 
         assert_eq!(test_validator.validate(jwt).await, None);
 
@@ -1013,13 +1156,13 @@ mod test {
         let server =
             Url::from_str("https://auth.example.com").expect("should parse a valid example server");
 
-        let test_validator = TestTokenValidator {
-            audiences: vec!["test-audience".to_string()],
-            issuers: vec![],
-            allow_any_audience: false,
-            key_pair: (key_id, jwk),
-            servers: vec![server],
-        };
+        let test_validator = TestTokenValidator::single(
+            vec!["test-audience".to_string()],
+            vec![],
+            false,
+            (key_id, jwk),
+            server,
+        );
 
         test_validator
             .validate(jwt)

--- a/crates/apollo-mcp-server/src/auth/valid_token.rs
+++ b/crates/apollo-mcp-server/src/auth/valid_token.rs
@@ -25,6 +25,20 @@ impl Deref for ValidToken {
     }
 }
 
+/// A signing key resolved from an authorization server, together with that
+/// server's discovered issuer identifier.
+///
+/// `issuer` is the `iss` value the authorization server advertises in its
+/// discovery metadata. It is used to bind issuer validation to the server
+/// whose JWKS verified the signature: a token's `iss` claim must equal this
+/// value, so a token signed by one configured server cannot pass by claiming
+/// a different configured server's issuer. `None` when the server's issuer
+/// could not be determined.
+pub(super) struct VerificationKey {
+    pub(super) jwk: Jwk,
+    pub(super) issuer: Option<String>,
+}
+
 /// Trait to handle validation of tokens
 pub(super) trait ValidateToken {
     /// Whether to skip audience validation (allow any audience)
@@ -33,15 +47,15 @@ pub(super) trait ValidateToken {
     /// Get the list of allowed audiences
     fn get_audiences(&self) -> &[String];
 
-    /// Get the accepted issuers for tokens verified by `server`'s JWKS
-    /// (empty = skip issuer validation for that server).
-    fn get_issuers_for(&self, server: &Url) -> &[String];
+    /// Get the list of accepted issuers (empty = skip issuer validation)
+    fn get_issuers(&self) -> &[String];
 
     /// Get the available upstream servers
-    fn get_servers(&self) -> &[Url];
+    fn get_servers(&self) -> &Vec<Url>;
 
-    /// Fetch the key by its ID
-    async fn get_key(&self, server: &Url, key_id: &str) -> Option<Jwk>;
+    /// Fetch the signing key by its ID, along with the issuing server's
+    /// discovered issuer identifier.
+    async fn get_key(&self, server: &Url, key_id: &str) -> Option<VerificationKey>;
 
     /// Attempt to validate a token against the validator
     async fn validate(&self, token: Authorization<Bearer>) -> Option<ValidToken> {
@@ -122,14 +136,13 @@ pub(super) trait ValidateToken {
         let key_id = header.kid.as_ref()?;
 
         for server in self.get_servers() {
-            let Some(jwk) = self.get_key(server, key_id).await else {
+            let Some(VerificationKey {
+                jwk,
+                issuer: discovered_issuer,
+            }) = self.get_key(server, key_id).await
+            else {
                 continue;
             };
-
-            // Issuers accepted for tokens this server signs. Bound to the server
-            // whose JWKS verifies the signature, so a token signed by one server
-            // cannot pass by claiming another configured server's issuer.
-            let issuers = self.get_issuers_for(server);
 
             let validation = {
                 let Some(alg) = jwk.alg else {
@@ -163,8 +176,8 @@ pub(super) trait ValidateToken {
                     val.set_audience(self.get_audiences());
                 }
 
-                if !issuers.is_empty() {
-                    val.set_issuer(issuers);
+                if !self.get_issuers().is_empty() {
+                    val.set_issuer(self.get_issuers());
                 }
 
                 val
@@ -180,13 +193,45 @@ pub(super) trait ValidateToken {
                         warn!("Token is missing the required `aud` claim");
                         break;
                     }
-                    // When issuer validation is enabled for this server, explicitly
-                    // reject tokens with a missing `iss` claim. The `jsonwebtoken`
-                    // crate skips its own issuer check when the claim is absent from
-                    // the raw JWT, so we enforce it here.
-                    if !issuers.is_empty() && token_data.claims.iss.is_none() {
-                        warn!("Token is missing the required `iss` claim");
-                        break;
+                    if !self.get_issuers().is_empty() {
+                        // When issuer validation is enabled, explicitly reject tokens
+                        // with a missing `iss` claim. The `jsonwebtoken` crate skips its
+                        // own issuer check when the claim is absent from the raw JWT,
+                        // so we enforce it here.
+                        let Some(token_issuer) = token_data.claims.iss.as_deref() else {
+                            warn!("Token is missing the required `iss` claim");
+                            break;
+                        };
+
+                        // Bind the issuer to the server whose JWKS verified the
+                        // signature: the token's `iss` must equal that server's
+                        // discovered issuer identifier. This prevents a token signed
+                        // by one configured server from being accepted while claiming
+                        // a different configured server's issuer. Fail closed if the
+                        // server's issuer could not be determined.
+                        // Bind the issuer to the server whose JWKS verified the
+                        // signature: the token's `iss` must equal that server's
+                        // discovered issuer identifier. This prevents a token signed
+                        // by one configured server from being accepted while claiming
+                        // a different configured server's issuer. Fail closed if the
+                        // server's issuer could not be determined.
+                        match discovered_issuer.as_deref() {
+                            Some(server_issuer) if server_issuer == token_issuer => {}
+                            Some(server_issuer) => {
+                                warn!(
+                                    token_issuer = %token_issuer,
+                                    server_issuer = %server_issuer,
+                                    "Token `iss` does not match the issuer of the server that signed it"
+                                );
+                                break;
+                            }
+                            None => {
+                                warn!(
+                                    "Cannot verify token `iss`: the signing server did not advertise an issuer"
+                                );
+                                break;
+                            }
+                        }
                     }
                     return Some(ValidToken {
                         token,
@@ -213,38 +258,47 @@ mod test {
     use tracing_test::traced_test;
     use url::Url;
 
-    use super::ValidateToken;
+    use super::{ValidateToken, VerificationKey};
 
     /// A single upstream server in the test validator: its URL, the one
-    /// `(kid, jwk)` it will serve, and the issuers configured for it.
+    /// `(kid, jwk)` it will serve, and the issuer it advertises in discovery.
     struct TestServer {
         url: Url,
         key_pair: (String, Jwk),
-        issuers: Vec<String>,
+        discovered_issuer: Option<String>,
     }
 
     struct TestTokenValidator {
         audiences: Vec<String>,
+        issuers: Vec<String>,
         allow_any_audience: bool,
         servers: Vec<TestServer>,
-        /// Parsed server URLs, owned so `get_servers` can return a slice.
+        /// Parsed server URLs, owned so `get_servers` can return a `&Vec<Url>`.
         /// Kept index-aligned with `servers`.
         server_urls: Vec<Url>,
     }
 
     impl TestTokenValidator {
-        /// Build a validator from `(server, key_pair, issuers)` tuples.
-        fn new(audiences: Vec<String>, allow_any_audience: bool, servers: Vec<TestServer>) -> Self {
+        fn new(
+            audiences: Vec<String>,
+            issuers: Vec<String>,
+            allow_any_audience: bool,
+            servers: Vec<TestServer>,
+        ) -> Self {
             let server_urls = servers.iter().map(|s| s.url.clone()).collect();
             Self {
                 audiences,
+                issuers,
                 allow_any_audience,
                 servers,
                 server_urls,
             }
         }
 
-        /// Convenience for the common single-server case.
+        /// Convenience for the common single-server case. The server's
+        /// discovered issuer defaults to the configured server URL with any
+        /// trailing slash trimmed, matching how a compliant server advertises
+        /// its issuer identifier; pass `discovered_issuer` to override.
         fn single(
             audiences: Vec<String>,
             issuers: Vec<String>,
@@ -252,13 +306,15 @@ mod test {
             key_pair: (String, Jwk),
             server: Url,
         ) -> Self {
+            let discovered_issuer = Some(server.as_str().trim_end_matches('/').to_string());
             Self::new(
                 audiences,
+                issuers,
                 allow_any_audience,
                 vec![TestServer {
                     url: server,
                     key_pair,
-                    issuers,
+                    discovered_issuer,
                 }],
             )
         }
@@ -273,27 +329,21 @@ mod test {
             &self.audiences
         }
 
-        fn get_issuers_for(&self, server: &Url) -> &[String] {
-            self.server_urls
-                .iter()
-                .zip(self.servers.iter())
-                .find(|(url, _)| *url == server)
-                .map(|(_, s)| s.issuers.as_slice())
-                .unwrap_or_default()
+        fn get_issuers(&self) -> &[String] {
+            &self.issuers
         }
 
-        fn get_servers(&self) -> &[url::Url] {
+        fn get_servers(&self) -> &Vec<url::Url> {
             &self.server_urls
         }
 
-        async fn get_key(&self, server: &url::Url, key_id: &str) -> Option<jwks::Jwk> {
+        async fn get_key(&self, server: &url::Url, key_id: &str) -> Option<VerificationKey> {
             // Find the requested server, then return its key only if the `kid` matches.
             let test_server = self.servers.iter().find(|s| &s.url == server)?;
-            test_server
-                .key_pair
-                .0
-                .eq(key_id)
-                .then_some(test_server.key_pair.1.clone())
+            test_server.key_pair.0.eq(key_id).then(|| VerificationKey {
+                jwk: test_server.key_pair.1.clone(),
+                issuer: test_server.discovered_issuer.clone(),
+            })
         }
     }
 
@@ -813,9 +863,10 @@ mod test {
             h
         };
 
-        // The signing server has TWO issuers configured; the token's `iss`
-        // matches the second, exercising the per-server allowlist (any-match)
-        // semantics rather than just the first entry.
+        // The configured allowlist holds two issuers. The signing server
+        // advertises the SECOND one as its discovered issuer, and the token's
+        // `iss` matches it — exercising both the allowlist (any-match) and the
+        // discovery binding to the actual signer.
         let claims = json!({
             "aud": "test-audience",
             "iss": "https://auth.other.com",
@@ -829,15 +880,18 @@ mod test {
         let server =
             Url::from_str("https://auth.example.com").expect("should parse a valid example server");
 
-        let test_validator = TestTokenValidator::single(
+        let test_validator = TestTokenValidator::new(
             vec![audience],
             vec![
                 "https://auth.example.com".to_string(),
                 "https://auth.other.com".to_string(),
             ],
             false,
-            (key_id, jwk),
-            server,
+            vec![TestServer {
+                url: server,
+                key_pair: (key_id, jwk),
+                discovered_issuer: Some("https://auth.other.com".to_string()),
+            }],
         );
 
         assert_eq!(
@@ -952,9 +1006,10 @@ mod test {
 
     // --- Multi-server issuer binding ---------------------------------------
     //
-    // These exercise the case Dale flagged in review: with more than one
-    // configured server, issuer validation must be bound to the server whose
-    // JWKS verified the signature, not applied as one global allowlist.
+    // These exercise the cross-server case: issuer validation is bound to the
+    // discovered issuer of the server whose JWKS verified the signature, so a
+    // token signed by one server cannot pass by claiming another server's
+    // issuer — even when both issuers are in the configured allowlist.
 
     #[traced_test]
     #[tokio::test]
@@ -962,7 +1017,7 @@ mod test {
         use serde_json::json;
 
         // Two servers share the same `kid` but use different signing secrets —
-        // the realistic collision that made a global issuer list exploitable.
+        // the realistic collision that makes a cross-server claim worth testing.
         let shared_kid = "shared-kid".to_string();
         let (server_a_encode, server_a_decode) = create_key("DEADBEEF");
         let (_server_b_encode, server_b_decode) = create_key("CAFED00D");
@@ -987,9 +1042,14 @@ mod test {
         let token = encode(&header, &claims, &server_a_encode).expect("encode JWT");
         let jwt = Authorization::bearer(&token).expect("create bearer token");
 
-        // Each server accepts only its own issuer.
+        // Both issuers are in the allowlist, so the cross-server protection must
+        // come from the discovery binding, not the allowlist.
         let test_validator = TestTokenValidator::new(
             vec!["test-audience".to_string()],
+            vec![
+                "https://auth-a.example.com".to_string(),
+                "https://auth-b.example.com".to_string(),
+            ],
             false,
             vec![
                 TestServer {
@@ -1001,7 +1061,7 @@ mod test {
                             decoding_key: server_a_decode,
                         },
                     ),
-                    issuers: vec!["https://auth-a.example.com".to_string()],
+                    discovered_issuer: Some("https://auth-a.example.com".to_string()),
                 },
                 TestServer {
                     url: server_b_url,
@@ -1012,23 +1072,23 @@ mod test {
                             decoding_key: server_b_decode,
                         },
                     ),
-                    issuers: vec!["https://auth-b.example.com".to_string()],
+                    discovered_issuer: Some("https://auth-b.example.com".to_string()),
                 },
             ],
         );
 
-        // Server A verifies the signature but rejects `iss=B` (InvalidIssuer);
-        // Server B would accept `iss=B` but its key fails the signature. So the
-        // token is rejected overall — exactly the cross-server leak being closed.
+        // Server A verifies the signature but its discovered issuer
+        // (`auth-a`) does not match the token's `iss` (`auth-b`); server B's key
+        // fails the signature. So the token is rejected overall.
         assert_eq!(test_validator.validate(jwt).await, None);
 
         logs_assert(|lines: &[&str]| {
             lines
                 .iter()
                 .filter(|line| line.contains("WARN"))
-                .any(|line| line.contains("InvalidIssuer"))
+                .any(|line| line.contains("does not match the issuer of the server that signed it"))
                 .then_some(())
-                .ok_or("Expected InvalidIssuer warning from the signing server".to_string())
+                .ok_or("Expected issuer-mismatch warning from the signing server".to_string())
         });
     }
 
@@ -1036,9 +1096,9 @@ mod test {
     async fn it_validates_token_against_its_own_servers_issuer_with_multiple_servers() {
         use serde_json::json;
 
-        // Two servers, distinct keys and issuers. A token signed by server B's
-        // key and claiming server B's issuer must validate, even though server A
-        // is also configured with a different issuer.
+        // Two servers with distinct keys and issuers. A token signed by server
+        // B and claiming server B's issuer must validate, even though server A
+        // is also configured.
         let kid_a = "kid-a".to_string();
         let kid_b = "kid-b".to_string();
         let (_server_a_encode, server_a_decode) = create_key("DEADBEEF");
@@ -1065,6 +1125,10 @@ mod test {
 
         let test_validator = TestTokenValidator::new(
             vec!["test-audience".to_string()],
+            vec![
+                "https://auth-a.example.com".to_string(),
+                "https://auth-b.example.com".to_string(),
+            ],
             false,
             vec![
                 TestServer {
@@ -1076,7 +1140,7 @@ mod test {
                             decoding_key: server_a_decode,
                         },
                     ),
-                    issuers: vec!["https://auth-a.example.com".to_string()],
+                    discovered_issuer: Some("https://auth-a.example.com".to_string()),
                 },
                 TestServer {
                     url: server_b_url,
@@ -1087,7 +1151,7 @@ mod test {
                             decoding_key: server_b_decode,
                         },
                     ),
-                    issuers: vec!["https://auth-b.example.com".to_string()],
+                    discovered_issuer: Some("https://auth-b.example.com".to_string()),
                 },
             ],
         );

--- a/crates/apollo-mcp-server/src/auth/valid_token.rs
+++ b/crates/apollo-mcp-server/src/auth/valid_token.rs
@@ -33,6 +33,9 @@ pub(super) trait ValidateToken {
     /// Get the list of allowed audiences
     fn get_audiences(&self) -> &[String];
 
+    /// Get the list of accepted issuers (empty = skip issuer validation)
+    fn get_issuers(&self) -> &[String];
+
     /// Get the available upstream servers
     fn get_servers(&self) -> &Vec<Url>;
 
@@ -53,6 +56,11 @@ pub(super) trait ValidateToken {
             /// so this field defaults to an empty vec when absent.
             #[serde(default, deserialize_with = "deserialize_audience")]
             pub aud: Vec<String>,
+
+            /// The issuer of this token (`iss`). Optional in the struct so tokens
+            /// without it still deserialize; enforced in `validate` when issuers are configured.
+            #[serde(default)]
+            pub iss: Option<String>,
 
             /// The user who owns this token
             pub sub: String,
@@ -149,6 +157,10 @@ pub(super) trait ValidateToken {
                     val.set_audience(self.get_audiences());
                 }
 
+                if !self.get_issuers().is_empty() {
+                    val.set_issuer(self.get_issuers());
+                }
+
                 val
             };
 
@@ -160,6 +172,14 @@ pub(super) trait ValidateToken {
                     // so we enforce it here.
                     if !self.allow_any_audience() && token_data.claims.aud.is_empty() {
                         warn!("Token is missing the required `aud` claim");
+                        break;
+                    }
+                    // When issuer validation is enabled, explicitly reject tokens
+                    // with a missing `iss` claim. The `jsonwebtoken` crate skips its
+                    // own issuer check when the claim is absent from the raw JWT,
+                    // so we enforce it here.
+                    if !self.get_issuers().is_empty() && token_data.claims.iss.is_none() {
+                        warn!("Token is missing the required `iss` claim");
                         break;
                     }
                     return Some(ValidToken {
@@ -191,6 +211,7 @@ mod test {
 
     struct TestTokenValidator {
         audiences: Vec<String>,
+        issuers: Vec<String>,
         allow_any_audience: bool,
         key_pair: (String, Jwk),
         servers: Vec<Url>,
@@ -203,6 +224,10 @@ mod test {
 
         fn get_audiences(&self) -> &[String] {
             &self.audiences
+        }
+
+        fn get_issuers(&self) -> &[String] {
+            &self.issuers
         }
 
         fn get_servers(&self) -> &Vec<url::Url> {
@@ -284,6 +309,7 @@ mod test {
 
         let test_validator = TestTokenValidator {
             audiences: vec![audience],
+            issuers: vec![],
             allow_any_audience: false,
             key_pair: (key_id, jwk),
             servers: vec![server],
@@ -326,6 +352,7 @@ mod test {
 
         let test_validator = TestTokenValidator {
             audiences: vec![audience],
+            issuers: vec![],
             allow_any_audience: false,
             key_pair: (key_id, jwk),
             servers: vec![server],
@@ -362,6 +389,7 @@ mod test {
 
         let test_validator = TestTokenValidator {
             audiences: vec![audience],
+            issuers: vec![],
             allow_any_audience: false,
             key_pair: (key_id, jwk),
             servers: vec![server],
@@ -399,6 +427,7 @@ mod test {
 
         let test_validator = TestTokenValidator {
             audiences: vec![audience],
+            issuers: vec![],
             allow_any_audience: false,
             key_pair: (key_id, jwk),
             servers: vec![server],
@@ -450,6 +479,7 @@ mod test {
 
         let test_validator = TestTokenValidator {
             audiences: vec![audience],
+            issuers: vec![],
             allow_any_audience: false,
             key_pair: (key_id, jwk),
             servers: vec![server],
@@ -485,6 +515,7 @@ mod test {
         // allow_any_audience should skip audience validation entirely
         let test_validator = TestTokenValidator {
             audiences: vec![],
+            issuers: vec![],
             allow_any_audience: true,
             key_pair: (key_id, jwk),
             servers: vec![server],
@@ -527,6 +558,7 @@ mod test {
 
         let test_validator = TestTokenValidator {
             audiences: vec![],
+            issuers: vec![],
             allow_any_audience: true,
             key_pair: (key_id, jwk),
             servers: vec![server],
@@ -578,6 +610,7 @@ mod test {
         // With allow_any_audience=false and configured audiences, missing aud should fail
         let test_validator = TestTokenValidator {
             audiences: vec!["expected-audience".to_string()],
+            issuers: vec![],
             allow_any_audience: false,
             key_pair: (key_id, jwk),
             servers: vec![server],
@@ -630,6 +663,7 @@ mod test {
 
         let test_validator = TestTokenValidator {
             audiences: vec![expected_audience],
+            issuers: vec![],
             allow_any_audience: false,
             key_pair: (key_id, jwk),
             servers: vec![server],
@@ -645,6 +679,280 @@ mod test {
                 .then_some(())
                 .ok_or("Expected warning for validation failure".to_string())
         });
+    }
+
+    #[tokio::test]
+    async fn it_validates_jwt_with_matching_issuer() {
+        use serde_json::json;
+
+        let key_id = "some-example-id".to_string();
+        let (encode_key, decode_key) = create_key("DEADBEEF");
+        let jwk = Jwk {
+            alg: Some(KeyAlgorithm::HS512),
+            decoding_key: decode_key,
+        };
+
+        let audience = "test-audience".to_string();
+        let issuer = "https://auth.example.com".to_string();
+        let in_the_future = chrono::Utc::now().timestamp() + 1000;
+
+        let header = {
+            let mut h = Header::new(Algorithm::HS512);
+            h.kid = Some(key_id.clone());
+            h
+        };
+
+        let claims = json!({
+            "aud": "test-audience",
+            "iss": "https://auth.example.com",
+            "exp": in_the_future,
+            "sub": "test user"
+        });
+
+        let token = encode(&header, &claims, &encode_key).expect("encode JWT");
+        let jwt = Authorization::bearer(&token).expect("create bearer token");
+
+        let server =
+            Url::from_str("https://auth.example.com").expect("should parse a valid example server");
+
+        let test_validator = TestTokenValidator {
+            audiences: vec![audience],
+            issuers: vec![issuer],
+            allow_any_audience: false,
+            key_pair: (key_id, jwk),
+            servers: vec![server],
+        };
+
+        assert_eq!(
+            test_validator
+                .validate(jwt)
+                .await
+                .expect("valid token")
+                .token
+                .token(),
+            token
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn it_rejects_different_issuer() {
+        use serde_json::json;
+
+        let key_id = "some-example-id".to_string();
+        let (encode_key, decode_key) = create_key("DEADBEEF");
+        let jwk = Jwk {
+            alg: Some(KeyAlgorithm::HS512),
+            decoding_key: decode_key,
+        };
+
+        let audience = "test-audience".to_string();
+        let issuer = "https://auth.example.com".to_string();
+        let in_the_future = chrono::Utc::now().timestamp() + 1000;
+
+        let header = {
+            let mut h = Header::new(Algorithm::HS512);
+            h.kid = Some(key_id.clone());
+            h
+        };
+
+        let claims = json!({
+            "aud": "test-audience",
+            "iss": "https://evil.example.com",
+            "exp": in_the_future,
+            "sub": "test user"
+        });
+
+        let token = encode(&header, &claims, &encode_key).expect("encode JWT");
+        let jwt = Authorization::bearer(&token).expect("create bearer token");
+
+        let server =
+            Url::from_str("https://auth.example.com").expect("should parse a valid example server");
+
+        let test_validator = TestTokenValidator {
+            audiences: vec![audience],
+            issuers: vec![issuer],
+            allow_any_audience: false,
+            key_pair: (key_id, jwk),
+            servers: vec![server],
+        };
+
+        assert_eq!(test_validator.validate(jwt).await, None);
+
+        logs_assert(|lines: &[&str]| {
+            lines
+                .iter()
+                .filter(|line| line.contains("WARN"))
+                .any(|line| line.contains("InvalidIssuer"))
+                .then_some(())
+                .ok_or("Expected warning for validation failure".to_string())
+        });
+    }
+
+    #[tokio::test]
+    async fn it_validates_jwt_when_issuer_matches_any_configured() {
+        use serde_json::json;
+
+        let key_id = "some-example-id".to_string();
+        let (encode_key, decode_key) = create_key("DEADBEEF");
+        let jwk = Jwk {
+            alg: Some(KeyAlgorithm::HS512),
+            decoding_key: decode_key,
+        };
+
+        let audience = "test-audience".to_string();
+        let in_the_future = chrono::Utc::now().timestamp() + 1000;
+
+        let header = {
+            let mut h = Header::new(Algorithm::HS512);
+            h.kid = Some(key_id.clone());
+            h
+        };
+
+        // Token's `iss` matches the SECOND configured issuer, exercising the
+        // allowlist (any-match) semantics rather than just the first entry.
+        let claims = json!({
+            "aud": "test-audience",
+            "iss": "https://auth.other.com",
+            "exp": in_the_future,
+            "sub": "test user"
+        });
+
+        let token = encode(&header, &claims, &encode_key).expect("encode JWT");
+        let jwt = Authorization::bearer(&token).expect("create bearer token");
+
+        let server =
+            Url::from_str("https://auth.example.com").expect("should parse a valid example server");
+
+        let test_validator = TestTokenValidator {
+            audiences: vec![audience],
+            issuers: vec![
+                "https://auth.example.com".to_string(),
+                "https://auth.other.com".to_string(),
+            ],
+            allow_any_audience: false,
+            key_pair: (key_id, jwk),
+            servers: vec![server],
+        };
+
+        assert_eq!(
+            test_validator
+                .validate(jwt)
+                .await
+                .expect("valid token")
+                .token
+                .token(),
+            token
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn it_rejects_missing_issuer_when_issuer_required() {
+        use serde_json::json;
+
+        let key_id = "some-example-id".to_string();
+        let (encode_key, decode_key) = create_key("DEADBEEF");
+        let jwk = Jwk {
+            alg: Some(KeyAlgorithm::HS512),
+            decoding_key: decode_key,
+        };
+
+        let audience = "test-audience".to_string();
+        let issuer = "https://auth.example.com".to_string();
+        let in_the_future = chrono::Utc::now().timestamp() + 1000;
+
+        // Create a JWT without the `iss` claim
+        let header = {
+            let mut h = Header::new(Algorithm::HS512);
+            h.kid = Some(key_id.clone());
+            h
+        };
+
+        let claims = json!({
+            "aud": "test-audience",
+            "exp": in_the_future,
+            "sub": "test user"
+        });
+
+        let token = encode(&header, &claims, &encode_key).expect("encode JWT");
+        let jwt = Authorization::bearer(&token).expect("create bearer token");
+
+        let server =
+            Url::from_str("https://auth.example.com").expect("should parse a valid example server");
+
+        // With configured issuers, a missing iss claim should fail
+        let test_validator = TestTokenValidator {
+            audiences: vec![audience],
+            issuers: vec![issuer],
+            allow_any_audience: false,
+            key_pair: (key_id, jwk),
+            servers: vec![server],
+        };
+
+        assert_eq!(test_validator.validate(jwt).await, None);
+
+        logs_assert(|lines: &[&str]| {
+            lines
+                .iter()
+                .filter(|line| line.contains("WARN"))
+                .any(|line| line.contains("missing the required `iss` claim"))
+                .then_some(())
+                .ok_or("Expected warning for missing iss claim".to_string())
+        });
+    }
+
+    #[tokio::test]
+    async fn it_validates_jwt_with_no_issuers_configured() {
+        use serde_json::json;
+
+        let key_id = "some-example-id".to_string();
+        let (encode_key, decode_key) = create_key("DEADBEEF");
+        let jwk = Jwk {
+            alg: Some(KeyAlgorithm::HS512),
+            decoding_key: decode_key,
+        };
+
+        let audience = "test-audience".to_string();
+        let in_the_future = chrono::Utc::now().timestamp() + 1000;
+
+        // No `iss` claim at all - should still be valid when issuers are not configured
+        let header = {
+            let mut h = Header::new(Algorithm::HS512);
+            h.kid = Some(key_id.clone());
+            h
+        };
+
+        let claims = json!({
+            "aud": "test-audience",
+            "exp": in_the_future,
+            "sub": "test user"
+        });
+
+        let token = encode(&header, &claims, &encode_key).expect("encode JWT");
+        let jwt = Authorization::bearer(&token).expect("create bearer token");
+
+        let server =
+            Url::from_str("https://auth.example.com").expect("should parse a valid example server");
+
+        // Empty issuers list - issuer validation is skipped (backward compatible)
+        let test_validator = TestTokenValidator {
+            audiences: vec![audience],
+            issuers: vec![],
+            allow_any_audience: false,
+            key_pair: (key_id, jwk),
+            servers: vec![server],
+        };
+
+        assert_eq!(
+            test_validator
+                .validate(jwt)
+                .await
+                .expect("valid token")
+                .token
+                .token(),
+            token
+        );
     }
 
     #[traced_test]
@@ -666,6 +974,7 @@ mod test {
 
         let test_validator = TestTokenValidator {
             audiences: vec![audience],
+            issuers: vec![],
             allow_any_audience: false,
             key_pair: (key_id, jwk),
             servers: vec![server],
@@ -706,6 +1015,7 @@ mod test {
 
         let test_validator = TestTokenValidator {
             audiences: vec!["test-audience".to_string()],
+            issuers: vec![],
             allow_any_audience: false,
             key_pair: (key_id, jwk),
             servers: vec![server],

--- a/crates/apollo-mcp-server/src/auth/valid_token.rs
+++ b/crates/apollo-mcp-server/src/auth/valid_token.rs
@@ -32,11 +32,10 @@ impl Deref for ValidToken {
 /// discovery metadata. It is used to bind issuer validation to the server
 /// whose JWKS verified the signature: a token's `iss` claim must equal this
 /// value, so a token signed by one configured server cannot pass by claiming
-/// a different configured server's issuer. `None` when the server's issuer
-/// could not be determined.
+/// a different configured server's issuer.
 pub(super) struct VerificationKey {
     pub(super) jwk: Jwk,
-    pub(super) issuer: Option<String>,
+    pub(super) issuer: String,
 }
 
 /// Trait to handle validation of tokens
@@ -207,30 +206,14 @@ pub(super) trait ValidateToken {
                         // signature: the token's `iss` must equal that server's
                         // discovered issuer identifier. This prevents a token signed
                         // by one configured server from being accepted while claiming
-                        // a different configured server's issuer. Fail closed if the
-                        // server's issuer could not be determined.
-                        // Bind the issuer to the server whose JWKS verified the
-                        // signature: the token's `iss` must equal that server's
-                        // discovered issuer identifier. This prevents a token signed
-                        // by one configured server from being accepted while claiming
-                        // a different configured server's issuer. Fail closed if the
-                        // server's issuer could not be determined.
-                        match discovered_issuer.as_deref() {
-                            Some(server_issuer) if server_issuer == token_issuer => {}
-                            Some(server_issuer) => {
-                                warn!(
-                                    token_issuer = %token_issuer,
-                                    server_issuer = %server_issuer,
-                                    "Token `iss` does not match the issuer of the server that signed it"
-                                );
-                                break;
-                            }
-                            None => {
-                                warn!(
-                                    "Cannot verify token `iss`: the signing server did not advertise an issuer"
-                                );
-                                break;
-                            }
+                        // a different configured server's issuer.
+                        if discovered_issuer != token_issuer {
+                            warn!(
+                                token_issuer = %token_issuer,
+                                server_issuer = %discovered_issuer,
+                                "Token `iss` does not match the issuer of the server that signed it"
+                            );
+                            break;
                         }
                     }
                     return Some(ValidToken {
@@ -265,7 +248,7 @@ mod test {
     struct TestServer {
         url: Url,
         key_pair: (String, Jwk),
-        discovered_issuer: Option<String>,
+        discovered_issuer: String,
     }
 
     struct TestTokenValidator {
@@ -306,7 +289,7 @@ mod test {
             key_pair: (String, Jwk),
             server: Url,
         ) -> Self {
-            let discovered_issuer = Some(server.as_str().trim_end_matches('/').to_string());
+            let discovered_issuer = server.as_str().trim_end_matches('/').to_string();
             Self::new(
                 audiences,
                 issuers,
@@ -890,7 +873,7 @@ mod test {
             vec![TestServer {
                 url: server,
                 key_pair: (key_id, jwk),
-                discovered_issuer: Some("https://auth.other.com".to_string()),
+                discovered_issuer: "https://auth.other.com".to_string(),
             }],
         );
 
@@ -1061,7 +1044,7 @@ mod test {
                             decoding_key: server_a_decode,
                         },
                     ),
-                    discovered_issuer: Some("https://auth-a.example.com".to_string()),
+                    discovered_issuer: "https://auth-a.example.com".to_string(),
                 },
                 TestServer {
                     url: server_b_url,
@@ -1072,7 +1055,7 @@ mod test {
                             decoding_key: server_b_decode,
                         },
                     ),
-                    discovered_issuer: Some("https://auth-b.example.com".to_string()),
+                    discovered_issuer: "https://auth-b.example.com".to_string(),
                 },
             ],
         );
@@ -1140,7 +1123,7 @@ mod test {
                             decoding_key: server_a_decode,
                         },
                     ),
-                    discovered_issuer: Some("https://auth-a.example.com".to_string()),
+                    discovered_issuer: "https://auth-a.example.com".to_string(),
                 },
                 TestServer {
                     url: server_b_url,
@@ -1151,7 +1134,7 @@ mod test {
                             decoding_key: server_b_decode,
                         },
                     ),
-                    discovered_issuer: Some("https://auth-b.example.com".to_string()),
+                    discovered_issuer: "https://auth-b.example.com".to_string(),
                 },
             ],
         );

--- a/docs/source/auth.mdx
+++ b/docs/source/auth.mdx
@@ -60,9 +60,9 @@ Skipping audience validation reduces security. Only use `allow_any_audience: tru
 
 ## Configure allowed issuers
 
-Specify which JWT issuers can access your MCP Server. Configure issuer validation per authorization server, so each server's accepted issuers apply only to the tokens signed by its own keys. This matches the per-JWKS `issuers` behavior in [JWT authentication for GraphOS Router](/graphos/routing/security/jwt).
+Specify which JWT issuers Apollo MCP Server accepts. Configure issuer validation per authorization server, so each server's accepted issuers apply only to the tokens signed by its own keys. This matches the per-JWKS `issuers` behavior in [JWT authentication for GraphOS Router](/graphos/routing/security/jwt).
 
-To configure issuers, give a server entry the object form with a `url` and an `issuers` list:
+To configure issuers, provide a server entry in object form with a `url` and an `issuers` list:
 
 ```yaml title="mcp.yaml"
 transport:

--- a/docs/source/auth.mdx
+++ b/docs/source/auth.mdx
@@ -60,22 +60,43 @@ Skipping audience validation reduces security. Only use `allow_any_audience: tru
 
 ## Configuring allowed issuers
 
-You can specify which JWT issuers are allowed to access your MCP Server.
+You can specify which JWT issuers are allowed to access your MCP Server. Issuer validation is configured per authorization server, so that each server's accepted issuers apply only to tokens its own keys signed. This matches the per-JWKS `issuers` behavior in [GraphOS Router's JWT authentication](/graphos/routing/security/jwt).
+
+To configure issuers, give a server entry the object form with a `url` and an `issuers` list:
 
 ```yaml title="mcp.yaml"
 transport:
   type: streamable_http
   auth:
     servers:
-      - https://auth.example.com
-    issuers:
-      - https://auth.example.com
-      - https://auth.other.com
+      - url: https://auth.example.com
+        issuers:
+          - https://auth.example.com
+      - url: https://auth.other.com
+        issuers:
+          - https://auth.other.com
 ```
 
-Set `issuers` to a list of accepted issuer values. The JWT's `iss` claim must match one of these values for the token to be considered valid. The server rejects a token with `401 Unauthorized` when its `iss` claim is missing or does not match any configured issuer.
+When a server entry lists `issuers`, a token whose signature is verified by that server's keys must carry an `iss` claim matching one of the listed values. The server rejects a token with `401 Unauthorized` when its `iss` claim is missing or does not match an accepted issuer for the server that signed it.
 
-When `issuers` is empty (the default), the server skips issuer validation entirely, so your existing configurations are unaffected. To validate the source of every token, set `issuers` to the exact issuer values your OAuth servers use.
+A server entry written as a bare URL string skips issuer validation for that server, so existing configurations are unaffected:
+
+```yaml title="mcp.yaml"
+transport:
+  type: streamable_http
+  auth:
+    servers:
+      - https://auth.example.com # no issuer validation
+      - url: https://auth.other.com # issuer validation enabled
+        issuers:
+          - https://auth.other.com
+```
+
+<Note>
+
+Binding issuers to each server prevents a token signed by one configured server from being accepted while claiming a different configured server's issuer. To validate the source of every token, give each server its own `issuers` list.
+
+</Note>
 
 ## Configure scope enforcement
 

--- a/docs/source/auth.mdx
+++ b/docs/source/auth.mdx
@@ -73,9 +73,9 @@ transport:
       - https://auth.other.com
 ```
 
-Set `issuers` to a list of accepted issuer values. The JWT's `iss` claim must match one of these values for the token to be considered valid. A token whose `iss` claim is missing or does not match any configured issuer is rejected with `401 Unauthorized`.
+Set `issuers` to a list of accepted issuer values. The JWT's `iss` claim must match one of these values for the token to be considered valid. The server rejects a token with `401 Unauthorized` when its `iss` claim is missing or does not match any configured issuer.
 
-When `issuers` is empty (the default), issuer validation is skipped entirely, so existing configurations are unaffected.
+When `issuers` is empty (the default), the server skips issuer validation entirely, so your existing configurations are unaffected. To validate the source of every token, set `issuers` to the exact issuer values your OAuth servers use.
 
 ## Configure scope enforcement
 

--- a/docs/source/auth.mdx
+++ b/docs/source/auth.mdx
@@ -60,43 +60,24 @@ Skipping audience validation reduces security. Only use `allow_any_audience: tru
 
 ## Configure allowed issuers
 
-Specify which JWT issuers Apollo MCP Server accepts. Configure issuer validation per authorization server, so each server's accepted issuers apply only to the tokens signed by its own keys. This matches the per-JWKS `issuers` behavior in [JWT authentication for GraphOS Router](/graphos/routing/security/jwt).
-
-To configure issuers, provide a server entry in object form with a `url` and an `issuers` list:
+Specify which JWT issuers Apollo MCP Server accepts.
 
 ```yaml title="mcp.yaml"
 transport:
   type: streamable_http
   auth:
     servers:
-      - url: "https://auth.example.com"
-        issuers:
-          - "https://auth.example.com"
-      - url: "https://auth.other.com"
-        issuers:
-          - "https://auth.other.com"
+      - "https://auth.example.com"
+    issuers:
+      - "https://auth.example.com"
+      - "https://auth.other.com"
 ```
 
-When a server entry lists `issuers`, a token whose signature that server's keys verify must carry an `iss` claim matching one of the listed values. The server rejects a token with `401 Unauthorized` when its `iss` claim is missing or does not match an accepted issuer for the server that signed it.
+Set `issuers` to a list of accepted issuer values. The JWT's `iss` claim must match one of these values for the token to be valid. The server rejects a token with `401 Unauthorized` when its `iss` claim is missing or does not match any configured issuer.
 
-A server entry written as a bare URL string skips issuer validation for that server, so your existing configurations are unaffected:
+The server also binds the `iss` claim to the authorization server that signed the token: the claim must equal the issuer that server advertises in its discovery metadata. This means a token signed by one configured server cannot be accepted while it claims a different configured server's issuer, which keeps issuer validation correct when you delegate to multiple servers.
 
-```yaml title="mcp.yaml"
-transport:
-  type: streamable_http
-  auth:
-    servers:
-      - "https://auth.example.com" # No issuer validation
-      - url: "https://auth.other.com" # Issuer validation enabled
-        issuers:
-          - "https://auth.other.com"
-```
-
-<Note>
-
-Binding issuers to each server prevents a token signed by one configured server from being accepted while it claims a different configured server's issuer. To validate the source of every token, give each server its own `issuers` list.
-
-</Note>
+When `issuers` is empty (the default), the server skips issuer validation, so your existing configurations are unaffected. To validate the source of every token, set `issuers` to the exact issuer values your OAuth servers use.
 
 ## Configure scope enforcement
 

--- a/docs/source/auth.mdx
+++ b/docs/source/auth.mdx
@@ -58,9 +58,9 @@ Skipping audience validation reduces security. Only use `allow_any_audience: tru
 
 </Caution>
 
-## Configuring allowed issuers
+## Configure allowed issuers
 
-You can specify which JWT issuers are allowed to access your MCP Server. Issuer validation is configured per authorization server, so that each server's accepted issuers apply only to tokens its own keys signed. This matches the per-JWKS `issuers` behavior in [GraphOS Router's JWT authentication](/graphos/routing/security/jwt).
+Specify which JWT issuers can access your MCP Server. Configure issuer validation per authorization server, so each server's accepted issuers apply only to the tokens signed by its own keys. This matches the per-JWKS `issuers` behavior in [JWT authentication for GraphOS Router](/graphos/routing/security/jwt).
 
 To configure issuers, give a server entry the object form with a `url` and an `issuers` list:
 
@@ -69,32 +69,32 @@ transport:
   type: streamable_http
   auth:
     servers:
-      - url: https://auth.example.com
+      - url: "https://auth.example.com"
         issuers:
-          - https://auth.example.com
-      - url: https://auth.other.com
+          - "https://auth.example.com"
+      - url: "https://auth.other.com"
         issuers:
-          - https://auth.other.com
+          - "https://auth.other.com"
 ```
 
-When a server entry lists `issuers`, a token whose signature is verified by that server's keys must carry an `iss` claim matching one of the listed values. The server rejects a token with `401 Unauthorized` when its `iss` claim is missing or does not match an accepted issuer for the server that signed it.
+When a server entry lists `issuers`, a token whose signature that server's keys verify must carry an `iss` claim matching one of the listed values. The server rejects a token with `401 Unauthorized` when its `iss` claim is missing or does not match an accepted issuer for the server that signed it.
 
-A server entry written as a bare URL string skips issuer validation for that server, so existing configurations are unaffected:
+A server entry written as a bare URL string skips issuer validation for that server, so your existing configurations are unaffected:
 
 ```yaml title="mcp.yaml"
 transport:
   type: streamable_http
   auth:
     servers:
-      - https://auth.example.com # no issuer validation
-      - url: https://auth.other.com # issuer validation enabled
+      - "https://auth.example.com" # No issuer validation
+      - url: "https://auth.other.com" # Issuer validation enabled
         issuers:
-          - https://auth.other.com
+          - "https://auth.other.com"
 ```
 
 <Note>
 
-Binding issuers to each server prevents a token signed by one configured server from being accepted while claiming a different configured server's issuer. To validate the source of every token, give each server its own `issuers` list.
+Binding issuers to each server prevents a token signed by one configured server from being accepted while it claims a different configured server's issuer. To validate the source of every token, give each server its own `issuers` list.
 
 </Note>
 

--- a/docs/source/auth.mdx
+++ b/docs/source/auth.mdx
@@ -58,6 +58,25 @@ Skipping audience validation reduces security. Only use `allow_any_audience: tru
 
 </Caution>
 
+## Configuring allowed issuers
+
+You can specify which JWT issuers are allowed to access your MCP Server.
+
+```yaml title="mcp.yaml"
+transport:
+  type: streamable_http
+  auth:
+    servers:
+      - https://auth.example.com
+    issuers:
+      - https://auth.example.com
+      - https://auth.other.com
+```
+
+Set `issuers` to a list of accepted issuer values. The JWT's `iss` claim must match one of these values for the token to be considered valid. A token whose `iss` claim is missing or does not match any configured issuer is rejected with `401 Unauthorized`.
+
+When `issuers` is empty (the default), issuer validation is skipped entirely, so existing configurations are unaffected.
+
 ## Configure scope enforcement
 
 Use the `scope_mode` option to control how the MCP Server validates scopes from OAuth tokens.

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -305,9 +305,10 @@ These fields are under the top-level `transport` key, nested under the `auth` ke
 
 | Option                            | Type                  | Default       | Description                                                                                                                                                                                                      |
 | :-------------------------------- | :-------------------- | :------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `servers`                         | `List<URL>`           |               | List of upstream delegated OAuth servers (must support RFC 8414 or OIDC metadata discovery endpoint).                                                                                                            |
+| `servers`                         | `List<URL \| object>` |               | List of upstream delegated OAuth servers (must support RFC 8414 or OIDC metadata discovery endpoint). Each entry is a bare URL string, or an object with `url` and an optional `issuers` list.                   |
+| `servers[].url`                   | `URL`                 |               | The upstream OAuth server URL (object form only).                                                                                                                                                                |
+| `servers[].issuers`               | `List<string>`        | `[]`          | Accepted token issuers for tokens this server signs. The JWT `iss` claim must match one of these values, bound to the server whose keys verified the signature (skipped if empty).                               |
 | `audiences`                       | `List<string>`        | `[]`          | List of accepted audiences from upstream signed JWTs (ignored if `allow_any_audience` is `true`)                                                                                                                 |
-| `issuers`                         | `List<string>`        | `[]`          | List of accepted token issuers. The JWT `iss` claim must match one of these values (skipped if empty)                                                                                                            |
 | `allow_any_audience`              | `bool`                | `false`       | Set to `true` to skip audience validation entirely (use with caution)                                                                                                                                            |
 | `resource`                        | `string`              |               | The externally available URL pointing to this MCP server. Can be `localhost` when testing locally.                                                                                                               |
 | `resource_documentation`          | `string`              |               | Optional link to more documentation relating to this MCP server                                                                                                                                                  |
@@ -328,19 +329,20 @@ transport:
   auth:
     # List of upstream delegated OAuth servers
     # These must support RFC 8414 or OIDC metadata discovery.
+    # Each entry is a bare URL string, or an object with `url` and an
+    # optional per-server `issuers` list. When a server lists `issuers`, the
+    # JWT `iss` claim of a token its keys signed must match one of those
+    # values; bare-string servers skip issuer validation.
     servers:
-      - https://auth.example.com
+      - url: https://auth.example.com
+        issuers:
+          - https://auth.example.com
 
     # List of accepted audiences from upstream signed JWTs
     # (Ignored if allow_any_audience is set to true)
     # See: https://www.ory.sh/docs/hydra/guides/audiences
     audiences:
       - mcp.example.audience
-
-    # List of accepted token issuers. The JWT iss claim must match one of
-    # these values. When empty (the default), the server skips issuer validation.
-    issuers:
-      - https://auth.example.com
 
     # Set to true to skip audience validation (use with caution)
     allow_any_audience: false

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -307,7 +307,7 @@ These fields are under the top-level `transport` key, nested under the `auth` ke
 | :-------------------------------- | :-------------------- | :------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `servers`                         | `List<URL \| object>` |               | List of upstream delegated OAuth servers (must support RFC 8414 or OIDC metadata discovery endpoint). Each entry is a bare URL string, or an object with `url` and an optional `issuers` list.                   |
 | `servers[].url`                   | `URL`                 |               | The upstream OAuth server URL (object form only).                                                                                                                                                                |
-| `servers[].issuers`               | `List<string>`        | `[]`          | Accepted token issuers for tokens this server signs. The JWT `iss` claim must match one of these values, bound to the server whose keys verified the signature (skipped if empty).                               |
+| `servers[].issuers`               | `List<string>`        | `[]`          | Accepted token issuers for tokens this server signs. The JWT `iss` claim must match one of these values, bound to the server whose keys verify the signature (skipped if empty).                                 |
 | `audiences`                       | `List<string>`        | `[]`          | List of accepted audiences from upstream signed JWTs (ignored if `allow_any_audience` is `true`)                                                                                                                 |
 | `allow_any_audience`              | `bool`                | `false`       | Set to `true` to skip audience validation entirely (use with caution)                                                                                                                                            |
 | `resource`                        | `string`              |               | The externally available URL pointing to this MCP server. Can be `localhost` when testing locally.                                                                                                               |
@@ -327,16 +327,16 @@ Below is an example configuration using `StreamableHTTP` transport with authenti
 transport:
   type: streamable_http
   auth:
-    # List of upstream delegated OAuth servers
+    # List of upstream delegated OAuth servers.
     # These must support RFC 8414 or OIDC metadata discovery.
-    # Each entry is a bare URL string, or an object with `url` and an
-    # optional per-server `issuers` list. When a server lists `issuers`, the
-    # JWT `iss` claim of a token its keys signed must match one of those
-    # values; bare-string servers skip issuer validation.
+    # The recommended approach is to use an object with a `url` and an
+    # `issuers` list. When a server lists `issuers`, the JWT `iss` claim of a
+    # token its keys sign must match one of those values to ensure secure
+    # token validation.
     servers:
-      - url: https://auth.example.com
+      - url: "https://auth.example.com"
         issuers:
-          - https://auth.example.com
+          - "https://auth.example.com"
 
     # List of accepted audiences from upstream signed JWTs
     # (Ignored if allow_any_audience is set to true)

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -305,10 +305,9 @@ These fields are under the top-level `transport` key, nested under the `auth` ke
 
 | Option                            | Type                  | Default       | Description                                                                                                                                                                                                      |
 | :-------------------------------- | :-------------------- | :------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `servers`                         | `List<URL \| object>` |               | List of upstream delegated OAuth servers (must support RFC 8414 or OIDC metadata discovery endpoint). Each entry is a bare URL string, or an object with `url` and an optional `issuers` list.                   |
-| `servers[].url`                   | `URL`                 |               | The upstream OAuth server URL (object form only).                                                                                                                                                                |
-| `servers[].issuers`               | `List<string>`        | `[]`          | Accepted token issuers for tokens this server signs. The JWT `iss` claim must match one of these values, bound to the server whose keys verify the signature (skipped if empty).                                 |
+| `servers`                         | `List<URL>`           |               | List of upstream delegated OAuth servers (must support RFC 8414 or OIDC metadata discovery endpoint).                                                                                                            |
 | `audiences`                       | `List<string>`        | `[]`          | List of accepted audiences from upstream signed JWTs (ignored if `allow_any_audience` is `true`)                                                                                                                 |
+| `issuers`                         | `List<string>`        | `[]`          | List of accepted token issuers. The JWT `iss` claim must match one of these values, and must equal the issuer advertised by the server that signed the token (skipped if empty).                                 |
 | `allow_any_audience`              | `bool`                | `false`       | Set to `true` to skip audience validation entirely (use with caution)                                                                                                                                            |
 | `resource`                        | `string`              |               | The externally available URL pointing to this MCP server. Can be `localhost` when testing locally.                                                                                                               |
 | `resource_documentation`          | `string`              |               | Optional link to more documentation relating to this MCP server                                                                                                                                                  |
@@ -327,22 +326,22 @@ Below is an example configuration using `StreamableHTTP` transport with authenti
 transport:
   type: streamable_http
   auth:
-    # List of upstream delegated OAuth servers.
+    # List of upstream delegated OAuth servers
     # These must support RFC 8414 or OIDC metadata discovery.
-    # The recommended approach is to use an object with a `url` and an
-    # `issuers` list. When a server lists `issuers`, the JWT `iss` claim of a
-    # token its keys sign must match one of those values to ensure secure
-    # token validation.
     servers:
-      - url: "https://auth.example.com"
-        issuers:
-          - "https://auth.example.com"
+      - https://auth.example.com
 
     # List of accepted audiences from upstream signed JWTs
     # (Ignored if allow_any_audience is set to true)
     # See: https://www.ory.sh/docs/hydra/guides/audiences
     audiences:
       - mcp.example.audience
+
+    # List of accepted token issuers. The JWT `iss` claim must match one of
+    # these values and the issuer the signing server advertises in discovery.
+    # When empty (the default), the server skips issuer validation.
+    issuers:
+      - "https://auth.example.com"
 
     # Set to true to skip audience validation (use with caution)
     allow_any_audience: false

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -307,6 +307,7 @@ These fields are under the top-level `transport` key, nested under the `auth` ke
 | :-------------------------------- | :-------------------- | :------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `servers`                         | `List<URL>`           |               | List of upstream delegated OAuth servers (must support RFC 8414 or OIDC metadata discovery endpoint).                                                                                                            |
 | `audiences`                       | `List<string>`        | `[]`          | List of accepted audiences from upstream signed JWTs (ignored if `allow_any_audience` is `true`)                                                                                                                 |
+| `issuers`                         | `List<string>`        | `[]`          | List of accepted token issuers; the JWT `iss` claim must match one (skipped if empty)                                                                                                                            |
 | `allow_any_audience`              | `bool`                | `false`       | Set to `true` to skip audience validation entirely (use with caution)                                                                                                                                            |
 | `resource`                        | `string`              |               | The externally available URL pointing to this MCP server. Can be `localhost` when testing locally.                                                                                                               |
 | `resource_documentation`          | `string`              |               | Optional link to more documentation relating to this MCP server                                                                                                                                                  |
@@ -335,6 +336,11 @@ transport:
     # See: https://www.ory.sh/docs/hydra/guides/audiences
     audiences:
       - mcp.example.audience
+
+    # List of accepted token issuers. The JWT `iss` claim must match one of
+    # these values. When empty (the default), issuer validation is skipped.
+    issuers:
+      - https://auth.example.com
 
     # Set to true to skip audience validation (use with caution)
     allow_any_audience: false

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -307,7 +307,7 @@ These fields are under the top-level `transport` key, nested under the `auth` ke
 | :-------------------------------- | :-------------------- | :------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `servers`                         | `List<URL>`           |               | List of upstream delegated OAuth servers (must support RFC 8414 or OIDC metadata discovery endpoint).                                                                                                            |
 | `audiences`                       | `List<string>`        | `[]`          | List of accepted audiences from upstream signed JWTs (ignored if `allow_any_audience` is `true`)                                                                                                                 |
-| `issuers`                         | `List<string>`        | `[]`          | List of accepted token issuers; the JWT `iss` claim must match one (skipped if empty)                                                                                                                            |
+| `issuers`                         | `List<string>`        | `[]`          | List of accepted token issuers. The JWT `iss` claim must match one of these values (skipped if empty)                                                                                                            |
 | `allow_any_audience`              | `bool`                | `false`       | Set to `true` to skip audience validation entirely (use with caution)                                                                                                                                            |
 | `resource`                        | `string`              |               | The externally available URL pointing to this MCP server. Can be `localhost` when testing locally.                                                                                                               |
 | `resource_documentation`          | `string`              |               | Optional link to more documentation relating to this MCP server                                                                                                                                                  |
@@ -337,8 +337,8 @@ transport:
     audiences:
       - mcp.example.audience
 
-    # List of accepted token issuers. The JWT `iss` claim must match one of
-    # these values. When empty (the default), issuer validation is skipped.
+    # List of accepted token issuers. The JWT iss claim must match one of
+    # these values. When empty (the default), the server skips issuer validation.
     issuers:
       - https://auth.example.com
 


### PR DESCRIPTION
## Summary

Apollo MCP Server validates a JWT's signature, expiry, and audience, but it never checks the **issuer (`iss`) claim** — unlike [Apollo Router's JWT authentication](https://www.apollographql.com/docs/router/configuration/authn-jwt), which supports issuer validation. This means that in a deployment delegating to multiple upstream OAuth servers, MCP cannot restrict which issuer a token must come from.

This PR adds **per-server** issuer validation: each configured authorization server can declare the `iss` values it is allowed to mint, and validation is bound to the server whose JWKS actually verified the signature. This brings the MCP Server to parity with the Router, which configures `issuers` per-JWKS entry.

> **Note:** This PR was originally written with a single global `transport.auth.issuers` list. Following [review feedback](https://github.com/apollographql/apollo-mcp-server/pull/757#discussion_r3343757827), it was reworked to bind issuers to each server. A global list applied the same allowlist to every server, so with multiple servers a token signed by server A could pass while claiming server B's issuer — and it did not match Router's per-JWKS semantics. The per-server design closes both gaps.

## Behavior

A `servers` entry is now **either** a bare URL string (unchanged behavior — no issuer check) **or** an object with a `url` and an optional per-server `issuers` list:

```yaml
transport:
  type: streamable_http
  auth:
    servers:
      - https://auth.example.com          # bare form — issuer validation skipped
      - url: https://auth.other.example.com
        issuers:
          - https://auth.other.example.com
```

- **Server entry has no `issuers` (bare string, or object without the field):** issuer validation is skipped for that server — existing configurations are completely unaffected.
- **Server entry lists `issuers`:** a token whose signature is verified by that server's keys must carry an `iss` claim matching one of that server's listed issuers, or the request is rejected with `401`.
- A token **missing the `iss` claim** while its signing server requires issuers is also rejected.
- Issuer validation is **bound to the signing server**: a token signed by one configured server cannot be accepted by claiming a different configured server's issuer.

## Implementation

- A new `AuthServer { url: String, issuers: Vec<String> }` type with a custom `Deserialize` that accepts either a bare URL string or `{ url, issuers }`. `auth::Config.servers` is now `Vec<AuthServer>`; the previous global `issuers` field is removed. `url` is kept as a `String` (not `Url`) for the same reason as before: `Url::parse` appends a trailing `/` to bare-authority inputs, which would break exact `iss` matching and alter the value advertised in the protected-resource metadata.
- `ValidateToken::get_issuers_for(server)` replaces the global `get_issuers()`; the `validate()` loop applies `Validation::set_issuer(...)` (and the missing-`iss` guard) using **only the current server's** issuers.
- Threaded through `NetworkedTokenValidator` (which now owns a parsed, index-aligned view of the configured servers).
- Ordering is preserved: signature and expiry are verified before the issuer check.

## Tests

- `iss` matches the signing server's configured issuer → valid
- `iss` matches **any** of a server's multiple configured issuers → valid
- `iss` does not match → rejected (`InvalidIssuer`)
- `iss` missing while the signing server requires issuers → rejected
- server has no issuers configured → token without `iss` still valid (backward-compat)
- **two configured servers, token signed by server A but claiming server B's issuer (shared `kid`) → rejected** (the cross-server regression test from review; verified to fail against the old global behavior)
- **two configured servers, each token validated against its own server's issuer → valid**
- config deserialization: bare-string form, object form with/without issuers, mixed list, invalid URL rejected

## Docs & changeset

- `docs/source/auth.mdx`: "Configuring allowed issuers" section, per-server shape.
- `docs/source/config-file.mdx`: `servers` table rows (`url` / `issuers`) + example.
- Changeset (`minor` — new backward-compatible feature).

`cargo fmt --check`, `cargo clippy --all-targets -- --deny warnings`, and the auth test suite all pass locally.
