### PR TITLE
ci: re-enable claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,10 +1,9 @@
 name: Code Review
 on:
-  # pull_request:
-  #   types: [opened, synchronize, ready_for_review]
-  #   paths:
-  #     - "**/*.rs"
-  # TEMPORARY: Disabling this workflow on reviews while we try out Claude new code review product
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    paths:
+      - "**/*.rs"
   workflow_dispatch:
 
 concurrency:
@@ -36,12 +35,12 @@ jobs:
 
           # If manual label is present, always use that
           if [ "$HAS_OPUS_LABEL" == "true" ]; then
-            MODEL="claude-opus-4-5-20251101"
+            MODEL="opus"
             echo "model=$MODEL" >> $GITHUB_OUTPUT
             echo "📊 Using Opus (manual override via label)"
             exit 0
           elif [ "$HAS_SONNET_LABEL" == "true" ]; then
-            MODEL="claude-sonnet-4-5-20250929"
+            MODEL="sonnet"
             echo "model=$MODEL" >> $GITHUB_OUTPUT
             echo "📊 Using Sonnet (manual override via label)"
             exit 0
@@ -53,11 +52,11 @@ jobs:
           TOTAL_LINES=$((ADDITIONS + DELETIONS))
 
           if [ $TOTAL_LINES -gt 500 ]; then
-            MODEL="claude-opus-4-5-20251101"
+            MODEL="opus"
             echo "model=$MODEL" >> $GITHUB_OUTPUT
             echo "📊 PR Size: $TOTAL_LINES lines changed - Using Opus (automatic)"
           else
-            MODEL="claude-sonnet-4-5-20250929"
+            MODEL="sonnet"
             echo "model=$MODEL" >> $GITHUB_OUTPUT
             echo "📊 PR Size: $TOTAL_LINES lines changed - Using Sonnet (default)"
           fi

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -25,7 +25,7 @@ jobs:
                   claude_args: |
                       --append-system-prompt "Write to .claude/MEMORIES.md when a user asks you to remember something for the future."
                       --max-turns 20
-                      --model claude-sonnet-4-5-20250929
+                      --model sonnet
             - name: Output Claude execution log
               if: always()
               run: |


### PR DESCRIPTION
The hosted Claude Code review (claude[bot]) stopped posting reviews and IT is investigating the issue. In the meantime, I'd like to brings back the older GitHub Action review so that PRs will get an automatic review again. We’ll also switch the model pins to the rolling aliases, so we won't have to bump version IDs manually.