### PR TITLE
chore: cover 403 insufficient-scope path and tidy auth module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,7 @@ dependencies = [
  "axum-extra",
  "axum-otel-metrics",
  "axum-tracing-opentelemetry",
+ "base64",
  "bon",
  "chrono",
  "clap",

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -70,6 +70,7 @@ parking_lot = "0.12.5"
 
 [dev-dependencies]
 assert_fs = "1"
+base64 = "0.22"
 http-body-util = "0.1"
 tempfile.workspace = true
 chrono = { version = "0.4.41", default-features = false, features = ["now"] }

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -656,6 +656,10 @@ mod tests {
     }
 
     mod oauth_validate {
+        use base64::Engine as _;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+
         use super::*;
 
         #[tokio::test]
@@ -716,12 +720,7 @@ mod tests {
             assert!(!www_auth.contains("scope="));
         }
 
-        #[tokio::test]
-        async fn valid_token_with_insufficient_scopes_returns_forbidden() {
-            use base64::Engine as _;
-            use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-            use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
-
+        async fn valid_token_with_insufficient_scopes_response() -> (StatusCode, String) {
             let mut server = mockito::Server::new_async().await;
             let kid = "test-kid";
             let secret = b"hs512-integration-test-signing-secret";
@@ -779,17 +778,38 @@ mod tests {
                 .unwrap();
             let res = app.oneshot(req).await.unwrap();
 
-            assert_eq!(res.status(), StatusCode::FORBIDDEN);
+            let status = res.status();
             let www_auth = res
                 .headers()
                 .get(WWW_AUTHENTICATE)
                 .unwrap()
                 .to_str()
                 .unwrap();
+
+            (status, www_auth.to_string())
+        }
+
+        #[tokio::test]
+        async fn valid_token_with_insufficient_scopes_returns_forbidden() {
+            let (status, _) = valid_token_with_insufficient_scopes_response().await;
+
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        #[tokio::test]
+        async fn valid_token_with_insufficient_scopes_sets_insufficient_scope_error() {
+            let (_, www_auth) = valid_token_with_insufficient_scopes_response().await;
+
             assert!(
                 www_auth.contains(r#"error="insufficient_scope""#),
                 "got: {www_auth}"
             );
+        }
+
+        #[tokio::test]
+        async fn valid_token_with_insufficient_scopes_includes_required_scope() {
+            let (_, www_auth) = valid_token_with_insufficient_scopes_response().await;
+
             assert!(www_auth.contains(r#"scope="write""#), "got: {www_auth}");
         }
     }

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -710,6 +710,83 @@ mod tests {
             assert!(www_auth.contains("resource_metadata"));
             assert!(!www_auth.contains("scope="));
         }
+
+        #[tokio::test]
+        async fn valid_token_with_insufficient_scopes_returns_forbidden() {
+            use base64::Engine as _;
+            use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+            use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+
+            let mut server = mockito::Server::new_async().await;
+            let kid = "test-kid";
+            let secret = b"hs512-integration-test-signing-secret";
+
+            let discovery = format!(
+                r#"{{"issuer":"{url}","jwks_uri":"{url}/jwks","id_token_signing_alg_values_supported":["HS512"]}}"#,
+                url = server.url()
+            );
+            let _discovery = server
+                .mock("GET", "/.well-known/oauth-authorization-server")
+                .with_status(200)
+                .with_header("content-type", "application/json")
+                .with_body(discovery)
+                .create_async()
+                .await;
+
+            // Symmetric (`oct`) JWK whose secret matches the signing key below.
+            let jwks = format!(
+                r#"{{"keys":[{{"kty":"oct","alg":"HS512","use":"sig","kid":"{kid}","k":"{k}"}}]}}"#,
+                k = URL_SAFE_NO_PAD.encode(secret)
+            );
+            let _jwks = server
+                .mock("GET", "/jwks")
+                .with_status(200)
+                .with_header("content-type", "application/json")
+                .with_body(jwks)
+                .create_async()
+                .await;
+
+            // A genuinely valid token that carries `read` but not the required `write`.
+            let exp = chrono::Utc::now().timestamp() + 1000;
+            let claims = serde_json::json!({
+                "aud": "test-audience",
+                "exp": exp,
+                "sub": "test-user",
+                "scope": "read",
+            });
+            let header = {
+                let mut h = Header::new(Algorithm::HS512);
+                h.kid = Some(kid.to_string());
+                h
+            };
+            let token =
+                encode(&header, &claims, &EncodingKey::from_secret(secret)).expect("encode JWT");
+
+            let mut config = test_config();
+            config.servers = vec![server.url()];
+            config.scopes = vec!["write".to_string()];
+            let app = test_router(config);
+
+            let req = Request::builder()
+                .uri("/test")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap();
+            let res = app.oneshot(req).await.unwrap();
+
+            assert_eq!(res.status(), StatusCode::FORBIDDEN);
+            let www_auth = res
+                .headers()
+                .get(WWW_AUTHENTICATE)
+                .unwrap()
+                .to_str()
+                .unwrap();
+            assert!(
+                www_auth.contains(r#"error="insufficient_scope""#),
+                "got: {www_auth}"
+            );
+            assert!(www_auth.contains(r#"scope="write""#), "got: {www_auth}");
+        }
     }
 
     mod scope_mode {

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -219,7 +219,6 @@ pub struct Config {
     /// Accepts human-readable durations (e.g., "5s", "10s", "30s").
     /// Defaults to 5 seconds when not specified.
     #[serde(deserialize_with = "humantime_serde::deserialize", default)]
-    #[serde(serialize_with = "humantime_serde::serialize")]
     #[schemars(with = "Option<String>")]
     pub discovery_timeout: Option<Duration>,
 
@@ -250,6 +249,18 @@ pub struct TlsConfig {
     pub danger_accept_invalid_certs: bool,
 }
 
+/// Joins a URL's path into its non-empty segments separated by `/`, dropping
+/// leading and trailing slashes. Shared by the protected-resource and discovery
+/// well-known URL builders.
+fn normalized_path_segments(url: &Url) -> String {
+    url.path()
+        .trim_matches('/')
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 /// Constructs the protected resource metadata URL per RFC 9728 Section 3.
 ///
 /// The well-known URI is formed by inserting `/.well-known/oauth-protected-resource`
@@ -266,13 +277,7 @@ fn build_resource_metadata_url(resource: &Url) -> Url {
         return url;
     }
 
-    let path = url
-        .path()
-        .trim_matches('/')
-        .split('/')
-        .filter(|s| !s.is_empty())
-        .collect::<Vec<_>>()
-        .join("/");
+    let path = normalized_path_segments(&url);
 
     if path.is_empty() {
         url.set_path("/.well-known/oauth-protected-resource");

--- a/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
@@ -48,13 +48,7 @@ fn build_discovery_urls(issuer: &Url) -> Result<Vec<Url>, DiscoveryUrlError> {
     normalized.set_query(None);
     normalized.set_fragment(None);
 
-    let path = normalized
-        .path()
-        .trim_matches('/')
-        .split('/')
-        .filter(|s| !s.is_empty())
-        .collect::<Vec<_>>()
-        .join("/");
+    let path = super::normalized_path_segments(&normalized);
 
     let Some(host) = normalized.host_str() else {
         return Err(DiscoveryUrlError::MissingHost(issuer.clone()));

--- a/crates/apollo-mcp-server/src/auth/protected_resource.rs
+++ b/crates/apollo-mcp-server/src/auth/protected_resource.rs
@@ -4,7 +4,6 @@ use url::Url;
 use super::Config;
 
 /// OAuth 2.1 Protected Resource Response
-// TODO: This might be better found in an existing rust crate (or contributed upstream to one)
 #[derive(Serialize)]
 pub(super) struct ProtectedResource {
     /// The URL of the resource

--- a/crates/apollo-mcp-server/src/auth/www_authenticate.rs
+++ b/crates/apollo-mcp-server/src/auth/www_authenticate.rs
@@ -1,6 +1,4 @@
 //! WWW Authenticate header definition.
-//!
-//! TODO: This might be nice to upstream to hyper.
 
 use headers::{Header, HeaderValue};
 use http::header::WWW_AUTHENTICATE;
@@ -68,7 +66,8 @@ impl Header for WwwAuthenticate {
             }
         };
 
-        // TODO: This shouldn't error, but it can so we might need to do something else here
+        // `from_str` is fallible even though our inputs are controlled, so log and skip
+        // rather than panic if it ever rejects the constructed value.
         match HeaderValue::from_str(&encoded) {
             Ok(value) => values.extend(std::iter::once(value)),
             Err(e) => warn!("could not construct WWW-AUTHENTICATE header: {e}"),


### PR DESCRIPTION
The middleware path that rejects a valid token without the required scope didn't have a test, so we're adding an end-to-end one. It sets up a mock authorization server with OIDC discovery and a symmetric JWKS. Also cleans up a `serialize_with` attribute on `discovery_timeout` that was never used since the type is only deserialized.