### PR TITLE
fix: negotiate MCP protocol version in initialize handler

### DIFF
--- a/.changeset/fix_protocol_version_negotiation.md
+++ b/.changeset/fix_protocol_version_negotiation.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+# Fix protocol version negotiation when output schema is enabled
+
+Enabling `overrides.enable_output_schema` previously forced the MCP `initialize` response to advertise protocol version `2025-11-25`. Over the `streamable_http` transport that version was returned to clients verbatim, so any client that did not support `2025-11-25` was refused with `Server's protocol version is not supported: 2025-11-25`. With the flag disabled the server advertised `2025-03-26` and connected normally.
+
+The server now negotiates the protocol version per the MCP lifecycle spec, echoing the client's requested version when it is supported and otherwise responding with the latest version the server supports (`2025-06-18`). The negotiated version no longer depends on `enable_output_schema`. The `outputSchema` and `structuredContent` fields stay gated by the negotiated version (`2025-06-18` and later), so older clients keep connecting without those fields.

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -639,7 +639,9 @@ impl ServerHandler for Running {
         // TODO: how to remove these?
         let mut peers = self.peers.write().await;
         peers.push(context.peer);
-        Ok(self.get_info())
+        let mut info = self.get_info();
+        info.protocol_version = negotiate_protocol_version(&request.protocol_version);
+        Ok(info)
     }
 
     #[tracing::instrument(skip_all, parent = get_parent_span(&context), fields(apollo.mcp.tool_name = request.name.as_ref(), apollo.mcp.request_id = %context.id.clone(), apollo.mcp.tool_arguments = tracing::field::Empty, apollo.mcp.tool_result = tracing::field::Empty))]
@@ -757,11 +759,10 @@ impl ServerHandler for Running {
         capabilities.prompts =
             (!self.prompts.is_empty()).then_some(PromptsCapability { list_changed: None });
 
-        let protocol_version = if self.enable_output_schema {
-            ProtocolVersion::default()
-        } else {
-            ProtocolVersion::V_2025_03_26
-        };
+        // Advertise our latest supported version as the default. The actual
+        // negotiated value is set per client in `initialize` via
+        // `negotiate_protocol_version`.
+        let protocol_version = LATEST_PROTOCOL_VERSION.clone();
 
         let mut impl_ = Implementation::new(
             self.server_info.name().to_string(),
@@ -783,6 +784,29 @@ impl ServerHandler for Running {
             result = result.with_instructions(instructions);
         }
         result
+    }
+}
+
+/// Latest MCP protocol version this server implements. Advertised when the
+/// client requests a version we do not support.
+const LATEST_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V_2025_06_18;
+
+/// MCP protocol versions this server implements.
+const SUPPORTED_PROTOCOL_VERSIONS: [ProtocolVersion; 2] =
+    [LATEST_PROTOCOL_VERSION, ProtocolVersion::V_2025_03_26];
+
+/// Negotiate the protocol version for the `initialize` response.
+///
+/// Per the MCP lifecycle spec, the server echoes the client's requested version
+/// when it implements that version, otherwise it responds with its latest
+/// supported version. This keeps negotiation independent of `enable_output_schema`:
+/// the `outputSchema` / `structuredContent` fields are gated separately by
+/// [`Running::client_supports_output_schema`].
+fn negotiate_protocol_version(requested: &ProtocolVersion) -> ProtocolVersion {
+    if SUPPORTED_PROTOCOL_VERSIONS.contains(requested) {
+        requested.clone()
+    } else {
+        LATEST_PROTOCOL_VERSION.clone()
     }
 }
 
