### PR TITLE
ci: fix @claude checkout, bump action versions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ai-review') && !github.event.pull_request.draft && github.event.pull_request.head.ref != 'release' && !startsWith(github.event.pull_request.head.ref, 'release/') }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }} # We need a proper checkout for the commands the skill runs
           repository: ${{ github.event.pull_request.head.repo.full_name }} # To properly handle forks
@@ -90,7 +90,7 @@ jobs:
 
       - name: Post failure comment
         if: failure() && steps.claude_review.outcome == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const body = '⚠️ Claude Code Review failed to complete. This could be due to API issues, rate limits, or insufficient credits. The PR can still be merged - manual review recommended.';

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -15,8 +15,12 @@ jobs:
         permissions:
             id-token: write
             pull-requests: write
-            contents: read
+            contents: write
+            issues: write
+            actions: read
         steps:
+            - name: Checkout repository
+              uses: actions/checkout@v7
             - uses: anthropics/claude-code-action@v1
               id: claude
               with:
@@ -38,7 +42,7 @@ jobs:
 
             - name: Post failure comment
               if: failure() && steps.claude.outcome == 'failure'
-              uses: actions/github-script@v7
+              uses: actions/github-script@v9
               with:
                   script: |
                       github.rest.issues.createComment({


### PR DESCRIPTION
Code Review is working now but mentioning the Claude bot doesn't work because the actions/checkout step is missing in the workflow.