### PR TITLE
refactor: consolidate ScopeMode logic into methods

### DIFF
--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -47,6 +47,19 @@ pub enum ScopeMode {
     RequireAny,
 }
 
+impl ScopeMode {
+    /// Whether the `present` scopes satisfy the `required` scopes under this
+    /// mode. Callers skip this check when no scopes are configured, so
+    /// `required` is expected to be non-empty.
+    fn is_satisfied_by(self, required: &[String], present: &[String]) -> bool {
+        match self {
+            ScopeMode::Disabled => true,
+            ScopeMode::RequireAll => required.iter().all(|req| present.contains(req)),
+            ScopeMode::RequireAny => required.iter().any(|req| present.contains(req)),
+        }
+    }
+}
+
 /// Errors that can occur when building a TLS-configured HTTP client
 #[derive(Debug, thiserror::Error)]
 pub enum TlsConfigError {
@@ -521,17 +534,9 @@ async fn oauth_validate(
 
     // Scope validation: only applies when scopes are configured
     if !auth_config.scopes.is_empty() {
-        let sufficient = match auth_config.scope_mode {
-            ScopeMode::Disabled => true,
-            ScopeMode::RequireAll => auth_config
-                .scopes
-                .iter()
-                .all(|req| valid_token.scopes.contains(req)),
-            ScopeMode::RequireAny => auth_config
-                .scopes
-                .iter()
-                .any(|req| valid_token.scopes.contains(req)),
-        };
+        let sufficient = auth_config
+            .scope_mode
+            .is_satisfied_by(&auth_config.scopes, &valid_token.scopes);
 
         if !sufficient {
             // Compute missing scopes for diagnostic logging
@@ -701,14 +706,7 @@ mod tests {
         use rstest::rstest;
 
         fn is_sufficient(mode: ScopeMode, required: &[String], present: &[String]) -> bool {
-            if required.is_empty() {
-                return true;
-            }
-            match mode {
-                ScopeMode::Disabled => true,
-                ScopeMode::RequireAll => required.iter().all(|req| present.contains(req)),
-                ScopeMode::RequireAny => required.iter().any(|req| present.contains(req)),
-            }
+            required.is_empty() || mode.is_satisfied_by(required, present)
         }
 
         fn s(vals: &[&str]) -> Vec<String> {

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -58,6 +58,17 @@ impl ScopeMode {
             ScopeMode::RequireAny => required.iter().any(|req| present.contains(req)),
         }
     }
+
+    /// The wire string for this mode, matching the serde `snake_case` rename.
+    /// Used when rendering the `scope_mode` hint in the `WWW-Authenticate`
+    /// header.
+    fn as_str(self) -> &'static str {
+        match self {
+            ScopeMode::Disabled => "disabled",
+            ScopeMode::RequireAll => "require_all",
+            ScopeMode::RequireAny => "require_any",
+        }
+    }
 }
 
 /// Errors that can occur when building a TLS-configured HTTP client
@@ -698,6 +709,26 @@ mod tests {
             assert!(www_auth.contains("Bearer"));
             assert!(www_auth.contains("resource_metadata"));
             assert!(!www_auth.contains("scope="));
+        }
+    }
+
+    mod scope_mode {
+        use super::*;
+
+        #[test]
+        fn as_str_matches_serde_rename() {
+            for mode in [
+                ScopeMode::Disabled,
+                ScopeMode::RequireAll,
+                ScopeMode::RequireAny,
+            ] {
+                let serde = serde_json::to_string(&mode).expect("serialize scope mode");
+                assert_eq!(
+                    format!("\"{}\"", mode.as_str()),
+                    serde,
+                    "as_str drifted from the serde rename for {mode:?}"
+                );
+            }
         }
     }
 

--- a/crates/apollo-mcp-server/src/auth/www_authenticate.rs
+++ b/crates/apollo-mcp-server/src/auth/www_authenticate.rs
@@ -62,11 +62,7 @@ impl Header for WwwAuthenticate {
                     header.push_str(&format!(r#", scope="{}""#, scope));
                 }
                 if let Some(scope_mode) = scope_mode {
-                    let mode_str = serde_json::to_string(&scope_mode)
-                        .unwrap_or_else(|_| "unknown".to_string())
-                        .trim_matches('"')
-                        .to_string();
-                    header.push_str(&format!(r#", scope_mode="{}""#, mode_str));
+                    header.push_str(&format!(r#", scope_mode="{}""#, scope_mode.as_str()));
                 }
                 header
             }


### PR DESCRIPTION
This PR moves the scope-sufficiency `match` out of the `oauth_validate` middleware and into a `ScopeMode::is_satisfied_by` method. This change simplifies the middleware to a single condition. More importantly, it allows the scope-validation tests to call the actual method instead of a hand-copied version that could drift from production. It also updates the `scope_mode` header rendering. Previously, it serialized the enum to JSON just to trim the quotes and included an unreachable `"unknown"` fallback. Now, it uses a straightforward and reliable `ScopeMode::as_str`. A small guard test ensures that `as_str` stays in sync with the serde `snake_case` rename.