### PR TITLE
ci: guard @claude workflow, fix concurrency key

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -6,12 +6,13 @@ on:
         types: [created]
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-    cancel-in-progress: true
+    group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}
+    cancel-in-progress: false
 
 jobs:
     claude:
         runs-on: ubuntu-latest
+        if: contains(github.event.comment.body, '@claude')
         permissions:
             id-token: write
             pull-requests: write


### PR DESCRIPTION
Adds an if guard so the Claude Code workflow only runs on comments that actually mention @claude, instead of firing on every comment (including bot comments) and relying on the action to no-op. Also fixes the concurrency group key, which used github.event.pull_request.number and was empty for issue_comment events, so all comment runs collapsed into one group and cancelled each other. Switches cancel-in-progress to false so concurrent @claude requests on the same PR no longer cancel each other's responses.