### PR TITLE
refactor: restructure auth token validation internals

### DIFF
--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -16,7 +16,7 @@ use axum_extra::{
     headers::{Authorization, authorization::Bearer},
 };
 use http::Method;
-use networked_token_validator::NetworkedTokenValidator;
+use networked_key_resolver::NetworkedKeyResolver;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -24,14 +24,14 @@ use tower_http::cors::{Any, CorsLayer};
 use tracing::warn;
 use url::Url;
 
-mod networked_token_validator;
+mod networked_key_resolver;
 mod protected_resource;
 mod valid_token;
 mod www_authenticate;
 
 use protected_resource::ProtectedResource;
+use valid_token::TokenValidator;
 pub(crate) use valid_token::ValidToken;
-use valid_token::ValidateToken;
 use www_authenticate::{BearerError, WwwAuthenticate};
 
 /// Scope enforcement mode for authenticated requests.
@@ -491,14 +491,13 @@ async fn oauth_validate(
         .iter()
         .map(|s| Url::parse(s).expect("validated by deserialize_auth_servers"))
         .collect();
-    let validator = NetworkedTokenValidator::new(
-        &auth_config.audiences,
-        &auth_config.issuers,
-        auth_config.allow_any_audience,
-        &auth_servers,
-        &auth_state.client,
-        discovery_timeout,
-    );
+    let validator = TokenValidator {
+        audiences: &auth_config.audiences,
+        issuers: &auth_config.issuers,
+        allow_any_audience: auth_config.allow_any_audience,
+        servers: &auth_servers,
+        keys: NetworkedKeyResolver::new(&auth_state.client, discovery_timeout),
+    };
     let token = token.ok_or_else(|| {
         tracing::Span::current().record("reason", "missing_token");
         tracing::Span::current().record("status_code", StatusCode::UNAUTHORIZED.as_u16());

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -262,9 +262,12 @@ fn build_resource_metadata_url(resource: &Url) -> Url {
 /// Internal state for the auth middleware, containing both config and pre-built HTTP client
 #[derive(Clone)]
 struct AuthState {
-    config: Config,
+    config: Arc<Config>,
     client: reqwest::Client,
     resource_metadata_url: Url,
+    /// Upstream OAuth server URLs, parsed once at startup so the per-request
+    /// path neither re-parses nor allocates them.
+    auth_servers: Arc<[Url]>,
     /// Per-operation required scopes, keyed by operation name.
     required_scopes: Arc<HashMap<String, Vec<String>>>,
 }
@@ -278,17 +281,24 @@ impl Config {
         router: Router,
         required_scopes: HashMap<String, Vec<String>>,
     ) -> Result<Router, TlsConfigError> {
-        // Validate server URLs have hosts (fail fast on config errors)
+        // Parse and validate server URLs once at startup (fail fast on config
+        // errors). The parsed list is reused for every request via `AuthState`.
         #[allow(clippy::expect_used)] // parseability validated at deserialize
-        for (i, server) in self.servers.iter().enumerate() {
-            let parsed = Url::parse(server).expect("validated by deserialize_auth_servers");
-            if parsed.host_str().is_none() {
-                return Err(TlsConfigError::ServerUrlMissingHost {
-                    index: i,
-                    url: server.clone(),
-                });
-            }
-        }
+        let auth_servers = self
+            .servers
+            .iter()
+            .enumerate()
+            .map(|(i, server)| {
+                let parsed = Url::parse(server).expect("validated by deserialize_auth_servers");
+                if parsed.host_str().is_none() {
+                    return Err(TlsConfigError::ServerUrlMissingHost {
+                        index: i,
+                        url: server.clone(),
+                    });
+                }
+                Ok(parsed)
+            })
+            .collect::<Result<Vec<Url>, _>>()?;
 
         let scheme = self.resource.scheme();
         if scheme != "http" && scheme != "https" {
@@ -314,7 +324,7 @@ impl Config {
         async fn protected_resource(
             State(auth_state): State<AuthState>,
         ) -> Json<ProtectedResource> {
-            Json(auth_state.config.into())
+            Json(ProtectedResource::from(auth_state.config.as_ref().clone()))
         }
 
         // Build HTTP client with TLS configuration and discovery headers
@@ -322,9 +332,10 @@ impl Config {
         let resource_metadata_url = build_resource_metadata_url(&self.resource);
         let metadata_route_path = resource_metadata_url.path().to_string();
         let auth_state = AuthState {
-            config: self.clone(),
+            config: Arc::new(self.clone()),
             client,
             resource_metadata_url,
+            auth_servers: Arc::from(auth_servers),
             required_scopes: Arc::new(required_scopes),
         };
 
@@ -344,6 +355,10 @@ impl Config {
         )))
     }
 }
+
+/// Default timeout for OIDC/OAuth discovery and JWKS requests when
+/// `transport.auth.discovery_timeout` is not configured.
+const DEFAULT_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// MCP discovery methods that are allowed without authentication when
 /// `allow_anonymous_mcp_discovery` is enabled.
@@ -483,19 +498,13 @@ async fn oauth_validate(
 
     let discovery_timeout = auth_config
         .discovery_timeout
-        .unwrap_or(Duration::from_secs(5));
+        .unwrap_or(DEFAULT_DISCOVERY_TIMEOUT);
 
-    #[allow(clippy::expect_used)] // parseability validated at deserialize
-    let auth_servers: Vec<Url> = auth_config
-        .servers
-        .iter()
-        .map(|s| Url::parse(s).expect("validated by deserialize_auth_servers"))
-        .collect();
     let validator = TokenValidator {
         audiences: &auth_config.audiences,
         issuers: &auth_config.issuers,
         allow_any_audience: auth_config.allow_any_audience,
-        servers: &auth_servers,
+        servers: &auth_state.auth_servers,
         keys: NetworkedKeyResolver::new(&auth_state.client, discovery_timeout),
     };
     let token = token.ok_or_else(|| {
@@ -605,10 +614,16 @@ mod tests {
 
     fn test_auth_state(config: Config) -> AuthState {
         let resource_metadata_url = build_resource_metadata_url(&config.resource);
+        let auth_servers = config
+            .servers
+            .iter()
+            .map(|s| Url::parse(s).expect("valid test server URL"))
+            .collect::<Vec<_>>();
         AuthState {
-            config,
+            config: Arc::new(config),
             client: reqwest::Client::new(),
             resource_metadata_url,
+            auth_servers: Arc::from(auth_servers),
             required_scopes: Arc::new(HashMap::new()),
         }
     }

--- a/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
@@ -7,33 +7,18 @@ use serde::Deserialize;
 use tracing::{error, info, trace, warn};
 use url::Url;
 
-use super::valid_token::{ValidateToken, VerificationKey};
+use super::valid_token::{KeyResolver, VerificationKey};
 
-/// Implementation of the `ValidateToken` trait which fetches key information
-/// from the network.
-pub(super) struct NetworkedTokenValidator<'a> {
-    audiences: &'a [String],
-    issuers: &'a [String],
-    allow_any_audience: bool,
-    upstreams: &'a [Url],
+/// [`KeyResolver`] that fetches signing keys from the network via OIDC/OAuth
+/// discovery.
+pub(super) struct NetworkedKeyResolver<'a> {
     client: &'a reqwest::Client,
     discovery_timeout: Duration,
 }
 
-impl<'a> NetworkedTokenValidator<'a> {
-    pub fn new(
-        audiences: &'a [String],
-        issuers: &'a [String],
-        allow_any_audience: bool,
-        upstreams: &'a [Url],
-        client: &'a reqwest::Client,
-        discovery_timeout: Duration,
-    ) -> Self {
+impl<'a> NetworkedKeyResolver<'a> {
+    pub fn new(client: &'a reqwest::Client, discovery_timeout: Duration) -> Self {
         Self {
-            audiences,
-            issuers,
-            allow_any_audience,
-            upstreams,
             client,
             discovery_timeout,
         }
@@ -196,29 +181,13 @@ async fn fetch_jwks(client: &reqwest::Client, jwks_uri: &str, timeout: Duration)
     }
 }
 
-impl ValidateToken for NetworkedTokenValidator<'_> {
-    fn allow_any_audience(&self) -> bool {
-        self.allow_any_audience
-    }
-
-    fn get_audiences(&self) -> &[String] {
-        self.audiences
-    }
-
-    fn get_issuers(&self) -> &[String] {
-        self.issuers
-    }
-
-    fn get_servers(&self) -> &[Url] {
-        self.upstreams
-    }
-
+impl KeyResolver for NetworkedKeyResolver<'_> {
     /// `discovery_timeout` bounds each network stage (metadata fetch and JWKS
     /// fetch) independently, so a cold-cache lookup can take up to 2×
     /// `discovery_timeout` on the happy path. The JWKS fetch does not fall
     /// back to alternate discovery URLs on failure; real providers advertise
     /// the same `jwks_uri` from every well-known path.
-    async fn get_key(&self, server: &Url, key_id: &str) -> Option<VerificationKey> {
+    async fn resolve_key(&self, server: &Url, key_id: &str) -> Option<VerificationKey> {
         let metadata = discover_metadata(self.client, server, self.discovery_timeout).await?;
         let mut jwks = fetch_jwks(self.client, &metadata.jwks_uri, self.discovery_timeout).await?;
         let mut jwk = jwks.keys.remove(key_id)?;

--- a/crates/apollo-mcp-server/src/auth/networked_token_validator.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_token_validator.rs
@@ -15,7 +15,7 @@ pub(super) struct NetworkedTokenValidator<'a> {
     audiences: &'a [String],
     issuers: &'a [String],
     allow_any_audience: bool,
-    upstreams: &'a Vec<Url>,
+    upstreams: &'a [Url],
     client: &'a reqwest::Client,
     discovery_timeout: Duration,
 }
@@ -25,7 +25,7 @@ impl<'a> NetworkedTokenValidator<'a> {
         audiences: &'a [String],
         issuers: &'a [String],
         allow_any_audience: bool,
-        upstreams: &'a Vec<Url>,
+        upstreams: &'a [Url],
         client: &'a reqwest::Client,
         discovery_timeout: Duration,
     ) -> Self {
@@ -209,7 +209,7 @@ impl ValidateToken for NetworkedTokenValidator<'_> {
         self.issuers
     }
 
-    fn get_servers(&self) -> &Vec<Url> {
+    fn get_servers(&self) -> &[Url] {
         self.upstreams
     }
 

--- a/crates/apollo-mcp-server/src/auth/valid_token.rs
+++ b/crates/apollo-mcp-server/src/auth/valid_token.rs
@@ -38,26 +38,38 @@ pub(super) struct VerificationKey {
     pub(super) issuer: String,
 }
 
-/// Trait to handle validation of tokens
-pub(super) trait ValidateToken {
-    /// Whether to skip audience validation (allow any audience)
-    fn allow_any_audience(&self) -> bool;
-
-    /// Get the list of allowed audiences
-    fn get_audiences(&self) -> &[String];
-
-    /// Get the list of accepted issuers (empty = skip issuer validation)
-    fn get_issuers(&self) -> &[String];
-
-    /// Get the available upstream servers
-    fn get_servers(&self) -> &[Url];
-
+/// Resolves a signing key for a `(server, key_id)` pair, returning it together
+/// with the issuer that server advertises in discovery.
+///
+/// This is the single seam that production fetches over the network and tests
+/// substitute in memory. Everything else about validation lives in
+/// [`TokenValidator`], so adding a new validation input does not touch this
+/// trait or its implementations.
+pub(super) trait KeyResolver {
     /// Fetch the signing key by its ID, along with the issuing server's
-    /// discovered issuer identifier.
-    async fn get_key(&self, server: &Url, key_id: &str) -> Option<VerificationKey>;
+    /// discovered issuer identifier. Returns `None` when the server does not
+    /// serve a key with that `key_id`.
+    async fn resolve_key(&self, server: &Url, key_id: &str) -> Option<VerificationKey>;
+}
 
-    /// Attempt to validate a token against the validator
-    async fn validate(&self, token: Authorization<Bearer>) -> Option<ValidToken> {
+/// Validates bearer JWTs against the configured audiences, issuers, and upstream
+/// servers, resolving signing keys through `keys`.
+pub(super) struct TokenValidator<'a, R: KeyResolver> {
+    /// Accepted audiences. Ignored when `allow_any_audience` is set.
+    pub(super) audiences: &'a [String],
+    /// Accepted issuers (empty = skip issuer validation).
+    pub(super) issuers: &'a [String],
+    /// Skip audience validation entirely.
+    pub(super) allow_any_audience: bool,
+    /// Upstream authorization servers to try, in order.
+    pub(super) servers: &'a [Url],
+    /// Resolves signing keys (the network seam).
+    pub(super) keys: R,
+}
+
+impl<R: KeyResolver> TokenValidator<'_, R> {
+    /// Attempt to validate a token against the configured rules.
+    pub(super) async fn validate(&self, token: Authorization<Bearer>) -> Option<ValidToken> {
         /// Claims which must be present in the JWT (and must match validation)
         /// in order for a JWT to be considered valid.
         ///
@@ -134,11 +146,11 @@ pub(super) trait ValidateToken {
         let header = decode_header(jwt).ok()?;
         let key_id = header.kid.as_ref()?;
 
-        for server in self.get_servers() {
+        for server in self.servers {
             let Some(VerificationKey {
                 jwk,
                 issuer: discovered_issuer,
-            }) = self.get_key(server, key_id).await
+            }) = self.keys.resolve_key(server, key_id).await
             else {
                 continue;
             };
@@ -169,14 +181,14 @@ pub(super) trait ValidateToken {
                         continue;
                     }
                 });
-                if self.allow_any_audience() {
+                if self.allow_any_audience {
                     val.validate_aud = false;
                 } else {
-                    val.set_audience(self.get_audiences());
+                    val.set_audience(self.audiences);
                 }
 
-                if !self.get_issuers().is_empty() {
-                    val.set_issuer(self.get_issuers());
+                if !self.issuers.is_empty() {
+                    val.set_issuer(self.issuers);
                 }
 
                 val
@@ -188,11 +200,11 @@ pub(super) trait ValidateToken {
                     // with a missing `aud` claim. The `jsonwebtoken` crate skips its
                     // own audience check when the claim is absent from the raw JWT,
                     // so we enforce it here.
-                    if !self.allow_any_audience() && token_data.claims.aud.is_empty() {
+                    if !self.allow_any_audience && token_data.claims.aud.is_empty() {
                         warn!("Token is missing the required `aud` claim");
                         break;
                     }
-                    if !self.get_issuers().is_empty() {
+                    if !self.issuers.is_empty() {
                         // When issuer validation is enabled, explicitly reject tokens
                         // with a missing `iss` claim. The `jsonwebtoken` crate skips its
                         // own issuer check when the claim is absent from the raw JWT,
@@ -241,23 +253,41 @@ mod test {
     use tracing_test::traced_test;
     use url::Url;
 
-    use super::{ValidateToken, VerificationKey};
+    use super::{KeyResolver, TokenValidator, ValidToken, VerificationKey};
 
-    /// A single upstream server in the test validator: its URL, the one
-    /// `(kid, jwk)` it will serve, and the issuer it advertises in discovery.
+    /// A single upstream server in the stub resolver: its URL, the one
+    /// `(kid, jwk)` it serves, and the issuer it advertises in discovery.
     struct TestServer {
         url: Url,
         key_pair: (String, Jwk),
         discovered_issuer: String,
     }
 
+    /// In-memory [`KeyResolver`] that stands in for the network in tests.
+    struct StubKeyResolver<'a> {
+        servers: &'a [TestServer],
+    }
+
+    impl KeyResolver for StubKeyResolver<'_> {
+        async fn resolve_key(&self, server: &Url, key_id: &str) -> Option<VerificationKey> {
+            // Find the requested server, then return its key only if the `kid` matches.
+            let test_server = self.servers.iter().find(|s| &s.url == server)?;
+            test_server.key_pair.0.eq(key_id).then(|| VerificationKey {
+                jwk: test_server.key_pair.1.clone(),
+                issuer: test_server.discovered_issuer.clone(),
+            })
+        }
+    }
+
+    /// Thin test harness that owns the validation inputs and delegates to the
+    /// real [`TokenValidator`] through a [`StubKeyResolver`]. Keeps the test
+    /// call sites concise while exercising the production validation path.
     struct TestTokenValidator {
         audiences: Vec<String>,
         issuers: Vec<String>,
         allow_any_audience: bool,
         servers: Vec<TestServer>,
-        /// Parsed server URLs, owned so `get_servers` can return a `&[Url]`.
-        /// Kept index-aligned with `servers`.
+        /// Parsed server URLs, kept index-aligned with `servers`.
         server_urls: Vec<Url>,
     }
 
@@ -278,10 +308,9 @@ mod test {
             }
         }
 
-        /// Convenience for the common single-server case. The server's
-        /// discovered issuer defaults to the configured server URL with any
-        /// trailing slash trimmed, matching how a compliant server advertises
-        /// its issuer identifier; pass `discovered_issuer` to override.
+        /// Convenience for the common single-server case. The discovered issuer
+        /// defaults to the server URL with any trailing slash trimmed, matching
+        /// how a compliant server advertises its issuer identifier.
         fn single(
             audiences: Vec<String>,
             issuers: Vec<String>,
@@ -301,32 +330,20 @@ mod test {
                 }],
             )
         }
-    }
 
-    impl ValidateToken for TestTokenValidator {
-        fn allow_any_audience(&self) -> bool {
-            self.allow_any_audience
-        }
-
-        fn get_audiences(&self) -> &[String] {
-            &self.audiences
-        }
-
-        fn get_issuers(&self) -> &[String] {
-            &self.issuers
-        }
-
-        fn get_servers(&self) -> &[url::Url] {
-            &self.server_urls
-        }
-
-        async fn get_key(&self, server: &url::Url, key_id: &str) -> Option<VerificationKey> {
-            // Find the requested server, then return its key only if the `kid` matches.
-            let test_server = self.servers.iter().find(|s| &s.url == server)?;
-            test_server.key_pair.0.eq(key_id).then(|| VerificationKey {
-                jwk: test_server.key_pair.1.clone(),
-                issuer: test_server.discovered_issuer.clone(),
-            })
+        /// Run the real [`TokenValidator`] against this harness's inputs.
+        async fn validate(&self, token: Authorization<Bearer>) -> Option<ValidToken> {
+            TokenValidator {
+                audiences: &self.audiences,
+                issuers: &self.issuers,
+                allow_any_audience: self.allow_any_audience,
+                servers: &self.server_urls,
+                keys: StubKeyResolver {
+                    servers: &self.servers,
+                },
+            }
+            .validate(token)
+            .await
         }
     }
 
@@ -1180,6 +1197,39 @@ mod test {
                 .then_some(())
                 .ok_or("Expected warning for missing algorithm".to_string())
         });
+    }
+
+    #[tokio::test]
+    async fn it_rejects_when_no_server_serves_the_kid() {
+        let (encode_key, decode_key) = create_key("DEADBEEF");
+        let jwk = Jwk {
+            alg: Some(KeyAlgorithm::HS512),
+            decoding_key: decode_key,
+        };
+
+        let audience = "test-audience".to_string();
+        let in_the_future = chrono::Utc::now().timestamp() + 1000;
+        // The token's `kid` does not match any key the configured server serves.
+        let jwt = create_jwt(
+            "token-kid".to_string(),
+            encode_key,
+            audience.clone(),
+            in_the_future,
+        );
+
+        let server =
+            Url::from_str("https://auth.example.com").expect("should parse a valid example server");
+
+        // The server only serves `server-kid`, so key resolution finds nothing.
+        let test_validator = TestTokenValidator::single(
+            vec![audience],
+            vec![],
+            false,
+            ("server-kid".to_string(), jwk),
+            server,
+        );
+
+        assert_eq!(test_validator.validate(jwt).await, None);
     }
 
     /// Build and validate a JWT with the given claims JSON, returning the

--- a/crates/apollo-mcp-server/src/auth/valid_token.rs
+++ b/crates/apollo-mcp-server/src/auth/valid_token.rs
@@ -50,7 +50,7 @@ pub(super) trait ValidateToken {
     fn get_issuers(&self) -> &[String];
 
     /// Get the available upstream servers
-    fn get_servers(&self) -> &Vec<Url>;
+    fn get_servers(&self) -> &[Url];
 
     /// Fetch the signing key by its ID, along with the issuing server's
     /// discovered issuer identifier.
@@ -256,7 +256,7 @@ mod test {
         issuers: Vec<String>,
         allow_any_audience: bool,
         servers: Vec<TestServer>,
-        /// Parsed server URLs, owned so `get_servers` can return a `&Vec<Url>`.
+        /// Parsed server URLs, owned so `get_servers` can return a `&[Url]`.
         /// Kept index-aligned with `servers`.
         server_urls: Vec<Url>,
     }
@@ -316,7 +316,7 @@ mod test {
             &self.issuers
         }
 
-        fn get_servers(&self) -> &Vec<url::Url> {
+        fn get_servers(&self) -> &[url::Url] {
             &self.server_urls
         }
 


### PR DESCRIPTION
This PR splits the old `ValidateToken` trait into a one-method `KeyResolver`, which is all the tests need to substitute for the network. There's also a plain `TokenValidator` struct that holds the validation data and contains the single `validate` implementation. This change removes the duplicated accessor boilerplate that both the production and test validators had, making it easier to add future validation inputs as struct fields instead of modifying a trait and two implementations.

Additionally, it now parses the configured server URLs once at startup and shares `Config` via `Arc`. This means an authenticated request no longer deep-clones the config or re-parses URLs during the hot path.