### PR TITLE
fix: tolerate transient Uplink manifest errors at startup

### DIFF
--- a/.changeset/fix_uplink_manifest_startup_resilience.md
+++ b/.changeset/fix_uplink_manifest_startup_resilience.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+# Tolerate transient Uplink manifest fetch errors during startup
+
+A transient Uplink persisted-query manifest fetch error (network timeout, DNS failure, HTTP 5xx, or a retryable `retry_later` response) is now retried instead of being treated as fatal. Previously the first such error during startup would exit the server, even though the Uplink poll loop would have recovered on the next tick.
+
+Apollo MCP Server now distinguishes transient errors (logged at warn and retried by the poll loop) from non-retryable errors such as an invalid API key (which remain fatal during startup and surface as an error while running). This matches how operation collections already behave, and the keep-last-good handling added previously is unchanged.

--- a/crates/apollo-mcp-registry/src/uplink.rs
+++ b/crates/apollo-mcp-registry/src/uplink.rs
@@ -36,6 +36,23 @@ pub enum Error {
     UplinkErrorNoRetry { code: String, message: String },
 }
 
+impl Error {
+    /// Returns `true` if the uplink poll loop treats this error as transient and keeps
+    /// polling, recovering on a later tick. Only `UplinkErrorNoRetry` stops the loop.
+    /// Callers use this to decide whether a manifest fetch error should be surfaced or
+    /// quietly retried. The match is exhaustive on purpose so a new variant must be
+    /// classified explicitly rather than silently defaulting to retryable.
+    pub(crate) fn is_transient(&self) -> bool {
+        match self {
+            Error::Http(_)
+            | Error::FetchFailedSingle
+            | Error::FetchFailedMultiple { .. }
+            | Error::UplinkError { .. } => true,
+            Error::UplinkErrorNoRetry { .. } => false,
+        }
+    }
+}
+
 /// Represents a request to Apollo Uplink
 #[derive(Debug)]
 pub struct UplinkRequest {
@@ -648,6 +665,27 @@ mod test {
         assert_eq!(
             error4.to_string(),
             "uplink error, the request will not be retried: code=UNKNOWN_REF message=Graph not found"
+        );
+    }
+
+    #[test]
+    fn is_transient_classifies_retryable_errors() {
+        // The poll loop keeps retrying every variant except UplinkErrorNoRetry.
+        assert!(Error::FetchFailedSingle.is_transient());
+        assert!(Error::FetchFailedMultiple { url_count: 3 }.is_transient());
+        assert!(
+            Error::UplinkError {
+                code: "TIMEOUT".to_string(),
+                message: "retry later".to_string(),
+            }
+            .is_transient()
+        );
+        assert!(
+            !Error::UplinkErrorNoRetry {
+                code: "UNKNOWN_REF".to_string(),
+                message: "Graph not found".to_string(),
+            }
+            .is_transient()
         );
     }
 

--- a/crates/apollo-mcp-registry/src/uplink.rs
+++ b/crates/apollo-mcp-registry/src/uplink.rs
@@ -439,6 +439,8 @@ mod test {
     use std::str::FromStr;
     use std::time::Duration;
     use url::Url;
+    use wiremock::matchers::any;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[tokio::test]
     async fn streams_schema_from_uplink() {
@@ -668,11 +670,32 @@ mod test {
         );
     }
 
+    #[tokio::test]
+    async fn http_error_is_transient() {
+        let mock_server = MockServer::start().await;
+        Mock::given(any())
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&mock_server)
+            .await;
+
+        let response = reqwest::get(mock_server.uri()).await.unwrap();
+        let error = Error::Http(response.error_for_status().unwrap_err());
+
+        assert!(error.is_transient());
+    }
+
     #[test]
-    fn is_transient_classifies_retryable_errors() {
-        // The poll loop keeps retrying every variant except UplinkErrorNoRetry.
+    fn fetch_failed_single_is_transient() {
         assert!(Error::FetchFailedSingle.is_transient());
+    }
+
+    #[test]
+    fn fetch_failed_multiple_is_transient() {
         assert!(Error::FetchFailedMultiple { url_count: 3 }.is_transient());
+    }
+
+    #[test]
+    fn uplink_error_with_retry_is_transient() {
         assert!(
             Error::UplinkError {
                 code: "TIMEOUT".to_string(),
@@ -680,6 +703,10 @@ mod test {
             }
             .is_transient()
         );
+    }
+
+    #[test]
+    fn uplink_error_no_retry_is_not_transient() {
         assert!(
             !Error::UplinkErrorNoRetry {
                 code: "UNKNOWN_REF".to_string(),

--- a/crates/apollo-mcp-registry/src/uplink/persisted_queries/manifest_poller.rs
+++ b/crates/apollo-mcp-registry/src/uplink/persisted_queries/manifest_poller.rs
@@ -193,13 +193,28 @@ fn create_uplink_stream(
             }
         }))
     })
-    .filter_map(|result| async move {
-        match result {
-            Ok(Some(manifest)) => Some(Ok(manifest)),
-            Ok(None) => Some(Ok(PersistedQueryManifest::default())),
-            Err(e) => Some(Err(e.into())),
+    .filter_map(|result| async move { classify_uplink_manifest_result(result) })
+}
+
+/// Maps a raw uplink manifest result into a stream item.
+///
+/// Transient errors are logged and dropped (`None`) so the uplink poll loop keeps polling
+/// and recovers on the next tick, rather than surfacing a `ManifestError` that would be
+/// fatal at startup. Only non-retryable errors are forwarded. A successful response is
+/// passed through and an empty response (`Ok(None)`) becomes an empty manifest. Mirrors
+/// the operation collection path's `is_transient` handling.
+fn classify_uplink_manifest_result(
+    result: Result<Option<PersistedQueryManifest>, crate::uplink::Error>,
+) -> Option<Result<PersistedQueryManifest, BoxError>> {
+    match result {
+        Ok(Some(manifest)) => Some(Ok(manifest)),
+        Ok(None) => Some(Ok(PersistedQueryManifest::default())),
+        Err(e) if e.is_transient() => {
+            tracing::warn!("transient error fetching persisted query manifest, will retry: {e}");
+            None
         }
-    })
+        Err(e) => Some(Err(e.into())),
+    }
 }
 
 fn create_hot_reload_stream(
@@ -245,4 +260,45 @@ fn create_hot_reload_stream(
             manifest
         })
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::uplink::Error;
+
+    #[test]
+    fn classify_passes_through_loaded_manifest() {
+        let result = Ok(Some(PersistedQueryManifest::default()));
+        assert!(matches!(
+            classify_uplink_manifest_result(result),
+            Some(Ok(_))
+        ));
+    }
+
+    #[test]
+    fn classify_treats_empty_response_as_empty_manifest() {
+        assert!(matches!(
+            classify_uplink_manifest_result(Ok(None)),
+            Some(Ok(_))
+        ));
+    }
+
+    #[test]
+    fn classify_drops_transient_error_so_the_poll_loop_retries() {
+        let result = Err(Error::FetchFailedSingle);
+        assert!(classify_uplink_manifest_result(result).is_none());
+    }
+
+    #[test]
+    fn classify_forwards_non_retryable_error() {
+        let result = Err(Error::UplinkErrorNoRetry {
+            code: "UNKNOWN_REF".to_string(),
+            message: "Graph not found".to_string(),
+        });
+        assert!(matches!(
+            classify_uplink_manifest_result(result),
+            Some(Err(_))
+        ));
+    }
 }

