### PR TITLE
refactor: tidy auth token validation and scope handling

### DIFF
--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -47,6 +47,19 @@ pub enum ScopeMode {
     RequireAny,
 }
 
+impl ScopeMode {
+    /// Whether the `present` scopes satisfy the `required` scopes under this
+    /// mode. Callers skip this check when no scopes are configured, so
+    /// `required` is expected to be non-empty.
+    fn is_satisfied_by(self, required: &[String], present: &[String]) -> bool {
+        match self {
+            ScopeMode::Disabled => true,
+            ScopeMode::RequireAll => required.iter().all(|req| present.contains(req)),
+            ScopeMode::RequireAny => required.iter().any(|req| present.contains(req)),
+        }
+    }
+}
+
 /// Errors that can occur when building a TLS-configured HTTP client
 #[derive(Debug, thiserror::Error)]
 pub enum TlsConfigError {
@@ -521,17 +534,9 @@ async fn oauth_validate(
 
     // Scope validation: only applies when scopes are configured
     if !auth_config.scopes.is_empty() {
-        let sufficient = match auth_config.scope_mode {
-            ScopeMode::Disabled => true,
-            ScopeMode::RequireAll => auth_config
-                .scopes
-                .iter()
-                .all(|req| valid_token.scopes.contains(req)),
-            ScopeMode::RequireAny => auth_config
-                .scopes
-                .iter()
-                .any(|req| valid_token.scopes.contains(req)),
-        };
+        let sufficient = auth_config
+            .scope_mode
+            .is_satisfied_by(&auth_config.scopes, &valid_token.scopes);
 
         if !sufficient {
             // Compute missing scopes for diagnostic logging
@@ -701,14 +706,7 @@ mod tests {
         use rstest::rstest;
 
         fn is_sufficient(mode: ScopeMode, required: &[String], present: &[String]) -> bool {
-            if required.is_empty() {
-                return true;
-            }
-            match mode {
-                ScopeMode::Disabled => true,
-                ScopeMode::RequireAll => required.iter().all(|req| present.contains(req)),
-                ScopeMode::RequireAny => required.iter().any(|req| present.contains(req)),
-            }
+            required.is_empty() || mode.is_satisfied_by(required, present)
         }
 
         fn s(vals: &[&str]) -> Vec<String> {

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -58,6 +58,17 @@ impl ScopeMode {
             ScopeMode::RequireAny => required.iter().any(|req| present.contains(req)),
         }
     }
+
+    /// The wire string for this mode, matching the serde `snake_case` rename.
+    /// Used when rendering the `scope_mode` hint in the `WWW-Authenticate`
+    /// header.
+    fn as_str(self) -> &'static str {
+        match self {
+            ScopeMode::Disabled => "disabled",
+            ScopeMode::RequireAll => "require_all",
+            ScopeMode::RequireAny => "require_any",
+        }
+    }
 }
 
 /// Errors that can occur when building a TLS-configured HTTP client
@@ -698,6 +709,26 @@ mod tests {
             assert!(www_auth.contains("Bearer"));
             assert!(www_auth.contains("resource_metadata"));
             assert!(!www_auth.contains("scope="));
+        }
+    }
+
+    mod scope_mode {
+        use super::*;
+
+        #[test]
+        fn as_str_matches_serde_rename() {
+            for mode in [
+                ScopeMode::Disabled,
+                ScopeMode::RequireAll,
+                ScopeMode::RequireAny,
+            ] {
+                let serde = serde_json::to_string(&mode).expect("serialize scope mode");
+                assert_eq!(
+                    format!("\"{}\"", mode.as_str()),
+                    serde,
+                    "as_str drifted from the serde rename for {mode:?}"
+                );
+            }
         }
     }
 

--- a/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
@@ -2,12 +2,12 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use jsonwebtoken::jwk::KeyAlgorithm;
-use jwks::Jwks;
+use jwks::{Jwk, Jwks};
 use serde::Deserialize;
 use tracing::{error, info, trace, warn};
 use url::Url;
 
-use super::valid_token::{KeyResolver, VerificationKey};
+use super::valid_token::KeyResolver;
 
 /// [`KeyResolver`] that fetches signing keys from the network via OIDC/OAuth
 /// discovery.
@@ -187,17 +187,14 @@ impl KeyResolver for NetworkedKeyResolver<'_> {
     /// `discovery_timeout` on the happy path. The JWKS fetch does not fall
     /// back to alternate discovery URLs on failure; real providers advertise
     /// the same `jwks_uri` from every well-known path.
-    async fn resolve_key(&self, server: &Url, key_id: &str) -> Option<VerificationKey> {
+    async fn resolve_key(&self, server: &Url, key_id: &str) -> Option<(Jwk, String)> {
         let metadata = discover_metadata(self.client, server, self.discovery_timeout).await?;
         let mut jwks = fetch_jwks(self.client, &metadata.jwks_uri, self.discovery_timeout).await?;
         let mut jwk = jwks.keys.remove(key_id)?;
         if jwk.alg.is_none() {
             jwk.alg = resolve_alg(&metadata.id_token_signing_alg_values_supported, server);
         }
-        Some(VerificationKey {
-            jwk,
-            issuer: metadata.issuer,
-        })
+        Some((jwk, metadata.issuer))
     }
 }
 

--- a/crates/apollo-mcp-server/src/auth/valid_token.rs
+++ b/crates/apollo-mcp-server/src/auth/valid_token.rs
@@ -70,78 +70,6 @@ pub(super) struct TokenValidator<'a, R: KeyResolver> {
 impl<R: KeyResolver> TokenValidator<'_, R> {
     /// Attempt to validate a token against the configured rules.
     pub(super) async fn validate(&self, token: Authorization<Bearer>) -> Option<ValidToken> {
-        /// Claims which must be present in the JWT (and must match validation)
-        /// in order for a JWT to be considered valid.
-        ///
-        /// See: https://auth0.com/docs/secure/tokens/json-web-tokens/json-web-token-claims#registered-claims
-        #[derive(Clone, Debug, Serialize, Deserialize)]
-        pub struct Claims {
-            /// The intended audience of this token.
-            /// Can be either a single string or an array of strings per JWT spec. (https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)
-            /// Some providers (e.g., AWS Cognito) omit `aud` entirely in access tokens,
-            /// so this field defaults to an empty vec when absent.
-            #[serde(default, deserialize_with = "deserialize_audience")]
-            pub aud: Vec<String>,
-
-            /// The issuer of this token (`iss`). Optional in the struct so tokens
-            /// without it still deserialize; enforced in `validate` when issuers are configured.
-            #[serde(default)]
-            pub iss: Option<String>,
-
-            /// The user who owns this token
-            pub sub: String,
-
-            /// OAuth scope claim (space-separated list per RFC 6749)
-            #[serde(default)]
-            pub scope: Option<String>,
-
-            /// Non-standard scope claim. Okta emits this as an array of
-            /// strings; Microsoft Entra emits it as a space-separated string.
-            /// Used as a fallback when the RFC 9068 `scope` claim is absent.
-            #[serde(default)]
-            pub scp: Option<ScpClaim>,
-        }
-
-        #[derive(Clone, Debug, Serialize, Deserialize)]
-        #[serde(untagged)]
-        enum ScpClaim {
-            Array(Vec<String>),
-            String(String),
-        }
-
-        impl Claims {
-            /// Resolve the scopes granted by this token, preferring the
-            /// RFC 9068 `scope` claim and falling back to the `scp` claim
-            /// used by Okta (array) and Microsoft Entra (space-separated string).
-            fn scopes(self) -> Vec<String> {
-                match (self.scope, self.scp) {
-                    (Some(s), _) | (None, Some(ScpClaim::String(s))) => {
-                        s.split_whitespace().map(String::from).collect()
-                    }
-                    (None, Some(ScpClaim::Array(v))) => v,
-                    (None, None) => Vec::new(),
-                }
-            }
-        }
-
-        fn deserialize_audience<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
-        where
-            D: serde::Deserializer<'de>,
-        {
-            #[derive(Deserialize)]
-            #[serde(untagged)]
-            enum Audience {
-                Single(String),
-                Multiple(Vec<String>),
-            }
-
-            Ok(match Option::<Audience>::deserialize(deserializer)? {
-                Some(Audience::Single(s)) => vec![s],
-                Some(Audience::Multiple(v)) => v,
-                None => Vec::new(),
-            })
-        }
-
         let jwt = token.token();
         let header = decode_header(jwt).ok()?;
         let key_id = header.kid.as_ref()?;
@@ -160,27 +88,11 @@ impl<R: KeyResolver> TokenValidator<'_, R> {
                     warn!("Skipping JWK with no algorithm specified");
                     continue;
                 };
-                let mut val = Validation::new(match alg {
-                    jwk::KeyAlgorithm::HS256 => Algorithm::HS256,
-                    jwk::KeyAlgorithm::HS384 => Algorithm::HS384,
-                    jwk::KeyAlgorithm::HS512 => Algorithm::HS512,
-                    jwk::KeyAlgorithm::ES256 => Algorithm::ES256,
-                    jwk::KeyAlgorithm::ES384 => Algorithm::ES384,
-                    jwk::KeyAlgorithm::RS256 => Algorithm::RS256,
-                    jwk::KeyAlgorithm::RS384 => Algorithm::RS384,
-                    jwk::KeyAlgorithm::RS512 => Algorithm::RS512,
-                    jwk::KeyAlgorithm::PS256 => Algorithm::PS256,
-                    jwk::KeyAlgorithm::PS384 => Algorithm::PS384,
-                    jwk::KeyAlgorithm::PS512 => Algorithm::PS512,
-                    jwk::KeyAlgorithm::EdDSA => Algorithm::EdDSA,
-
-                    // No other validation key type is supported by this library, so we
-                    // warn and fail if we encounter one.
-                    other => {
-                        warn!("Skipping JWT signed by unsupported algorithm: {other:?}");
-                        continue;
-                    }
-                });
+                let Some(algorithm) = jwt_algorithm(alg) else {
+                    warn!("Skipping JWT signed by unsupported algorithm: {alg:?}");
+                    continue;
+                };
+                let mut val = Validation::new(algorithm);
                 if self.allow_any_audience {
                     val.validate_aud = false;
                 } else {
@@ -242,6 +154,101 @@ impl<R: KeyResolver> TokenValidator<'_, R> {
     }
 }
 
+/// Claims which must be present in the JWT (and must match validation) in order
+/// for a JWT to be considered valid.
+///
+/// See: https://auth0.com/docs/secure/tokens/json-web-tokens/json-web-token-claims#registered-claims
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Claims {
+    /// The intended audience of this token.
+    /// Can be either a single string or an array of strings per JWT spec. (https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)
+    /// Some providers (e.g., AWS Cognito) omit `aud` entirely in access tokens,
+    /// so this field defaults to an empty vec when absent.
+    #[serde(default, deserialize_with = "deserialize_audience")]
+    aud: Vec<String>,
+
+    /// The issuer of this token (`iss`). Optional in the struct so tokens
+    /// without it still deserialize; enforced in `validate` when issuers are configured.
+    #[serde(default)]
+    iss: Option<String>,
+
+    /// The subject the token was issued for. Required so a token without a
+    /// `sub` claim is rejected at deserialize time.
+    sub: String,
+
+    /// OAuth scope claim (space-separated list per RFC 6749)
+    #[serde(default)]
+    scope: Option<String>,
+
+    /// Non-standard scope claim. Okta emits this as an array of
+    /// strings; Microsoft Entra emits it as a space-separated string.
+    /// Used as a fallback when the RFC 9068 `scope` claim is absent.
+    #[serde(default)]
+    scp: Option<ScpClaim>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+enum ScpClaim {
+    Array(Vec<String>),
+    String(String),
+}
+
+impl Claims {
+    /// Resolve the scopes granted by this token, preferring the RFC 9068
+    /// `scope` claim and falling back to the `scp` claim used by Okta (array)
+    /// and Microsoft Entra (space-separated string).
+    fn scopes(self) -> Vec<String> {
+        match (self.scope, self.scp) {
+            (Some(s), _) | (None, Some(ScpClaim::String(s))) => {
+                s.split_whitespace().map(String::from).collect()
+            }
+            (None, Some(ScpClaim::Array(v))) => v,
+            (None, None) => Vec::new(),
+        }
+    }
+}
+
+/// Accepts the JWT `aud` claim as either a single string or an array of
+/// strings, normalizing both to a `Vec<String>` (empty when absent).
+fn deserialize_audience<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Audience {
+        Single(String),
+        Multiple(Vec<String>),
+    }
+
+    Ok(match Option::<Audience>::deserialize(deserializer)? {
+        Some(Audience::Single(s)) => vec![s],
+        Some(Audience::Multiple(v)) => v,
+        None => Vec::new(),
+    })
+}
+
+/// Maps a JWKS key algorithm to the `jsonwebtoken` [`Algorithm`] used for
+/// verification, returning `None` for algorithms this library does not support.
+fn jwt_algorithm(alg: jwk::KeyAlgorithm) -> Option<Algorithm> {
+    Some(match alg {
+        jwk::KeyAlgorithm::HS256 => Algorithm::HS256,
+        jwk::KeyAlgorithm::HS384 => Algorithm::HS384,
+        jwk::KeyAlgorithm::HS512 => Algorithm::HS512,
+        jwk::KeyAlgorithm::ES256 => Algorithm::ES256,
+        jwk::KeyAlgorithm::ES384 => Algorithm::ES384,
+        jwk::KeyAlgorithm::RS256 => Algorithm::RS256,
+        jwk::KeyAlgorithm::RS384 => Algorithm::RS384,
+        jwk::KeyAlgorithm::RS512 => Algorithm::RS512,
+        jwk::KeyAlgorithm::PS256 => Algorithm::PS256,
+        jwk::KeyAlgorithm::PS384 => Algorithm::PS384,
+        jwk::KeyAlgorithm::PS512 => Algorithm::PS512,
+        jwk::KeyAlgorithm::EdDSA => Algorithm::EdDSA,
+        _ => return None,
+    })
+}
+
 #[cfg(test)]
 mod test {
     use std::str::FromStr;
@@ -253,7 +260,7 @@ mod test {
     use tracing_test::traced_test;
     use url::Url;
 
-    use super::{KeyResolver, TokenValidator, ValidToken, VerificationKey};
+    use super::{Claims, KeyResolver, TokenValidator, ValidToken, VerificationKey, jwt_algorithm};
 
     /// A single upstream server in the stub resolver: its URL, the one
     /// `(kid, jwk)` it serves, and the issuer it advertises in discovery.
@@ -1232,104 +1239,49 @@ mod test {
         assert_eq!(test_validator.validate(jwt).await, None);
     }
 
-    /// Build and validate a JWT with the given claims JSON, returning the
-    /// extracted scopes from the resulting `ValidToken`.
-    async fn validate_with_claims(claims: serde_json::Value) -> Vec<String> {
-        let key_id = "some-example-id".to_string();
-        let (encode_key, decode_key) = create_key("DEADBEEF");
-        let jwk = Jwk {
-            alg: Some(KeyAlgorithm::HS512),
-            decoding_key: decode_key,
-        };
-
-        let header = {
-            let mut h = Header::new(Algorithm::HS512);
-            h.kid = Some(key_id.clone());
-            h
-        };
-        let token = encode(&header, &claims, &encode_key).expect("encode JWT");
-        let jwt = Authorization::bearer(&token).expect("create bearer token");
-
-        let server =
-            Url::from_str("https://auth.example.com").expect("should parse a valid example server");
-
-        let test_validator = TestTokenValidator::single(
-            vec!["test-audience".to_string()],
-            vec![],
-            false,
-            (key_id, jwk),
-            server,
-        );
-
-        test_validator
-            .validate(jwt)
-            .await
-            .expect("valid token")
-            .scopes
+    /// Deserialize [`Claims`] from JSON and resolve its scopes. Exercises the
+    /// `scope`/`scp` claim handling directly, without the JWT round-trip.
+    fn scopes_of(claims: serde_json::Value) -> Vec<String> {
+        serde_json::from_value::<Claims>(claims)
+            .expect("deserialize claims")
+            .scopes()
     }
 
-    #[tokio::test]
-    async fn it_extracts_scopes_from_scope_claim() {
-        let in_the_future = chrono::Utc::now().timestamp() + 1000;
-        let scopes = validate_with_claims(serde_json::json!({
-            "aud": "test-audience",
-            "exp": in_the_future,
-            "sub": "test user",
-            "scope": "read write"
-        }))
-        .await;
+    #[test]
+    fn scopes_come_from_scope_claim() {
+        let scopes = scopes_of(serde_json::json!({ "sub": "u", "scope": "read write" }));
         assert_eq!(scopes, vec!["read".to_string(), "write".to_string()]);
     }
 
-    #[tokio::test]
-    async fn it_extracts_scopes_from_scp_array_claim() {
-        let in_the_future = chrono::Utc::now().timestamp() + 1000;
-        let scopes = validate_with_claims(serde_json::json!({
-            "aud": "test-audience",
-            "exp": in_the_future,
-            "sub": "test user",
-            "scp": ["read", "write"]
-        }))
-        .await;
+    #[test]
+    fn scopes_fall_back_to_scp_array() {
+        let scopes = scopes_of(serde_json::json!({ "sub": "u", "scp": ["read", "write"] }));
         assert_eq!(scopes, vec!["read".to_string(), "write".to_string()]);
     }
 
-    #[tokio::test]
-    async fn it_extracts_scopes_from_scp_string_claim() {
-        let in_the_future = chrono::Utc::now().timestamp() + 1000;
-        let scopes = validate_with_claims(serde_json::json!({
-            "aud": "test-audience",
-            "exp": in_the_future,
-            "sub": "test user",
-            "scp": "read write"
-        }))
-        .await;
+    #[test]
+    fn scopes_fall_back_to_scp_string() {
+        let scopes = scopes_of(serde_json::json!({ "sub": "u", "scp": "read write" }));
         assert_eq!(scopes, vec!["read".to_string(), "write".to_string()]);
     }
 
-    #[tokio::test]
-    async fn it_prefers_scope_over_scp_when_both_present() {
-        let in_the_future = chrono::Utc::now().timestamp() + 1000;
-        let scopes = validate_with_claims(serde_json::json!({
-            "aud": "test-audience",
-            "exp": in_the_future,
-            "sub": "test user",
-            "scope": "read",
-            "scp": ["write"]
-        }))
-        .await;
+    #[test]
+    fn scope_claim_wins_over_scp() {
+        let scopes =
+            scopes_of(serde_json::json!({ "sub": "u", "scope": "read", "scp": ["write"] }));
         assert_eq!(scopes, vec!["read".to_string()]);
     }
 
-    #[tokio::test]
-    async fn it_returns_empty_scopes_when_neither_claim_present() {
-        let in_the_future = chrono::Utc::now().timestamp() + 1000;
-        let scopes = validate_with_claims(serde_json::json!({
-            "aud": "test-audience",
-            "exp": in_the_future,
-            "sub": "test user"
-        }))
-        .await;
+    #[test]
+    fn scopes_empty_when_neither_claim_present() {
+        let scopes = scopes_of(serde_json::json!({ "sub": "u" }));
         assert!(scopes.is_empty());
+    }
+
+    #[test]
+    fn jwt_algorithm_maps_supported_algorithms() {
+        assert_eq!(jwt_algorithm(KeyAlgorithm::HS512), Some(Algorithm::HS512));
+        assert_eq!(jwt_algorithm(KeyAlgorithm::RS256), Some(Algorithm::RS256));
+        assert_eq!(jwt_algorithm(KeyAlgorithm::EdDSA), Some(Algorithm::EdDSA));
     }
 }

--- a/crates/apollo-mcp-server/src/auth/valid_token.rs
+++ b/crates/apollo-mcp-server/src/auth/valid_token.rs
@@ -25,19 +25,6 @@ impl Deref for ValidToken {
     }
 }
 
-/// A signing key resolved from an authorization server, together with that
-/// server's discovered issuer identifier.
-///
-/// `issuer` is the `iss` value the authorization server advertises in its
-/// discovery metadata. It is used to bind issuer validation to the server
-/// whose JWKS verified the signature: a token's `iss` claim must equal this
-/// value, so a token signed by one configured server cannot pass by claiming
-/// a different configured server's issuer.
-pub(super) struct VerificationKey {
-    pub(super) jwk: Jwk,
-    pub(super) issuer: String,
-}
-
 /// Resolves a signing key for a `(server, key_id)` pair, returning it together
 /// with the issuer that server advertises in discovery.
 ///
@@ -46,10 +33,14 @@ pub(super) struct VerificationKey {
 /// [`TokenValidator`], so adding a new validation input does not touch this
 /// trait or its implementations.
 pub(super) trait KeyResolver {
-    /// Fetch the signing key by its ID, along with the issuing server's
-    /// discovered issuer identifier. Returns `None` when the server does not
-    /// serve a key with that `key_id`.
-    async fn resolve_key(&self, server: &Url, key_id: &str) -> Option<VerificationKey>;
+    /// Fetch the signing key for `key_id`, together with the issuer the server
+    /// advertises in its discovery metadata. Returns `None` when the server
+    /// does not serve a key with that `key_id`.
+    ///
+    /// The returned issuer is the value issuer validation binds to: a token's
+    /// `iss` claim must equal it, so a token signed by one configured server
+    /// cannot pass by claiming a different server's issuer.
+    async fn resolve_key(&self, server: &Url, key_id: &str) -> Option<(Jwk, String)>;
 }
 
 /// Validates bearer JWTs against the configured audiences, issuers, and upstream
@@ -75,11 +66,7 @@ impl<R: KeyResolver> TokenValidator<'_, R> {
         let key_id = header.kid.as_ref()?;
 
         for server in self.servers {
-            let Some(VerificationKey {
-                jwk,
-                issuer: discovered_issuer,
-            }) = self.keys.resolve_key(server, key_id).await
-            else {
+            let Some((jwk, discovered_issuer)) = self.keys.resolve_key(server, key_id).await else {
                 continue;
             };
 
@@ -260,7 +247,7 @@ mod test {
     use tracing_test::traced_test;
     use url::Url;
 
-    use super::{Claims, KeyResolver, TokenValidator, ValidToken, VerificationKey, jwt_algorithm};
+    use super::{Claims, KeyResolver, TokenValidator, ValidToken, jwt_algorithm};
 
     /// A single upstream server in the stub resolver: its URL, the one
     /// `(kid, jwk)` it serves, and the issuer it advertises in discovery.
@@ -276,12 +263,14 @@ mod test {
     }
 
     impl KeyResolver for StubKeyResolver<'_> {
-        async fn resolve_key(&self, server: &Url, key_id: &str) -> Option<VerificationKey> {
+        async fn resolve_key(&self, server: &Url, key_id: &str) -> Option<(Jwk, String)> {
             // Find the requested server, then return its key only if the `kid` matches.
             let test_server = self.servers.iter().find(|s| &s.url == server)?;
-            test_server.key_pair.0.eq(key_id).then(|| VerificationKey {
-                jwk: test_server.key_pair.1.clone(),
-                issuer: test_server.discovered_issuer.clone(),
+            test_server.key_pair.0.eq(key_id).then(|| {
+                (
+                    test_server.key_pair.1.clone(),
+                    test_server.discovered_issuer.clone(),
+                )
             })
         }
     }

--- a/crates/apollo-mcp-server/src/auth/valid_token.rs
+++ b/crates/apollo-mcp-server/src/auth/valid_token.rs
@@ -1195,6 +1195,40 @@ mod test {
         });
     }
 
+    #[traced_test]
+    #[tokio::test]
+    async fn it_rejects_jwk_with_unsupported_algorithm() {
+        let key_id = "some-example-id".to_string();
+        let (encode_key, decode_key) = create_key("DEADBEEF");
+        // The JWK advertises a key-management algorithm the validator does not
+        // support for token signing, so `jwt_algorithm` returns `None`.
+        let jwk = Jwk {
+            alg: Some(KeyAlgorithm::RSA1_5),
+            decoding_key: decode_key,
+        };
+
+        let audience = "test-audience".to_string();
+        let in_the_future = chrono::Utc::now().timestamp() + 1000;
+        let jwt = create_jwt(key_id.clone(), encode_key, audience.clone(), in_the_future);
+
+        let server =
+            Url::from_str("https://auth.example.com").expect("should parse a valid example server");
+
+        let test_validator =
+            TestTokenValidator::single(vec![audience], vec![], false, (key_id, jwk), server);
+
+        assert_eq!(test_validator.validate(jwt).await, None);
+
+        logs_assert(|lines: &[&str]| {
+            lines
+                .iter()
+                .filter(|line| line.contains("WARN"))
+                .any(|line| line.contains("unsupported algorithm"))
+                .then_some(())
+                .ok_or("Expected warning for unsupported algorithm".to_string())
+        });
+    }
+
     #[tokio::test]
     async fn it_rejects_when_no_server_serves_the_kid() {
         let (encode_key, decode_key) = create_key("DEADBEEF");
@@ -1268,9 +1302,37 @@ mod test {
     }
 
     #[test]
-    fn jwt_algorithm_maps_supported_algorithms() {
-        assert_eq!(jwt_algorithm(KeyAlgorithm::HS512), Some(Algorithm::HS512));
-        assert_eq!(jwt_algorithm(KeyAlgorithm::RS256), Some(Algorithm::RS256));
-        assert_eq!(jwt_algorithm(KeyAlgorithm::EdDSA), Some(Algorithm::EdDSA));
+    fn null_audience_deserializes_to_empty() {
+        let claims: Claims = serde_json::from_value(serde_json::json!({ "sub": "u", "aud": null }))
+            .expect("deserialize claims");
+        assert!(claims.aud.is_empty());
+    }
+
+    #[test]
+    fn jwt_algorithm_maps_every_supported_algorithm() {
+        use KeyAlgorithm::*;
+        let supported = [
+            (HS256, Algorithm::HS256),
+            (HS384, Algorithm::HS384),
+            (HS512, Algorithm::HS512),
+            (ES256, Algorithm::ES256),
+            (ES384, Algorithm::ES384),
+            (RS256, Algorithm::RS256),
+            (RS384, Algorithm::RS384),
+            (RS512, Algorithm::RS512),
+            (PS256, Algorithm::PS256),
+            (PS384, Algorithm::PS384),
+            (PS512, Algorithm::PS512),
+            (EdDSA, Algorithm::EdDSA),
+        ];
+        for (key_alg, expected) in supported {
+            assert_eq!(jwt_algorithm(key_alg), Some(expected), "{key_alg:?}");
+        }
+    }
+
+    #[test]
+    fn jwt_algorithm_returns_none_for_unsupported() {
+        // `RSA1_5` is a key-management algorithm, not a token-signing one.
+        assert_eq!(jwt_algorithm(KeyAlgorithm::RSA1_5), None);
     }
 }

--- a/crates/apollo-mcp-server/src/auth/www_authenticate.rs
+++ b/crates/apollo-mcp-server/src/auth/www_authenticate.rs
@@ -62,11 +62,7 @@ impl Header for WwwAuthenticate {
                     header.push_str(&format!(r#", scope="{}""#, scope));
                 }
                 if let Some(scope_mode) = scope_mode {
-                    let mode_str = serde_json::to_string(&scope_mode)
-                        .unwrap_or_else(|_| "unknown".to_string())
-                        .trim_matches('"')
-                        .to_string();
-                    header.push_str(&format!(r#", scope_mode="{}""#, mode_str));
+                    header.push_str(&format!(r#", scope_mode="{}""#, scope_mode.as_str()));
                 }
                 header
             }


### PR DESCRIPTION
On the validation side, we're moving the `Claims` type and the algorithm mapping out of the long `validate` method. Now, the function reads more clearly as a "try each server, resolve key, decode, check claims" loop, and we can unit-test the claim logic directly. We’re also replacing the `VerificationKey` struct with a simple `(Jwk, String)` tuple returned from `KeyResolver::resolve_key`.

On the scope side, we're pulling the scope-sufficiency check into a new `ScopeMode::is_satisfied_by` method. This way, the scope tests will use the actual logic instead of a copied version. We’re also rendering the `scope_mode` header through `ScopeMode::as_str` instead of going through a JSON round-trip.