### PR TITLE
feat: configure Rhai scripts directory

### DIFF
--- a/.changeset/configurable_rhai_scripts_directory.md
+++ b/.changeset/configurable_rhai_scripts_directory.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Configure the Rhai scripts directory
+
+Apollo MCP Server now supports configuring the directory used to load Rhai scripts with the top-level `rhai.scripts` option. The default remains `rhai`, preserving existing behavior, while deployments that mount scripts elsewhere can point startup loading and hot reload watching at that directory.

--- a/crates/apollo-mcp-server/src/event.rs
+++ b/crates/apollo-mcp-server/src/event.rs
@@ -24,7 +24,7 @@ pub enum Event {
     /// the server retains its existing tool catalog
     ManifestError(Box<dyn std::error::Error + Send + Sync + 'static>),
 
-    /// Rhai scripts in the rhai/ directory have changed
+    /// Rhai scripts in the configured Rhai directory have changed
     RhaiScriptsChanged,
 
     /// The configuration file has changed, server should restart

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -157,6 +157,7 @@ fn build_server(config_path: Option<&std::path::Path>) -> anyhow::Result<Server>
 
     Ok(Server::builder()
         .maybe_config_path(config_path.map(Path::to_path_buf))
+        .rhai_dir(config.rhai.scripts_dir)
         .transport(config.transport)
         .schema_source(schema_source)
         .operation_source(operation_source)

--- a/crates/apollo-mcp-server/src/runtime.rs
+++ b/crates/apollo-mcp-server/src/runtime.rs
@@ -11,6 +11,7 @@ mod introspection;
 pub mod logging;
 mod operation_source;
 mod overrides;
+mod rhai;
 mod schema_source;
 mod schemas;
 pub mod telemetry;
@@ -118,6 +119,21 @@ mod test {
             let config = read_config(path)?;
 
             assert!(config.overrides.disable_type_description);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn it_extracts_rhai_scripts_from_nested_env() {
+        figment::Jail::expect_with(move |jail| {
+            jail.set_env("APOLLO_MCP_RHAI__SCRIPTS", "/config/rhai");
+
+            let config = super::read_config_from_env()?;
+
+            assert_eq!(
+                config.rhai.scripts_dir,
+                std::path::PathBuf::from("/config/rhai")
+            );
             Ok(())
         });
     }
@@ -274,6 +290,9 @@ mod test {
                         },
                         allowed: 100,
                     },
+                },
+                rhai: RhaiConfig {
+                    scripts_dir: "rhai",
                 },
                 introspection: Introspection {
                     execute: ExecuteConfig {

--- a/crates/apollo-mcp-server/src/runtime/config.rs
+++ b/crates/apollo-mcp-server/src/runtime/config.rs
@@ -12,7 +12,8 @@ use apollo_mcp_server::server_info::ServerInfoConfig;
 
 use super::{
     OperationSource, SchemaSource, endpoint::Endpoint, graphos::GraphOSConfig,
-    introspection::Introspection, logging::Logging, overrides::Overrides, telemetry::Telemetry,
+    introspection::Introspection, logging::Logging, overrides::Overrides, rhai::RhaiConfig,
+    telemetry::Telemetry,
 };
 
 /// Configuration for the MCP server
@@ -53,6 +54,10 @@ pub struct Config {
     /// Health check configuration
     #[serde(default)]
     pub health_check: HealthCheckConfig,
+
+    /// Rhai scripting configuration
+    #[serde(default)]
+    pub rhai: RhaiConfig,
 
     /// Introspection configuration
     pub introspection: Introspection,

--- a/crates/apollo-mcp-server/src/runtime/rhai.rs
+++ b/crates/apollo-mcp-server/src/runtime/rhai.rs
@@ -1,0 +1,42 @@
+use std::path::PathBuf;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[serde(default)]
+pub struct RhaiConfig {
+    /// Directory containing Rhai scripts. The server loads `main.rhai` from this directory.
+    #[serde(rename = "scripts")]
+    pub scripts_dir: PathBuf,
+}
+
+impl Default for RhaiConfig {
+    fn default() -> Self {
+        Self {
+            scripts_dir: PathBuf::from("rhai"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RhaiConfig;
+
+    #[test]
+    fn default_path_matches_existing_rhai_directory() {
+        assert_eq!(
+            RhaiConfig::default().scripts_dir,
+            std::path::PathBuf::from("rhai")
+        );
+    }
+
+    #[test]
+    fn deserializes_custom_path() {
+        let config = serde_yaml::from_str::<RhaiConfig>("scripts: /config/rhai\n")
+            .expect("Rhai config should parse");
+
+        assert_eq!(config.scripts_dir, std::path::PathBuf::from("/config/rhai"));
+    }
+}

--- a/crates/apollo-mcp-server/src/server.rs
+++ b/crates/apollo-mcp-server/src/server.rs
@@ -42,6 +42,7 @@ pub type ConfigValidator =
 /// An Apollo MCP Server
 pub struct Server {
     config_path: Option<PathBuf>,
+    rhai_dir: PathBuf,
     transport: Transport,
     schema_source: SchemaSource,
     operation_source: OperationSource,
@@ -127,6 +128,7 @@ impl Server {
     #[builder]
     pub fn new(
         config_path: Option<PathBuf>,
+        rhai_dir: PathBuf,
         transport: Transport,
         schema_source: SchemaSource,
         operation_source: OperationSource,
@@ -168,6 +170,7 @@ impl Server {
         };
         Self {
             config_path,
+            rhai_dir,
             transport,
             schema_source,
             operation_source,

--- a/crates/apollo-mcp-server/src/server/states.rs
+++ b/crates/apollo-mcp-server/src/server/states.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use apollo_compiler::{Schema, validation::Valid};
 use apollo_federation::{ApiSchemaOptions, Supergraph};
@@ -39,6 +39,7 @@ pub(super) struct StateMachine {}
 
 /// Common configuration options for the states
 struct Config {
+    rhai_dir: PathBuf,
     transport: Transport,
     endpoint: Url,
     headers: HeaderMap,
@@ -81,7 +82,7 @@ impl StateMachine {
             .boxed();
         let operation_stream = server.operation_source.into_stream().await.boxed();
         let ctrl_c_stream = Self::ctrl_c_stream().boxed();
-        let rhai_stream = Self::rhai_watch_stream().boxed();
+        let rhai_stream = Self::rhai_watch_stream(&server.rhai_dir).boxed();
         let config_stream = Self::config_watch_stream(server.config_path.as_deref()).boxed();
         let sighup_stream = Self::sighup_stream().boxed();
         let mut stream = stream::select_all(vec![
@@ -95,6 +96,7 @@ impl StateMachine {
 
         let mut state = State::Configuring(Configuring {
             config: Config {
+                rhai_dir: server.rhai_dir,
                 transport: server.transport,
                 endpoint: server.endpoint,
                 headers: server.headers,
@@ -272,7 +274,7 @@ impl StateMachine {
             .boxed()
     }
 
-    /// Watch the config file for changes, mirroring the rhai_watch_stream pattern.
+    /// Watch the config file for changes, mirroring the Rhai watch stream pattern.
     /// Skips the initial event that files::watch always emits on startup.
     fn config_watch_stream(config_path: Option<&Path>) -> impl Stream<Item = ServerEvent> {
         match config_path {
@@ -309,9 +311,7 @@ impl StateMachine {
         }
     }
 
-    fn rhai_watch_stream() -> impl Stream<Item = ServerEvent> {
-        let rhai_dir = Path::new("rhai");
-
+    fn rhai_watch_stream(rhai_dir: &Path) -> impl Stream<Item = ServerEvent> + use<> {
         // Limitation: the rhai directory must exist on startup for hot reloading to work.
         // If the user creates it after the fact, they will need to restart the server.
         if rhai_dir.is_dir() {
@@ -436,6 +436,7 @@ impl From<ServerError> for State {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::path::PathBuf;
     use std::sync::Arc;
 
     use apollo_compiler::Schema;
@@ -493,6 +494,7 @@ mod tests {
 
     fn test_config() -> Config {
         Config {
+            rhai_dir: PathBuf::from("rhai"),
             transport: Transport::StreamableHttp {
                 auth: None,
                 address: "127.0.0.1".parse().unwrap(),

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -193,7 +193,7 @@ impl Running {
         Self::notify_tool_list_changed(self.peers.clone()).await;
     }
 
-    /// Reload Rhai scripts from the rhai/ directory.
+    /// Reload Rhai scripts from the configured Rhai directory.
     /// On failure, logs the error and keeps the previous scripts.
     pub(super) fn reload_rhai_scripts(&self) {
         let mut engine = self.rhai_engine.lock();

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -147,7 +147,7 @@ impl Starting {
             _ => None, // No health checks for Stdio or when disabled.
         };
 
-        let mut engine = RhaiEngine::new("rhai");
+        let mut engine = RhaiEngine::new(&self.config.rhai_dir);
         engine.load_from_path().map_err(|err| {
             error!("Error loading Rhai scripts: {err}");
             ServerError::RhaiError
@@ -296,6 +296,7 @@ mod tests {
     async fn start_basic_server() {
         let starting = Starting {
             config: Config {
+                rhai_dir: std::path::PathBuf::from("rhai"),
                 transport: Transport::StreamableHttp {
                     auth: None,
                     address: "127.0.0.1".parse().unwrap(),

--- a/crates/apollo-mcp-server/tests/collection_sync.rs
+++ b/crates/apollo-mcp-server/tests/collection_sync.rs
@@ -2,6 +2,7 @@
 //! poller syncs an operation with invalid variables JSON from Explorer.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use apollo_mcp_registry::{
@@ -113,6 +114,7 @@ async fn collection_sync_with_bad_variables_keeps_server_alive() {
         .await;
 
     let server = Server::builder()
+        .rhai_dir(PathBuf::from("rhai"))
         .transport(Transport::StreamableHttp {
             auth: None,
             address: "127.0.0.1".parse().unwrap(),

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -37,6 +37,7 @@ All fields are optional.
 | `logging`         | `Logging`             |                          | Logging configuration                                            |
 | `operations`      | `OperationSource`     |                          | Operations configuration                                         |
 | `overrides`       | `Overrides`           |                          | Overrides for server behavior                                    |
+| `rhai`            | `Rhai`                |                          | Rhai scripting configuration                                     |
 | `schema`          | `SchemaSource`        |                          | Schema configuration                                             |
 | `server_info`     | `ServerInfo`          |                          | Server metadata configuration                                    |
 | `transport`       | `Transport`           |                          | The type of server transport to use                              |
@@ -141,6 +142,21 @@ These fields are under the top-level `health_check` key. Learn more about [healt
 Health checks are only available when using the `streamable_http` transport. The health check feature is inspired by Apollo Router's health check implementation.
 
 </Note>
+
+### Rhai
+
+These fields are under the top-level `rhai` key and configure where Apollo MCP Server loads Rhai scripts from. Learn more about [Rhai scripting](/apollo-mcp-server/rhai-getting-started).
+
+| Option    | Type       | Default | Description                                                                          |
+| :-------- | :--------- | :------ | :----------------------------------------------------------------------------------- |
+| `scripts` | `FilePath` | `rhai`  | Directory containing Rhai scripts. The server loads `main.rhai` from this directory. |
+
+```yaml title="mcp.yaml"
+rhai:
+  scripts: /config/rhai
+```
+
+The path can be absolute or relative to the process working directory. If `main.rhai` doesn't exist, the server starts normally without scripting.
 
 ### Introspection
 

--- a/docs/source/rhai-getting-started.mdx
+++ b/docs/source/rhai-getting-started.mdx
@@ -13,7 +13,7 @@ Common use-cases include:
 
 ## Setup
 
-Create a `rhai/` directory alongside your server configuration, and add a `main.rhai` file inside it:
+Create a `rhai/` directory in the server's working directory, and add a `main.rhai` file inside it:
 
 ```
 your-project/
@@ -23,6 +23,13 @@ your-project/
 ```
 
 The `rhai/main.rhai` file is the entry point for all Rhai scripting. The server loads the file on startup. If the file doesn't exist, the server starts normally, without any scripting.
+
+To load scripts from a different directory, set `rhai.scripts` in your configuration file:
+
+```yaml title="mcp.yaml"
+rhai:
+  scripts: /config/rhai
+```
 
 ## Writing your first hook
 


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-468 -->

This lets deployments configure where Apollo MCP Server loads Rhai scripts from instead of always looking for `rhai/` under the process working directory. The default remains `rhai`, so existing setups keep working, while containerized deployments can mount scripts somewhere like `/config/rhai` and point the server there with `rhai.scripts`. The configured scripts directory is used both for startup loading and for hot reload watching.