--- a/crates/apollo-mcp-server/src/server/states.rs
+++ b/crates/apollo-mcp-server/src/server/states.rs
@@ -213,11 +213,7 @@ impl StateMachine {
             },
             ServerEvent::ManifestError(e) => match state {
                 State::Running(running) => {
-                    // Transient uplink errors are filtered out upstream in
-                    // create_uplink_stream, so only non-retryable errors reach here.
-                    // Keep the last known good operations and log at error level,
-                    // matching the CollectionError handling above.
-                    tracing::error!(
+                    tracing::warn!(
                         "Manifest error while running, keeping existing operations: {e}"
                     );
                     running.into()
@@ -570,8 +566,7 @@ mod tests {
         );
     }
 
-    // A ManifestError (a non-retryable manifest fetch failure, since transient ones are
-    // filtered upstream) while Running should NOT kill the server or clear the catalog.
+    // A ManifestError while Running should NOT kill the server or clear the catalog.
     #[tokio::test]
     async fn manifest_error_keeps_running_server_alive_and_retains_catalog() {
         let running = create_running_server();

--- a/crates/apollo-mcp-server/src/server/states.rs
+++ b/crates/apollo-mcp-server/src/server/states.rs
@@ -213,9 +213,12 @@ impl StateMachine {
             },
             ServerEvent::ManifestError(e) => match state {
                 State::Running(running) => {
-                    tracing::warn!(
-                        "Transient manifest fetch error while running, \
-                         keeping existing operations: {e}"
+                    // Transient uplink errors are filtered out upstream in
+                    // create_uplink_stream, so only non-retryable errors reach here.
+                    // Keep the last known good operations and log at error level,
+                    // matching the CollectionError handling above.
+                    tracing::error!(
+                        "Manifest error while running, keeping existing operations: {e}"
                     );
                     running.into()
                 }
@@ -567,8 +570,8 @@ mod tests {
         );
     }
 
-    // A ManifestError (transient Uplink fetch failure) while Running should NOT kill the server
-    // and must NOT clear the existing tool catalog.
+    // A ManifestError (a non-retryable manifest fetch failure, since transient ones are
+    // filtered upstream) while Running should NOT kill the server or clear the catalog.
     #[tokio::test]
     async fn manifest_error_keeps_running_server_alive_and_retains_catalog() {
         let running = create_running_server();
@@ -616,6 +619,34 @@ mod tests {
         assert!(
             matches!(new_state, State::Error(_)),
             "expected ManifestError during startup to be fatal"
+        );
+    }
+
+    // Contrast with ManifestError: an authoritative empty manifest (HTTP 200 with no
+    // operations) arrives as OperationsUpdated([]) and SHOULD clear the operations.
+    #[tokio::test]
+    async fn empty_operations_update_clears_operations_while_running() {
+        let running = create_running_server();
+        let state = State::Running(running);
+
+        // Load one operation, then deliver an authoritative empty update.
+        let state = process_event(
+            state,
+            ServerEvent::OperationsUpdated(vec![RawOperation::from((
+                "query GetId { id }".to_string(),
+                Some("test.graphql".to_string()),
+            ))]),
+        )
+        .await;
+
+        let new_state = process_event(state, ServerEvent::OperationsUpdated(vec![])).await;
+
+        let State::Running(running) = new_state else {
+            panic!("expected server to remain Running after an intentional empty update");
+        };
+        assert!(
+            running.operations.read().await.is_empty(),
+            "an authoritative empty manifest should clear the operations"
         );
     }
 


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-524 -->

After #762 the server still treated every persisted-query manifest fetch error as fatal during startup, so a brief Uplink blip at boot would crash the process even though the Uplink poll loop would have recovered on the very next tick. This change classifies manifest errors as transient or permanent in the Uplink stream, where the typed error is still available, so transient errors are logged at warn and left for the poll loop to retry while only non-retryable errors such as an invalid API key remain fatal at startup and surface as an error while running. That brings the manifest path in line with how operation collections already behave.