### PR TITLE
feat: upgrade rmcp to 2.1 for MCP 2025-11-25

### DIFF
--- a/.changeset/upgrade_rmcp_to_2_1.md
+++ b/.changeset/upgrade_rmcp_to_2_1.md
@@ -1,0 +1,9 @@
+---
+default: minor
+---
+
+# Upgrade rmcp to 2.1 and support MCP 2025-11-25
+
+Apollo MCP Server now depends on rmcp 2.1, which aligns the protocol implementation with the MCP 2025-11-25 specification. The server advertises `2025-11-25` as its latest supported protocol version and negotiates it with clients that request it. Clients on `2025-06-18` and `2025-03-26` continue to work, and clients requesting a version the server does not implement are downgraded to the latest supported version rather than refused. Output schema and structured content remain gated at `2025-06-18` and later, so they now apply to `2025-11-25` as well.
+
+You can now configure browser Origin validation for the `streamable_http` transport with a new `allowed_origins` list under `host_validation`. Origin validation follows RFC 6454 and stays disabled when the list is empty, so existing configurations are unchanged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ The project is a Rust workspace with three crates:
 
 ## Key Dependencies
 
-- `rmcp 0.14` - MCP protocol implementation
+- `rmcp 2.1` - MCP protocol implementation (aligned with MCP 2025-11-25)
 - `apollo-compiler`, `apollo-federation` - GraphQL parsing and schema handling
 - `axum 0.8` - HTTP server
 - `tokio` - Async runtime

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,10 +714,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -3857,9 +3855,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.6.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
 dependencies = [
  "async-trait",
  "base64",
@@ -3888,9 +3886,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.6.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ insta = { version = "1.43.1", features = [
   "yaml",
   "glob",
 ] }
-rmcp = { version = "1.6", features = [
+rmcp = { version = "2.1", features = [
   "server",
   "transport-io",
   "transport-streamable-http-server",

--- a/crates/apollo-mcp-server/src/apps/app.rs
+++ b/crates/apollo-mcp-server/src/apps/app.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use rmcp::model::{ClientCapabilities, ErrorCode, Extensions, RawResource, Resource, Tool};
+use rmcp::model::{ClientCapabilities, ErrorCode, Extensions, Resource, Tool};
 use serde_json::Value;
 use url::Url;
 
@@ -69,20 +69,9 @@ pub(crate) struct PrefetchOperation {
 
 impl App {
     pub(crate) fn resource(&self) -> Resource {
-        Resource::new(
-            RawResource {
-                name: self.name.clone(),
-                uri: self.uri.to_string(),
-                mime_type: None,
-                // TODO: load all this from a manifest file
-                title: None,
-                description: self.description.clone(),
-                icons: None,
-                size: None,
-                meta: None,
-            },
-            None,
-        )
+        let mut resource = Resource::new(self.uri.to_string(), self.name.clone());
+        resource.description = self.description.clone();
+        resource
     }
 }
 

--- a/crates/apollo-mcp-server/src/apps/resource.rs
+++ b/crates/apollo-mcp-server/src/apps/resource.rs
@@ -10,7 +10,7 @@ use super::App;
 const MCP_MIME_TYPE: &str = "text/html;profile=mcp-app";
 
 pub(crate) fn attach_resource_mime_type(mut resource: Resource) -> Resource {
-    resource.raw.mime_type = Some(MCP_MIME_TYPE.to_string());
+    resource.mime_type = Some(MCP_MIME_TYPE.to_string());
     resource
 }
 
@@ -159,7 +159,7 @@ pub(crate) async fn get_app_resource(
 
 #[cfg(test)]
 mod tests {
-    use rmcp::model::{Extensions, RawResource};
+    use rmcp::model::Extensions;
 
     use crate::apps::app::TargetedAppResource;
     use crate::apps::manifest::{CSPSettings, WidgetSettings};
@@ -168,24 +168,12 @@ mod tests {
 
     #[test]
     fn attach_correct_mime_type() {
-        let resource = Resource::new(
-            RawResource {
-                name: "TestResource".to_string(),
-                uri: "ui://test".to_string(),
-                mime_type: None,
-                title: None,
-                description: None,
-                icons: None,
-                size: None,
-                meta: None,
-            },
-            None,
-        );
+        let resource = Resource::new("ui://test", "TestResource");
 
         let result = attach_resource_mime_type(resource);
 
         assert_eq!(
-            result.raw.mime_type,
+            result.mime_type,
             Some("text/html;profile=mcp-app".to_string())
         );
     }

--- a/crates/apollo-mcp-server/src/apps/tool.rs
+++ b/crates/apollo-mcp-server/src/apps/tool.rs
@@ -7,7 +7,7 @@ use http::request::Parts;
 use opentelemetry::Context;
 use opentelemetry::trace::FutureExt;
 use parking_lot::Mutex;
-use rmcp::model::{CallToolResult, Content, JsonObject, Meta, Tool};
+use rmcp::model::{CallToolResult, ContentBlock, JsonObject, Meta, Tool};
 use serde_json::{Map, Value, json};
 use url::Url;
 
@@ -213,7 +213,8 @@ fn nest_app_tool_result(
 
     let wrapped_restricted = Value::Object(restricted_map);
     result.content = vec![
-        Content::json(&wrapped_restricted).unwrap_or(Content::text(wrapped_restricted.to_string())),
+        ContentBlock::json(&wrapped_restricted)
+            .unwrap_or(ContentBlock::text(wrapped_restricted.to_string())),
     ];
     result.structured_content = Some(wrapped_restricted);
 

--- a/crates/apollo-mcp-server/src/explorer.rs
+++ b/crates/apollo-mcp-server/src/explorer.rs
@@ -1,6 +1,6 @@
 use crate::errors::McpError;
 use crate::schema_from_type;
-use rmcp::model::{CallToolResult, Content, ErrorCode, Tool};
+use rmcp::model::{CallToolResult, ContentBlock, ErrorCode, Tool};
 use rmcp::schemars::JsonSchema;
 use rmcp::serde_json::Value;
 use rmcp::{schemars, serde_json};
@@ -81,7 +81,7 @@ impl Explorer {
         };
         let url = self.create_explorer_url(input)?;
         debug!(?url, input=?pretty, "Created URL to open operation in Apollo Explorer");
-        let mut result = CallToolResult::success(vec![Content::text(url.clone())]);
+        let mut result = CallToolResult::success(vec![ContentBlock::text(url.clone())]);
         result.structured_content = Some(Value::Array(vec![url.into()]));
         Ok(result)
     }

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -10,7 +10,7 @@ use opentelemetry::KeyValue;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, Extension};
 use reqwest_tracing::{OtelName, TracingMiddleware};
-use rmcp::model::{CallToolResult, Content, Meta};
+use rmcp::model::{CallToolResult, ContentBlock, Meta};
 use serde_json::{Map, Value};
 use url::Url;
 
@@ -67,7 +67,7 @@ pub trait Executable {
         let variables = match self.variables(request.input.clone()) {
             Ok(v) => v,
             Err(ValidationError(msg)) => {
-                return Ok(CallToolResult::error(vec![Content::text(msg)]));
+                return Ok(CallToolResult::error(vec![ContentBlock::text(msg)]));
             }
         };
 
@@ -80,7 +80,7 @@ pub trait Executable {
         } = match self.operation(request.input) {
             Ok(details) => details,
             Err(ValidationError(msg)) => {
-                return Ok(CallToolResult::error(vec![Content::text(msg)]));
+                return Ok(CallToolResult::error(vec![ContentBlock::text(msg)]));
             }
         };
 
@@ -107,7 +107,7 @@ pub trait Executable {
         {
             Ok(resp) => resp,
             Err(e) => {
-                return Ok(CallToolResult::error(vec![Content::text(format!(
+                return Ok(CallToolResult::error(vec![ContentBlock::text(format!(
                     "Failed to send GraphQL request: {e}"
                 ))]));
             }
@@ -145,7 +145,7 @@ pub trait Executable {
                 };
                 Ok(result.with_meta(meta))
             }
-            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+            Err(e) => Ok(CallToolResult::error(vec![ContentBlock::text(format!(
                 "Failed to read GraphQL response body: {e}"
             ))])),
         };
@@ -186,7 +186,7 @@ mod test {
     use opentelemetry_sdk::metrics::{
         InMemoryMetricExporter, MeterProviderBuilder, PeriodicReader,
     };
-    use rmcp::model::RawContent;
+    use rmcp::model::ContentBlock;
     use serde_json::{Map, Value, json};
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
@@ -311,7 +311,7 @@ mod test {
         // then
         assert_eq!(result.is_error, Some(true));
         let content = &result.content[0];
-        if let RawContent::Text(text) = &content.raw {
+        if let ContentBlock::Text(text) = content {
             assert!(text.text.starts_with("Failed to send GraphQL request"));
         } else {
             panic!("Expected text content");
@@ -345,7 +345,7 @@ mod test {
         // then
         assert_eq!(result.is_error, Some(true));
         let content = &result.content[0];
-        if let RawContent::Text(text) = &content.raw {
+        if let ContentBlock::Text(text) = content {
             assert!(
                 text.text
                     .starts_with("Failed to read GraphQL response body")

--- a/crates/apollo-mcp-server/src/host_validation.rs
+++ b/crates/apollo-mcp-server/src/host_validation.rs
@@ -2,22 +2,32 @@ use rmcp::transport::StreamableHttpServerConfig;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-/// Configuration for Host header validation to prevent DNS rebinding attacks.
+/// Configuration for Host and Origin header validation to prevent DNS
+/// rebinding and cross-origin attacks.
 ///
-/// Host validation is enforced by rmcp's Streamable HTTP transport via
-/// [`StreamableHttpServerConfig::allowed_hosts`]. This struct is a thin,
+/// Both checks are enforced by rmcp's Streamable HTTP transport via
+/// [`StreamableHttpServerConfig::allowed_hosts`] and
+/// [`StreamableHttpServerConfig::allowed_origins`]. This struct is a thin,
 /// stable surface for our YAML schema; [`HostValidationConfig::apply_to`]
 /// translates it onto the rmcp config.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(default, deny_unknown_fields)]
 pub struct HostValidationConfig {
-    /// Enable Host header validation (enabled by default for security).
+    /// Enable Host and Origin header validation (enabled by default for security).
     pub enabled: bool,
 
     /// Additional allowed hosts beyond the loopback defaults
     /// (`localhost`, `127.0.0.1`, `::1`). Entries may be bare hostnames
     /// (any port allowed) or `host:port` authorities.
     pub allowed_hosts: Vec<String>,
+
+    /// Allowed browser origins for inbound `Origin` validation (RFC 6454).
+    /// Empty (the default) leaves Origin validation disabled, matching rmcp.
+    /// When non-empty, requests carrying an `Origin` header must match one of
+    /// these `(scheme, host, port)` entries; entries must include a scheme
+    /// (for example `https://app.example.com`), and `"null"` matches the
+    /// browser's `Origin: null`.
+    pub allowed_origins: Vec<String>,
 }
 
 impl Default for HostValidationConfig {
@@ -25,48 +35,67 @@ impl Default for HostValidationConfig {
         Self {
             enabled: true,
             allowed_hosts: Vec::new(),
+            allowed_origins: Vec::new(),
         }
     }
 }
 
 impl HostValidationConfig {
-    /// Creates a configuration with Host header validation disabled.
+    /// Creates a configuration with Host and Origin validation disabled.
     #[must_use]
     pub fn disabled() -> Self {
         Self {
             enabled: false,
             allowed_hosts: Vec::new(),
+            allowed_origins: Vec::new(),
         }
     }
 
-    /// Apply this host-validation configuration onto an rmcp
+    /// Apply this validation configuration onto an rmcp
     /// [`StreamableHttpServerConfig`] and return the updated config.
     ///
+    /// Host validation (DNS rebinding protection):
     /// - `enabled = false` -> `disable_allowed_hosts()` (allow any host; not recommended)
-    /// - `enabled = true, allowed_hosts = []` -> leave rmcp's defaults in place
+    /// - `enabled = true, allowed_hosts = []` -> leave rmcp's loopback defaults in place
     /// - `enabled = true, allowed_hosts = [..]` -> rmcp's defaults + user-supplied hosts
+    ///
+    /// Origin validation (RFC 6454), opt-in and disabled by default in rmcp:
+    /// - `enabled = false` -> `disable_allowed_origins()`
+    /// - `enabled = true, allowed_origins = []` -> leave Origin validation disabled
+    /// - `enabled = true, allowed_origins = [..]` -> enforce the given origins
     ///
     /// rmcp's `with_allowed_hosts` replaces the list rather than appending, so
     /// when the user supplies extra hosts we read rmcp's existing defaults off
     /// of `rmcp_config` and merge them back in to preserve loopback access.
+    /// Origins have no rmcp defaults, so the user list is set as-is.
     #[must_use]
     pub(crate) fn apply_to(
         &self,
         rmcp_config: StreamableHttpServerConfig,
     ) -> StreamableHttpServerConfig {
         if !self.enabled {
-            return rmcp_config.disable_allowed_hosts();
+            return rmcp_config
+                .disable_allowed_hosts()
+                .disable_allowed_origins();
         }
-        if self.allowed_hosts.is_empty() {
-            return rmcp_config;
-        }
-        let mut merged = rmcp_config.allowed_hosts.clone();
-        for host in &self.allowed_hosts {
-            if !merged.iter().any(|h| h.eq_ignore_ascii_case(host)) {
-                merged.push(host.clone());
+
+        let mut config = rmcp_config;
+
+        if !self.allowed_hosts.is_empty() {
+            let mut merged = config.allowed_hosts.clone();
+            for host in &self.allowed_hosts {
+                if !merged.iter().any(|h| h.eq_ignore_ascii_case(host)) {
+                    merged.push(host.clone());
+                }
             }
+            config = config.with_allowed_hosts(merged);
         }
-        rmcp_config.with_allowed_hosts(merged)
+
+        if !self.allowed_origins.is_empty() {
+            config = config.with_allowed_origins(self.allowed_origins.clone());
+        }
+
+        config
     }
 }
 
@@ -78,6 +107,12 @@ mod tests {
         config
             .apply_to(StreamableHttpServerConfig::default())
             .allowed_hosts
+    }
+
+    fn rmcp_allowed_origins_after_apply(config: &HostValidationConfig) -> Vec<String> {
+        config
+            .apply_to(StreamableHttpServerConfig::default())
+            .allowed_origins
     }
 
     #[test]
@@ -111,6 +146,7 @@ mod tests {
         let config = HostValidationConfig {
             enabled: true,
             allowed_hosts: vec!["mcp.test.com".into(), "mcp.test.com:8080".into()],
+            allowed_origins: Vec::new(),
         };
         let hosts = rmcp_allowed_hosts_after_apply(&config);
         let mut expected = StreamableHttpServerConfig::default().allowed_hosts;
@@ -123,10 +159,48 @@ mod tests {
         let config = HostValidationConfig {
             enabled: true,
             allowed_hosts: vec!["LOCALHOST".into(), "mcp.test.com".into()],
+            allowed_origins: Vec::new(),
         };
         let hosts = rmcp_allowed_hosts_after_apply(&config);
         let mut expected = StreamableHttpServerConfig::default().allowed_hosts;
         expected.push("mcp.test.com".to_string());
         assert_eq!(hosts, expected);
+    }
+
+    #[test]
+    fn enabled_default_has_no_allowed_origins() {
+        let origins = rmcp_allowed_origins_after_apply(&HostValidationConfig::default());
+        assert!(origins.is_empty());
+    }
+
+    #[test]
+    fn user_origins_are_applied_when_enabled() {
+        let config = HostValidationConfig {
+            enabled: true,
+            allowed_hosts: Vec::new(),
+            allowed_origins: vec![
+                "https://app.example.com".into(),
+                "http://localhost:8080".into(),
+            ],
+        };
+        let origins = rmcp_allowed_origins_after_apply(&config);
+        assert_eq!(
+            origins,
+            vec![
+                "https://app.example.com".to_string(),
+                "http://localhost:8080".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn disabled_clears_allowed_origins() {
+        let config = HostValidationConfig {
+            enabled: false,
+            allowed_hosts: Vec::new(),
+            allowed_origins: vec!["https://app.example.com".into()],
+        };
+        let origins = rmcp_allowed_origins_after_apply(&config);
+        assert!(origins.is_empty());
     }
 }

--- a/crates/apollo-mcp-server/src/introspection/tools/introspect.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/introspect.rs
@@ -6,7 +6,7 @@ use apollo_compiler::Schema;
 use apollo_compiler::ast::OperationType;
 use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::validation::Valid;
-use rmcp::model::{CallToolResult, Content, Tool};
+use rmcp::model::{CallToolResult, ContentBlock, Tool};
 use rmcp::schemars::JsonSchema;
 use rmcp::serde_json::Value;
 use rmcp::{schemars, serde_json};
@@ -102,7 +102,7 @@ impl Introspect {
                 })
                 .map(|(_, extended_type)| extended_type)
                 .map(|extended_type| self.serialize(extended_type))
-                .map(Content::text)
+                .map(ContentBlock::text)
                 .collect(),
         ))
     }
@@ -213,11 +213,9 @@ mod tests {
             .content
             .iter()
             .filter_map(|c| {
-                use rmcp::model::RawContent;
-                use std::ops::Deref;
-                let c = c.deref();
+                use rmcp::model::ContentBlock;
                 match c {
-                    RawContent::Text(text) => Some(text.text.clone()),
+                    ContentBlock::Text(text) => Some(text.text.clone()),
                     _ => None,
                 }
             })
@@ -252,11 +250,9 @@ mod tests {
             .content
             .iter()
             .filter_map(|c| {
-                use rmcp::model::RawContent;
-                use std::ops::Deref;
-                let c = c.deref();
+                use rmcp::model::ContentBlock;
                 match c {
-                    RawContent::Text(text) => Some(text.text.clone()),
+                    ContentBlock::Text(text) => Some(text.text.clone()),
                     _ => None,
                 }
             })
@@ -294,11 +290,9 @@ mod tests {
             .content
             .iter()
             .filter_map(|c| {
-                use rmcp::model::RawContent;
-                use std::ops::Deref;
-                let c = c.deref();
+                use rmcp::model::ContentBlock;
                 match c {
-                    RawContent::Text(text) => Some(text.text.clone()),
+                    ContentBlock::Text(text) => Some(text.text.clone()),
                     _ => None,
                 }
             })

--- a/crates/apollo-mcp-server/src/introspection/tools/search.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/search.rs
@@ -8,7 +8,7 @@ use apollo_compiler::ast::{Field, OperationType as AstOperationType, Selection};
 use apollo_compiler::validation::Valid;
 use apollo_compiler::{Name, Node, Schema};
 use apollo_schema_index::{OperationType, Options, SchemaIndex};
-use rmcp::model::{CallToolResult, Content, ErrorCode, Tool};
+use rmcp::model::{CallToolResult, ContentBlock, ErrorCode, Tool};
 use rmcp::schemars::JsonSchema;
 use rmcp::serde_json::Value;
 use rmcp::{schemars, serde_json};
@@ -167,7 +167,7 @@ impl Search {
                         extended_type.serialize().to_string()
                     }
                 })
-                .map(Content::text)
+                .map(ContentBlock::text)
                 .collect(),
         ))
     }
@@ -176,9 +176,8 @@ impl Search {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rmcp::model::RawContent;
+    use rmcp::model::ContentBlock;
     use rstest::{fixture, rstest};
-    use std::ops::Deref;
 
     const TEST_SCHEMA: &str = include_str!("testdata/schema.graphql");
 
@@ -186,12 +185,9 @@ mod tests {
         result
             .content
             .into_iter()
-            .filter_map(|c| {
-                let c = c.deref();
-                match c {
-                    RawContent::Text(text) => Some(text.text.clone()),
-                    _ => None,
-                }
+            .filter_map(|c| match c {
+                ContentBlock::Text(text) => Some(text.text.clone()),
+                _ => None,
             })
             .collect::<Vec<String>>()
             .join("\n")

--- a/crates/apollo-mcp-server/src/introspection/tools/validate.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/validate.rs
@@ -4,7 +4,7 @@ use apollo_compiler::Schema;
 use apollo_compiler::parser::Parser;
 use apollo_compiler::validation::Valid;
 use rmcp::model::CallToolResult;
-use rmcp::model::Content;
+use rmcp::model::ContentBlock;
 use rmcp::model::Tool;
 use rmcp::schemars::JsonSchema;
 use rmcp::serde_json::Value;
@@ -49,12 +49,14 @@ impl Validate {
         let input = match serde_json::from_value::<Input>(input) {
             Ok(i) => i,
             Err(e) => {
-                return CallToolResult::error(vec![Content::text(format!("Invalid input: {e}"))]);
+                return CallToolResult::error(vec![ContentBlock::text(format!(
+                    "Invalid input: {e}"
+                ))]);
             }
         };
 
         if let Err(e) = operation_defs(&input.operation, true, None) {
-            return CallToolResult::error(vec![Content::text(e.to_string())]);
+            return CallToolResult::error(vec![ContentBlock::text(e.to_string())]);
         }
 
         if operation_defs(&input.operation, true, None)
@@ -62,7 +64,7 @@ impl Validate {
             .flatten()
             .is_none()
         {
-            return CallToolResult::error(vec![Content::text("Invalid operation type")]);
+            return CallToolResult::error(vec![ContentBlock::text("Invalid operation type")]);
         }
 
         let schema_guard = self.schema.read().await;
@@ -70,8 +72,8 @@ impl Validate {
             .parse_executable(&schema_guard, input.operation.as_str(), "operation.graphql")
             .and_then(|p| p.validate(&schema_guard))
         {
-            Ok(_) => CallToolResult::success(vec![Content::text("Operation is valid")]),
-            Err(e) => CallToolResult::error(vec![Content::text(e.to_string())]),
+            Ok(_) => CallToolResult::success(vec![ContentBlock::text("Operation is valid")]),
+            Err(e) => CallToolResult::error(vec![ContentBlock::text(e.to_string())]),
         }
     }
 }

--- a/crates/apollo-mcp-server/src/server.rs
+++ b/crates/apollo-mcp-server/src/server.rs
@@ -102,7 +102,8 @@ pub enum Transport {
         #[serde(default = "Transport::default_stateful_mode")]
         stateful_mode: bool,
 
-        /// Host header validation configuration for DNS rebinding protection.
+        /// Host and Origin header validation configuration for DNS rebinding
+        /// and cross-origin protection.
         #[serde(default)]
         host_validation: HostValidationConfig,
     },

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -8,13 +8,13 @@ use reqwest::header::HeaderMap;
 use rmcp::ErrorData;
 use rmcp::model::{
     ClientCapabilities, Extensions, GetPromptRequestParams, GetPromptResult, Implementation,
-    ListPromptsResult, ListResourcesResult, PromptMessage, PromptMessageRole, PromptsCapability,
-    ReadResourceResult, ResourcesCapability, ToolsCapability,
+    ListPromptsResult, ListResourcesResult, PromptMessage, PromptsCapability, ReadResourceResult,
+    ResourcesCapability, Role, ToolsCapability,
 };
 use rmcp::{
     Peer, RoleServer, ServerHandler, ServiceError,
     model::{
-        CallToolRequestParams, CallToolResult, Content, ErrorCode, InitializeRequestParams,
+        CallToolRequestParams, CallToolResult, ContentBlock, ErrorCode, InitializeRequestParams,
         InitializeResult, ListToolsResult, PaginatedRequestParams, ProtocolVersion,
         ServerCapabilities, ServerInfo,
     },
@@ -366,7 +366,7 @@ impl Running {
         {
             match serde_json::from_value(Value::from(request.arguments)) {
                 Ok(args) => introspect_tool.execute(args).await,
-                Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                Err(e) => Ok(CallToolResult::error(vec![ContentBlock::text(format!(
                     "Invalid input: {e}"
                 ))])),
             }
@@ -375,7 +375,7 @@ impl Running {
         {
             match serde_json::from_value(Value::from(request.arguments)) {
                 Ok(args) => search_tool.execute(args).await,
-                Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                Err(e) => Ok(CallToolResult::error(vec![ContentBlock::text(format!(
                     "Invalid input: {e}"
                 ))])),
             }
@@ -384,7 +384,7 @@ impl Running {
         {
             match serde_json::from_value(Value::from(request.arguments)) {
                 Ok(args) => explorer_tool.execute(args).await,
-                Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                Err(e) => Ok(CallToolResult::error(vec![ContentBlock::text(format!(
                     "Invalid input: {e}"
                 ))])),
             }
@@ -418,7 +418,7 @@ impl Running {
         {
             match serde_json::from_value(Value::from(request.arguments)) {
                 Ok(args) => Ok(validate_tool.execute(args).await),
-                Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                Err(e) => Ok(CallToolResult::error(vec![ContentBlock::text(format!(
                     "Invalid input: {e}"
                 ))])),
             }
@@ -605,8 +605,7 @@ impl Running {
             prompt_file.template.clone()
         };
 
-        let mut result =
-            GetPromptResult::new(vec![PromptMessage::new_text(PromptMessageRole::User, text)]);
+        let mut result = GetPromptResult::new(vec![PromptMessage::new_text(Role::User, text)]);
         if let Some(desc) = &prompt_file.prompt.description {
             result = result.with_description(desc);
         }
@@ -639,9 +638,10 @@ impl ServerHandler for Running {
         // TODO: how to remove these?
         let mut peers = self.peers.write().await;
         peers.push(context.peer);
-        let mut info = self.get_info();
-        info.protocol_version = negotiate_protocol_version(&request.protocol_version);
-        Ok(info)
+        // rmcp negotiates the protocol version during `initialize`: it echoes the
+        // client's requested version when supported and otherwise falls back to
+        // the version advertised by `get_info`.
+        Ok(self.get_info())
     }
 
     #[tracing::instrument(skip_all, parent = get_parent_span(&context), fields(apollo.mcp.tool_name = request.name.as_ref(), apollo.mcp.request_id = %context.id.clone(), apollo.mcp.tool_arguments = tracing::field::Empty, apollo.mcp.tool_result = tracing::field::Empty))]
@@ -658,7 +658,7 @@ impl ServerHandler for Running {
         }
 
         let peer_info = context.peer.peer_info();
-        let protocol_version = peer_info.map(|info| &info.protocol_version);
+        let protocol_version = peer_info.as_ref().map(|info| &info.protocol_version);
 
         let result = self
             .call_tool_impl(request, &context.extensions, protocol_version)
@@ -684,8 +684,8 @@ impl ServerHandler for Running {
         context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
         let peer_info = context.peer.peer_info();
-        let client_capabilities = peer_info.map(|info| &info.capabilities);
-        let protocol_version = peer_info.map(|info| &info.protocol_version);
+        let client_capabilities = peer_info.as_ref().map(|info| &info.capabilities);
+        let protocol_version = peer_info.as_ref().map(|info| &info.protocol_version);
 
         self.list_tools_impl(context.extensions, client_capabilities, protocol_version)
             .await
@@ -706,7 +706,8 @@ impl ServerHandler for Running {
         request: rmcp::model::ReadResourceRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResult, ErrorData> {
-        let client_capabilities = context.peer.peer_info().map(|info| &info.capabilities);
+        let peer_info = context.peer.peer_info();
+        let client_capabilities = peer_info.as_ref().map(|info| &info.capabilities);
 
         self.read_resource_impl(request, context.extensions, client_capabilities)
             .await
@@ -730,6 +731,10 @@ impl ServerHandler for Running {
         self.get_prompt_impl(request)
     }
 
+    // `logging` is deprecated by SEP-2577, but we still override this handler so
+    // clients that send `logging/setLevel` without checking capabilities get an
+    // empty success instead of `-32601`.
+    #[allow(deprecated)]
     #[tracing::instrument(skip_all)]
     async fn set_level(
         &self,
@@ -752,17 +757,16 @@ impl ServerHandler for Running {
             .add(1, &[]);
 
         let mut capabilities = ServerCapabilities::default();
-        capabilities.tools = Some(ToolsCapability {
-            list_changed: Some(true),
-        });
+        let mut tools = ToolsCapability::default();
+        tools.list_changed = Some(true);
+        capabilities.tools = Some(tools);
         capabilities.resources = (!self.apps.is_empty()).then(ResourcesCapability::default);
-        capabilities.prompts =
-            (!self.prompts.is_empty()).then_some(PromptsCapability { list_changed: None });
+        capabilities.prompts = (!self.prompts.is_empty()).then(PromptsCapability::default);
 
-        // Advertise our latest supported version as the default. The actual
-        // negotiated value is set per client in `initialize` via
-        // `negotiate_protocol_version`.
-        let protocol_version = LATEST_PROTOCOL_VERSION.clone();
+        // Advertise the latest supported version as the default. rmcp negotiates
+        // the per-client value during `initialize`, echoing the client's requested
+        // version when supported and otherwise falling back to this one.
+        let protocol_version = ProtocolVersion::LATEST;
 
         let mut impl_ = Implementation::new(
             self.server_info.name().to_string(),
@@ -784,29 +788,6 @@ impl ServerHandler for Running {
             result = result.with_instructions(instructions);
         }
         result
-    }
-}
-
-/// Latest MCP protocol version this server implements. Advertised when the
-/// client requests a version we do not support.
-const LATEST_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V_2025_06_18;
-
-/// MCP protocol versions this server implements.
-const SUPPORTED_PROTOCOL_VERSIONS: &[ProtocolVersion] =
-    &[LATEST_PROTOCOL_VERSION, ProtocolVersion::V_2025_03_26];
-
-/// Negotiate the protocol version for the `initialize` response.
-///
-/// Per the MCP lifecycle spec, the server echoes the client's requested version
-/// when it implements that version, otherwise it responds with its latest
-/// supported version. This keeps negotiation independent of `enable_output_schema`:
-/// the `outputSchema` / `structuredContent` fields are gated separately by
-/// [`Running::client_supports_output_schema`].
-fn negotiate_protocol_version(requested: &ProtocolVersion) -> ProtocolVersion {
-    if SUPPORTED_PROTOCOL_VERSIONS.contains(requested) {
-        requested.clone()
-    } else {
-        LATEST_PROTOCOL_VERSION.clone()
     }
 }
 
@@ -2175,29 +2156,13 @@ mod tests {
 
             let info = running.get_info();
 
-            assert_eq!(info.protocol_version, ProtocolVersion::V_2025_06_18);
-        }
-
-        // A supported version is echoed back; an unsupported one falls back to
-        // our latest. The `downgrade_newer` case is the AMS-525 regression: a
-        // client offering a newer version than we implement must be downgraded
-        // rather than refused.
-        #[rstest]
-        #[case::echo_2025_03_26(ProtocolVersion::V_2025_03_26, ProtocolVersion::V_2025_03_26)]
-        #[case::echo_2025_06_18(ProtocolVersion::V_2025_06_18, ProtocolVersion::V_2025_06_18)]
-        #[case::downgrade_newer(ProtocolVersion::V_2025_11_25, ProtocolVersion::V_2025_06_18)]
-        #[case::fallback_older(ProtocolVersion::V_2024_11_05, ProtocolVersion::V_2025_06_18)]
-        fn negotiate_returns_supported_or_latest(
-            #[case] requested: ProtocolVersion,
-            #[case] expected: ProtocolVersion,
-        ) {
-            assert_eq!(negotiate_protocol_version(&requested), expected);
+            assert_eq!(info.protocol_version, ProtocolVersion::LATEST);
         }
     }
 
     mod prompts {
         use super::*;
-        use rmcp::model::{GetPromptRequestParams, Prompt, PromptArgument, PromptMessageRole};
+        use rmcp::model::{GetPromptRequestParams, Prompt, PromptArgument, Role};
 
         fn running_with_prompts(prompts: Vec<crate::prompts::PromptFile>) -> Running {
             let schema = Schema::parse("type Query { id: String }", "schema.graphql")
@@ -2247,11 +2212,11 @@ mod tests {
                 .get_prompt_impl(GetPromptRequestParams::new("greet").with_arguments(args))
                 .unwrap();
             assert_eq!(result.messages.len(), 1);
-            assert_eq!(result.messages[0].role, PromptMessageRole::User);
+            assert_eq!(result.messages[0].role, Role::User);
             assert!(
                 matches!(
                     &result.messages[0].content,
-                    rmcp::model::PromptMessageContent::Text { text } if text == "Hello Alice!"
+                    rmcp::model::ContentBlock::Text(text) if text.text == "Hello Alice!"
                 ),
                 "Expected Text content with 'Hello Alice!', got {:?}",
                 result.messages[0].content
@@ -2769,22 +2734,94 @@ mod integration_tests {
 
         #[tokio::test]
         async fn negotiates_down_when_client_requests_newer_version() {
-            // Regression for AMS-525: with output schema enabled, a client offering
-            // 2025-11-25 over streamable_http previously received 2025-11-25 verbatim
-            // and was refused. The server must downgrade to its latest supported
-            // version (2025-06-18) instead.
+            // Regression for AMS-525: a client offering a protocol version newer
+            // than any rmcp implements over streamable_http must be downgraded to
+            // the latest supported version (2025-11-25) rather than refused.
             let running = create_running_with_output_schema();
             let session_manager: Arc<LocalSessionManager> = LocalSessionManager::default().into();
             let service = create_service(running, Arc::clone(&session_manager));
 
             let response = service
-                .oneshot(build_initialize_request("2025-11-25"))
+                .oneshot(build_initialize_request("2999-01-01"))
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = extract_json_body(response).await;
+            assert_eq!(body["result"]["protocolVersion"], "2025-11-25");
+        }
+
+        #[tokio::test]
+        async fn echoes_supported_version_when_client_requests_older_version() {
+            // rmcp negotiates over streamable_http: a client offering a supported
+            // version older than our latest gets that version echoed back rather
+            // than being upgraded to the latest.
+            let running = create_running_with_output_schema();
+            let session_manager: Arc<LocalSessionManager> = LocalSessionManager::default().into();
+            let service = create_service(running, Arc::clone(&session_manager));
+
+            let response = service
+                .oneshot(build_initialize_request("2025-06-18"))
                 .await
                 .unwrap();
 
             assert_eq!(response.status(), StatusCode::OK);
             let body = extract_json_body(response).await;
             assert_eq!(body["result"]["protocolVersion"], "2025-06-18");
+        }
+
+        #[tokio::test]
+        async fn negotiates_protocol_version_over_stdio_transport() {
+            // The `stdio` transport drives this same `ServerHandler` through rmcp's
+            // generic `serve()` (see `Transport::Stdio` in `starting.rs`), which
+            // negotiates the protocol version in its service layer just like
+            // `StreamableHttpService`. This regression test proves a stdio client
+            // offering a supported older version gets that version echoed back
+            // rather than the server's latest, so removing the handler-side
+            // negotiation does not silently regress stdio.
+            use rmcp::ServiceExt as _;
+            use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
+
+            let running = create_running_with_output_schema();
+
+            // In-memory transport standing in for stdio: the server wraps its half
+            // and the test drives the client half with newline-delimited JSON-RPC.
+            let (server_io, client_io) = tokio::io::duplex(4096);
+            let (server_r, server_w) = tokio::io::split(server_io);
+            let (client_r, mut client_w) = tokio::io::split(client_io);
+
+            let server = tokio::spawn(async move {
+                let service = running
+                    .serve((server_r, server_w))
+                    .await
+                    .expect("stdio serve should complete the initialize handshake");
+                let _ = service.waiting().await;
+            });
+
+            let mut request = json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": { "name": "test-client", "version": "1.0.0" }
+                }
+            })
+            .to_string();
+            request.push('\n');
+            client_w.write_all(request.as_bytes()).await.unwrap();
+
+            let mut reader = BufReader::new(client_r);
+            let mut response_line = String::new();
+            reader.read_line(&mut response_line).await.unwrap();
+            let body: serde_json::Value = serde_json::from_str(&response_line).unwrap();
+            assert_eq!(body["result"]["protocolVersion"], "2025-03-26");
+
+            // Close the client side so the server task shuts down cleanly.
+            drop(reader);
+            drop(client_w);
+            let _ = server.await;
         }
     }
 

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -276,20 +276,27 @@ For Apollo MCP Server `≤v1.0.0`, the default `port` value is `5000`. In `v1.1.
 
 ### Host Validation
 
-These fields are under the `host_validation` key within the `transport` configuration. Host validation prevents DNS rebinding attacks by rejecting requests with unexpected `Host` headers.
+These fields are under the `host_validation` key within the `transport` configuration. Host validation prevents DNS rebinding attacks by rejecting requests with unexpected `Host` headers. Origin validation additionally protects browser-based clients by rejecting requests whose `Origin` header is not on the allow list.
 
-| Option          | Type           | Default | Description                                                      |
-| :-------------- | :------------- | :------ | :--------------------------------------------------------------- |
-| `enabled`       | `bool`         | `true`  | Enable Host header validation to prevent DNS rebinding attacks   |
-| `allowed_hosts` | `List<string>` | `[]`    | Additional allowed hostnames beyond localhost (can include port) |
+| Option            | Type           | Default | Description                                                                 |
+| :---------------- | :------------- | :------ | :-------------------------------------------------------------------------- |
+| `enabled`         | `bool`         | `true`  | Enable Host and Origin header validation                                    |
+| `allowed_hosts`   | `List<string>` | `[]`    | Additional allowed hostnames beyond localhost (can include port)            |
+| `allowed_origins` | `List<string>` | `[]`    | Allowed browser origins (RFC 6454); empty leaves Origin validation disabled |
 
 <Note>
 
-Host validation is only available when using the `streamable_http` transport. Loopback addresses (`localhost`, `127.0.0.1`, `::1`) are always allowed when validation is enabled.
+Host and Origin validation are only available when using the `streamable_http` transport. Loopback addresses (`localhost`, `127.0.0.1`, `::1`) are always allowed as hosts when validation is enabled. Origin validation is opt-in: it only applies when `allowed_origins` is non-empty, and requests without an `Origin` header still pass. Origin entries must include a scheme (for example `https://app.example.com`), and `null` matches the browser's `Origin: null`.
 
 </Note>
 
-For production deployments behind a reverse proxy, add your server's hostname:
+<Note>
+
+`host_validation.allowed_origins` is distinct from [CORS](/apollo-mcp-server/cors) `origins`. `allowed_origins` is a server-side guard that rejects disallowed requests with `HTTP 403` to prevent DNS rebinding, while CORS controls the `Access-Control-Allow-Origin` response header that browsers use to decide whether to expose a cross-origin response. Browser clients on other origins typically need both configured.
+
+</Note>
+
+For production deployments behind a reverse proxy, add your server's hostname and any browser origins that call it directly:
 
 ```yaml title="mcp.yaml"
 transport:
@@ -297,6 +304,8 @@ transport:
   host_validation:
     allowed_hosts:
       - mcp.example.com
+    allowed_origins:
+      - https://app.example.com
 ```
 
 ### Auth


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-541 -->

This upgrades `rmcp` from 1.6 to 2.1, which aligns our MCP implementation with the 2025-11-25 specification. The [2.x API migration](https://github.com/modelcontextprotocol/rust-sdk/discussions/926) is mostly mechanical, with `Content` becoming `ContentBlock`, `RawResource` replaced by `Resource` builders, `PromptMessageRole` becoming `Role`, and the capability structs now non-exhaustive. Because `rmcp` now performs protocol version negotiation natively in the streamable_http transport, I removed our custom initialize-handler workaround from #768 and let the SDK negotiate, advertising `ProtocolVersion::LATEST` (2025-11-25) as the fallback. I also wired up rmcp 2.x's new RFC 6454 Origin validation as an opt-in `allowed_origins` list under `host_validation`.