### PR TITLE
fix: retain tool catalog on transient Uplink manifest fetch failure

### DIFF
--- a/.changeset/fix_uplink_manifest_error_retain_catalog.md
+++ b/.changeset/fix_uplink_manifest_error_retain_catalog.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+# Retain tool catalog on transient Uplink manifest fetch failure
+
+When `operations.source: uplink` is configured, a transient Uplink persisted-query manifest fetch failure (network timeout, DNS failure, HTTP 5xx, or a retryable `retry_later` response) previously caused the server to silently replace its active tool catalog with an empty list. The server continued reporting `/health` as UP and sent `tools/list_changed` to clients, which then received `{"tools": []}` with no error signal.
+
+Apollo MCP Server now retains the last known good tool catalog when a transient Uplink manifest fetch error occurs and logs the error. The catalog is only cleared when Uplink authoritatively returns a valid empty manifest (HTTP 200 with an empty persisted query collection), which represents an intentional operator action. A manifest fetch failure during initial startup before the first successful load remains fatal.

--- a/crates/apollo-mcp-registry/src/uplink/persisted_queries/event.rs
+++ b/crates/apollo-mcp-registry/src/uplink/persisted_queries/event.rs
@@ -23,3 +23,15 @@ impl Debug for Event {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_manifest_error_formats_message() {
+        let event = Event::ManifestError("timeout".into());
+        let output = format!("{event:?}");
+        assert_eq!(output, "ManifestError(timeout)");
+    }
+}

--- a/crates/apollo-mcp-registry/src/uplink/persisted_queries/event.rs
+++ b/crates/apollo-mcp-registry/src/uplink/persisted_queries/event.rs
@@ -1,10 +1,14 @@
 use std::fmt::Debug;
 use std::fmt::Formatter;
 
+use tower::BoxError;
+
 /// Persisted Query events
 pub enum Event {
     /// The persisted query manifest was updated
     UpdateManifest(Vec<(String, String)>),
+    /// A transient error occurred while fetching the manifest; the previous catalog is retained
+    ManifestError(BoxError),
 }
 
 impl Debug for Event {
@@ -12,6 +16,9 @@ impl Debug for Event {
         match self {
             Event::UpdateManifest(_) => {
                 write!(f, "UpdateManifest(<redacted>)")
+            }
+            Event::ManifestError(e) => {
+                write!(f, "ManifestError({e})")
             }
         }
     }

--- a/crates/apollo-mcp-registry/src/uplink/persisted_queries/manifest_poller.rs
+++ b/crates/apollo-mcp-registry/src/uplink/persisted_queries/manifest_poller.rs
@@ -41,14 +41,7 @@ impl ManifestSource {
                             .map(|(k, v)| (k.operation_id.clone(), v.clone()))
                             .collect(),
                     ),
-                    Err(e) => {
-                        tracing::error!(
-                            "transient error fetching persisted query manifest; \
-                             retaining previous catalog: {}",
-                            e
-                        );
-                        Event::ManifestError(e)
-                    }
+                    Err(e) => Event::ManifestError(e),
                 })
                 .boxed(),
             Err(e) => {

--- a/crates/apollo-mcp-registry/src/uplink/persisted_queries/manifest_poller.rs
+++ b/crates/apollo-mcp-registry/src/uplink/persisted_queries/manifest_poller.rs
@@ -42,8 +42,12 @@ impl ManifestSource {
                             .collect(),
                     ),
                     Err(e) => {
-                        tracing::error!("error from manifest stream: {}", e);
-                        Event::UpdateManifest(vec![])
+                        tracing::error!(
+                            "transient error fetching persisted query manifest; \
+                             retaining previous catalog: {}",
+                            e
+                        );
+                        Event::ManifestError(e)
                     }
                 })
                 .boxed(),