@@ -2038,6 +2062,7 @@ mod tests {
 
     mod get_info {
         use super::*;
+        use rstest::rstest;
 
         #[test]
         fn get_info_should_use_default_metadata_when_config_is_empty() {
@@ -2129,37 +2154,42 @@ mod tests {
         }
 
         #[test]
-        fn advertises_default_version_when_output_schema_disabled() {
-            let schema = Schema::parse("type Query { id: String }", "schema.graphql")
-                .unwrap()
-                .validate()
-                .unwrap();
+        fn advertises_latest_supported_version_regardless_of_output_schema() {
+            let schema = Arc::new(RwLock::new(
+                Schema::parse("type Query { id: String }", "schema.graphql")
+                    .unwrap()
+                    .validate()
+                    .unwrap(),
+            ));
 
-            let running = Running {
-                enable_output_schema: false,
-                ..test_running(Arc::new(RwLock::new(schema)))
-            };
+            // The advertised version no longer depends on `enable_output_schema`;
+            // output schema fields are gated separately by the negotiated version.
+            for enable_output_schema in [false, true] {
+                let running = Running {
+                    enable_output_schema,
+                    ..test_running(Arc::clone(&schema))
+                };
 
-            let info = running.get_info();
+                let info = running.get_info();
 
-            assert_eq!(info.protocol_version, ProtocolVersion::V_2025_03_26);
+                assert_eq!(info.protocol_version, ProtocolVersion::V_2025_06_18);
+            }
         }
 
-        #[test]
-        fn advertises_v2025_06_18_when_output_schema_enabled() {
-            let schema = Schema::parse("type Query { id: String }", "schema.graphql")
-                .unwrap()
-                .validate()
-                .unwrap();
-
-            let running = Running {
-                enable_output_schema: true,
-                ..test_running(Arc::new(RwLock::new(schema)))
-            };
-
-            let info = running.get_info();
-
-            assert_eq!(info.protocol_version, ProtocolVersion::default());
+        // A supported version is echoed back; an unsupported one falls back to
+        // our latest. The `downgrade_newer` case is the AMS-525 regression: a
+        // client offering a newer version than we implement must be downgraded
+        // rather than refused.
+        #[rstest]
+        #[case::echo_2025_03_26(ProtocolVersion::V_2025_03_26, ProtocolVersion::V_2025_03_26)]
+        #[case::echo_2025_06_18(ProtocolVersion::V_2025_06_18, ProtocolVersion::V_2025_06_18)]
+        #[case::downgrade_newer(ProtocolVersion::V_2025_11_25, ProtocolVersion::V_2025_06_18)]
+        #[case::fallback_older(ProtocolVersion::V_2024_11_05, ProtocolVersion::V_2025_06_18)]
+        fn negotiate_returns_supported_or_latest(
+            #[case] requested: ProtocolVersion,
+            #[case] expected: ProtocolVersion,
+        ) {
+            assert_eq!(negotiate_protocol_version(&requested), expected);
         }
     }
 
@@ -2733,6 +2763,26 @@ mod integration_tests {
                     tool["name"]
                 );
             }
+        }
+
+        #[tokio::test]
+        async fn negotiates_down_when_client_requests_newer_version() {
+            // Regression for AMS-525: with output schema enabled, a client offering
+            // 2025-11-25 over streamable_http previously received 2025-11-25 verbatim
+            // and was refused. The server must downgrade to its latest supported
+            // version (2025-06-18) instead.
+            let running = create_running_with_output_schema();
+            let session_manager: Arc<LocalSessionManager> = LocalSessionManager::default().into();
+            let service = create_service(running, Arc::clone(&session_manager));
+
+            let response = service
+                .oneshot(build_initialize_request("2025-11-25"))
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = extract_json_body(response).await;
+            assert_eq!(body["result"]["protocolVersion"], "2025-06-18");
         }
     }
 

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -792,8 +792,8 @@ impl ServerHandler for Running {
 const LATEST_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V_2025_06_18;
 
 /// MCP protocol versions this server implements.
-const SUPPORTED_PROTOCOL_VERSIONS: [ProtocolVersion; 2] =
-    [LATEST_PROTOCOL_VERSION, ProtocolVersion::V_2025_03_26];
+const SUPPORTED_PROTOCOL_VERSIONS: &[ProtocolVersion] =
+    &[LATEST_PROTOCOL_VERSION, ProtocolVersion::V_2025_03_26];
 
 /// Negotiate the protocol version for the `initialize` response.
 ///
@@ -2153,8 +2153,12 @@ mod tests {
             );
         }
 
-        #[test]
-        fn advertises_latest_supported_version_regardless_of_output_schema() {
+        #[rstest]
+        #[case::output_schema_disabled(false)]
+        #[case::output_schema_enabled(true)]
+        fn advertises_latest_supported_version_regardless_of_output_schema(
+            #[case] enable_output_schema: bool,
+        ) {
             let schema = Arc::new(RwLock::new(
                 Schema::parse("type Query { id: String }", "schema.graphql")
                     .unwrap()
@@ -2164,16 +2168,14 @@ mod tests {
 
             // The advertised version no longer depends on `enable_output_schema`;
             // output schema fields are gated separately by the negotiated version.
-            for enable_output_schema in [false, true] {
-                let running = Running {
-                    enable_output_schema,
-                    ..test_running(Arc::clone(&schema))
-                };
+            let running = Running {
+                enable_output_schema,
+                ..test_running(Arc::clone(&schema))
+            };
 
-                let info = running.get_info();
+            let info = running.get_info();
 
-                assert_eq!(info.protocol_version, ProtocolVersion::V_2025_06_18);
-            }
+            assert_eq!(info.protocol_version, ProtocolVersion::V_2025_06_18);
         }
 
         // A supported version is echoed back; an unsupported one falls back to


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-525 -->

With `enable_output_schema` turned on, the server advertised `ProtocolVersion::default()` in its `initialize` response. For rmcp 1.6, this resolves to the latest version, which is `2025-11-25`. Unlike the stdio transport, the streamable_http transport doesn’t apply the version downgrade, so that value reached clients as is. Any client that didn’t support `2025-11-25` was refused with the message, `Server's protocol version is not supported: 2025-11-25`. This change allows the `initialize` handler to negotiate according to the MCP lifecycle spec. It will echo the client's requested version when we implement it, and otherwise respond with our latest supported version, which is `2025-06-18`. The negotiated version no longer relies on `enable_output_schema`, and the `outputSchema` and `structuredContent` fields are still gated separately by the existing `client_supports_output_schema` check.

The underlying transport gap (streamable_http does not negotiate, unlike stdio) is tracked upstream in modelcontextprotocol/rust-sdk#916, and this handler-side fix stays correct whether or not that is addressed.

# Testing

Start the server with `overrides.enable_output_schema: true` and `transport.type: streamable_http`, then send an initialize request offering a newer version than the server implements:

```sh
   curl -sS -i http://127.0.0.1:8000/mcp \
     -H 'Content-Type: application/json' \
     -H 'Accept: application/json, text/event-stream' \
     -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}'
```
Expect HTTP 200 and a result whose `protocolVersion` is `2025-06-18` (not `2025-11-25`), confirming the client is no longer refused. Repeat with `"protocolVersion":"2025-03-26"` and confirm the response echoes `2025-03-26`.