--- a/crates/apollo-mcp-server/src/errors.rs
+++ b/crates/apollo-mcp-server/src/errors.rs
@@ -44,6 +44,20 @@ pub enum OperationError {
     Manifest(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operation_error_manifest_display() {
+        let err = OperationError::Manifest("connection refused".into());
+        assert_eq!(
+            err.to_string(),
+            "Error fetching Uplink persisted-query manifest: connection refused"
+        );
+    }
+}
+
 /// An error in server initialization
 #[derive(Debug, thiserror::Error)]
 pub enum ServerError {

--- a/crates/apollo-mcp-server/src/errors.rs
+++ b/crates/apollo-mcp-server/src/errors.rs
@@ -5,6 +5,7 @@ use apollo_mcp_registry::platform_api::operation_collections::error::CollectionE
 use reqwest::header::{InvalidHeaderName, InvalidHeaderValue};
 use rmcp::serde_json;
 use tokio::task::JoinError;
+use tower::BoxError;
 use url::ParseError;
 
 /// An error in operation parsing
@@ -39,6 +40,9 @@ pub enum OperationError {
 
     #[error("Error loading collection: {0}")]
     Collection(CollectionError),
+
+    #[error("Error fetching Uplink persisted-query manifest: {0}")]
+    Manifest(BoxError),
 }
 
 /// An error in server initialization

--- a/crates/apollo-mcp-server/src/errors.rs
+++ b/crates/apollo-mcp-server/src/errors.rs
@@ -5,7 +5,6 @@ use apollo_mcp_registry::platform_api::operation_collections::error::CollectionE
 use reqwest::header::{InvalidHeaderName, InvalidHeaderValue};
 use rmcp::serde_json;
 use tokio::task::JoinError;
-use tower::BoxError;
 use url::ParseError;
 
 /// An error in operation parsing
@@ -42,7 +41,7 @@ pub enum OperationError {
     Collection(CollectionError),
 
     #[error("Error fetching Uplink persisted-query manifest: {0}")]
-    Manifest(BoxError),
+    Manifest(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
 /// An error in server initialization

--- a/crates/apollo-mcp-server/src/errors.rs
+++ b/crates/apollo-mcp-server/src/errors.rs
@@ -40,7 +40,7 @@ pub enum OperationError {
     #[error("Error loading collection: {0}")]
     Collection(CollectionError),
 
-    #[error("Error fetching Uplink persisted-query manifest: {0}")]
+    #[error("Error fetching persisted-query manifest: {0}")]
     Manifest(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
@@ -53,7 +53,7 @@ mod tests {
         let err = OperationError::Manifest("connection refused".into());
         assert_eq!(
             err.to_string(),
-            "Error fetching Uplink persisted-query manifest: connection refused"
+            "Error fetching persisted-query manifest: connection refused"
         );
     }
 }

--- a/crates/apollo-mcp-server/src/event.rs
+++ b/crates/apollo-mcp-server/src/event.rs
@@ -5,7 +5,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::fmt::Result;
 use std::io;
-use tower::BoxError;
 
 /// MCP Server events
 pub enum Event {
@@ -23,7 +22,7 @@ pub enum Event {
 
     /// A transient error occurred fetching the Uplink persisted-query manifest;
     /// the server retains its existing tool catalog
-    ManifestError(BoxError),
+    ManifestError(Box<dyn std::error::Error + Send + Sync + 'static>),
 
     /// Rhai scripts in the rhai/ directory have changed
     RhaiScriptsChanged,

--- a/crates/apollo-mcp-server/src/event.rs
+++ b/crates/apollo-mcp-server/src/event.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::fmt::Result;
 use std::io;
+use tower::BoxError;
 
 /// MCP Server events
 pub enum Event {
@@ -19,6 +20,10 @@ pub enum Event {
 
     /// An error occurred when loading operations from collection
     CollectionError(CollectionError),
+
+    /// A transient error occurred fetching the Uplink persisted-query manifest;
+    /// the server retains its existing tool catalog
+    ManifestError(BoxError),
 
     /// Rhai scripts in the rhai/ directory have changed
     RhaiScriptsChanged,
@@ -44,6 +49,9 @@ impl Debug for Event {
             }
             Event::CollectionError(e) => {
                 write!(f, "OperationError({e:?})")
+            }
+            Event::ManifestError(e) => {
+                write!(f, "ManifestError({e})")
             }
             Event::RhaiScriptsChanged => {
                 write!(f, "RhaiScriptsChanged")
@@ -91,6 +99,13 @@ mod tests {
         let event = Event::CollectionError(CollectionError::Response("TEST".to_string()));
         let output = format!("{:?}", event);
         assert_eq!(output, r#"OperationError(Response("TEST"))"#);
+    }
+
+    #[test]
+    fn debug_event_manifest_error() {
+        let event = Event::ManifestError("timeout".into());
+        let output = format!("{:?}", event);
+        assert_eq!(output, "ManifestError(timeout)");
     }
 
     #[test]

--- a/crates/apollo-mcp-server/src/operations/operation_source.rs
+++ b/crates/apollo-mcp-server/src/operations/operation_source.rs
@@ -45,8 +45,11 @@ impl OperationSource {
             OperationSource::Manifest(source) => source
                 .into_stream()
                 .await
-                .map(|ManifestEvent::UpdateManifest(operations)| {
-                    Event::OperationsUpdated(raw_operations_from_manifest(operations))
+                .map(|event| match event {
+                    ManifestEvent::UpdateManifest(operations) => {
+                        Event::OperationsUpdated(raw_operations_from_manifest(operations))
+                    }
+                    ManifestEvent::ManifestError(e) => Event::ManifestError(e),
                 })
                 .boxed(),
             OperationSource::Collection(collection_source) => collection_source

--- a/crates/apollo-mcp-server/src/operations/operation_source.rs
+++ b/crates/apollo-mcp-server/src/operations/operation_source.rs
@@ -216,10 +216,29 @@ impl From<Vec<PathBuf>> for OperationSource {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use apollo_mcp_registry::uplink::persisted_queries::ManifestSource;
     use futures::StreamExt;
     use std::env::temp_dir;
     use std::fs;
     use std::io::Write;
+    use std::path::PathBuf;
+
+    // A LocalStatic manifest pointing at a missing file causes load_local_manifests to
+    // return Err, which exercises the ManifestError forwarding path in into_stream().
+    #[tokio::test]
+    async fn manifest_error_is_forwarded_from_manifest_source() {
+        let source = ManifestSource::LocalStatic(vec![PathBuf::from(
+            "/nonexistent/manifest_poller_test_file.json",
+        )]);
+        let op_source = OperationSource::Manifest(source);
+        let mut stream = op_source.into_stream().await;
+
+        let event = stream.next().await.expect("expected an event");
+        assert!(
+            matches!(event, Event::ManifestError(_)),
+            "expected ManifestError forwarded from manifest stream, got: {event:?}",
+        );
+    }
 
     #[tokio::test]
     async fn deduplication_of_overlapping_paths() {

--- a/crates/apollo-mcp-server/src/server/states.rs
+++ b/crates/apollo-mcp-server/src/server/states.rs
@@ -213,8 +213,8 @@ impl StateMachine {
             },
             ServerEvent::ManifestError(e) => match state {
                 State::Running(running) => {
-                    tracing::error!(
-                        "Transient Uplink manifest fetch error while running, \
+                    tracing::warn!(
+                        "Transient manifest fetch error while running, \
                          keeping existing operations: {e}"
                     );
                     running.into()
@@ -574,15 +574,31 @@ mod tests {
         let running = create_running_server();
         let state = State::Running(running);
 
-        let event = ServerEvent::ManifestError(
-            "connection timeout fetching persisted query manifest".into(),
-        );
+        // Populate the catalog first so we can assert it is retained.
+        let state = process_event(
+            state,
+            ServerEvent::OperationsUpdated(vec![RawOperation::from((
+                "query GetId { id }".to_string(),
+                Some("test.graphql".to_string()),
+            ))]),
+        )
+        .await;
 
-        let new_state = process_event(state, event).await;
+        let new_state = process_event(
+            state,
+            ServerEvent::ManifestError(
+                "connection timeout fetching persisted query manifest".into(),
+            ),
+        )
+        .await;
 
-        assert!(
-            matches!(new_state, State::Running(_)),
-            "expected server to remain Running after ManifestError"
+        let State::Running(running) = new_state else {
+            panic!("expected server to remain Running after ManifestError");
+        };
+        assert_eq!(
+            running.operations.read().await.len(),
+            1,
+            "ManifestError must not clear the existing tool catalog"
         );
     }
 

--- a/crates/apollo-mcp-server/src/server/states.rs
+++ b/crates/apollo-mcp-server/src/server/states.rs
@@ -211,6 +211,16 @@ impl StateMachine {
                 }
                 _ => State::Error(ServerError::Operation(OperationError::Collection(e))),
             },
+            ServerEvent::ManifestError(e) => match state {
+                State::Running(running) => {
+                    tracing::error!(
+                        "Transient Uplink manifest fetch error while running, \
+                         keeping existing operations: {e}"
+                    );
+                    running.into()
+                }
+                _ => State::Error(ServerError::Operation(OperationError::Manifest(e))),
+            },
             ServerEvent::RhaiScriptsChanged => match state {
                 State::Running(running) => {
                     running.reload_rhai_scripts();
@@ -554,6 +564,42 @@ mod tests {
         assert!(
             matches!(new_state, State::Running(_)),
             "expected server to remain Running after operations update"
+        );
+    }
+
+    // A ManifestError (transient Uplink fetch failure) while Running should NOT kill the server
+    // and must NOT clear the existing tool catalog.
+    #[tokio::test]
+    async fn manifest_error_keeps_running_server_alive_and_retains_catalog() {
+        let running = create_running_server();
+        let state = State::Running(running);
+
+        let event = ServerEvent::ManifestError(
+            "connection timeout fetching persisted query manifest".into(),
+        );
+
+        let new_state = process_event(state, event).await;
+
+        assert!(
+            matches!(new_state, State::Running(_)),
+            "expected server to remain Running after ManifestError"
+        );
+    }
+
+    // A ManifestError during startup (before Running) should be fatal.
+    #[tokio::test]
+    async fn manifest_error_during_startup_is_fatal() {
+        let event = ServerEvent::ManifestError("timeout on first fetch".into());
+
+        let state = State::Configuring(Configuring {
+            config: test_config(),
+        });
+
+        let new_state = process_event(state, event).await;
+
+        assert!(
+            matches!(new_state, State::Error(_)),
+            "expected ManifestError during startup to be fatal"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #761.

When `operations.source: uplink` is configured, a transient Uplink persisted-query manifest fetch failure (network timeout, DNS failure, HTTP 5xx, retryable `retry_later` response) previously caused the server to replace its active tool catalog with an empty list. The server continued reporting `/health` UP, sent `tools/list_changed` to connected clients, and those clients received `{"tools": []}` with no error signal.

This PR fixes the bug by mirroring the existing `CollectionError` keep-last-good pattern for manifest fetch failures.

## Root Cause

`manifest_poller.rs:44–47` converted any `Err` from the Uplink stream into `Event::UpdateManifest(vec![])` — treating a transient infrastructure failure as an authoritative "empty collection" signal:

```rust
// Before (bug): error → silently wipes catalog
Err(e) => {
    tracing::error!("error from manifest stream: {}", e);
    Event::UpdateManifest(vec![])
}
```

## Changes

- **`apollo-mcp-registry`** — Added `ManifestError(BoxError)` variant to the manifest event enum. `manifest_poller.rs` now emits `ManifestError(e)` on `Err` instead of `UpdateManifest(vec![])`.
- **`apollo-mcp-server`** — Added `ManifestError(BoxError)` to `ServerEvent` and `OperationError`. `operation_source.rs` forwards `ManifestError` through the event stream. State machine handles `ManifestError` while `Running` by retaining the existing catalog and logging the error (exactly as `CollectionError` is handled); treats it as fatal during startup before the first successful load.
- **Tests** — Two new regression tests in `states.rs`: one confirming the server stays alive with its catalog intact on `ManifestError` while Running; one confirming it is fatal during startup.

## Behavior

| Uplink response | Before | After |
|---|---|---|
| HTTP 200, non-empty manifest | Apply catalog ✅ | Apply catalog ✅ |
| HTTP 200, empty manifest | Clear catalog ✅ | Clear catalog ✅ |
| Network error / timeout | **Silent empty catalog** ❌ | Retain catalog, log error ✅ |
| HTTP 5xx / `retry_later` | **Silent empty catalog** ❌ | Retain catalog, log error ✅ |

## Test Plan

- [ ] `cargo test -p apollo-mcp-server manifest_error` — both new regression tests pass
- [ ] `cargo test -p apollo-mcp-server collection_error` — existing tests still pass
- [ ] `cargo clippy --all-targets -- --deny warnings` — no new warnings
- [ ] Manual: start server with `operations.source: uplink`, simulate Uplink unreachable, confirm `tools/list` returns previous tools and `/health` logs a structured error

🤖 Generated with [Claude Code](https://claude.com/claude-code)