### PR TITLE
feat(auth): Add singleflight cold JWKS fetches per issuer URL

### DIFF
--- a/.changeset/singleflight_jwks_cold_misses.md
+++ b/.changeset/singleflight_jwks_cold_misses.md
@@ -1,0 +1,9 @@
+---
+default: minor
+---
+
+# Singleflight JWKS fetches on cold cache misses
+
+When multiple requests arrive simultaneously for an issuer whose JWKS is not yet cached (or whose entry has just expired), Apollo MCP Server now coalesces them into a single outbound discovery + JWKS fetch instead of fanning out one fetch per request. Followers await the leader's result and then read the populated cache; one upstream round-trip serves all concurrent callers.
+
+This bounds the cold-start and TTL-flip fanout to a single upstream pair per issuer regardless of inbound concurrency.

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -554,6 +554,7 @@ async fn oauth_validate(
         keys: NetworkedKeyResolver::new(
             &auth_state.client,
             discovery_timeout,
+            &auth_state.inflight,
             &auth_state.jwks_cache,
             jwks_cache_ttl,
         ),

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
 use axum::{
@@ -16,7 +16,7 @@ use axum_extra::{
     headers::{Authorization, authorization::Bearer},
 };
 use http::Method;
-use networked_key_resolver::{CachedJwks, NetworkedKeyResolver};
+use networked_key_resolver::{CachedJwks, InflightMap, NetworkedKeyResolver};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -301,6 +301,7 @@ struct AuthState {
     config: Arc<Config>,
     client: reqwest::Client,
     jwks_cache: Arc<RwLock<HashMap<Url, CachedJwks>>>,
+    inflight: Arc<InflightMap>,
     resource_metadata_url: Url,
     /// Upstream OAuth server URLs, parsed once at startup so the per-request
     /// path neither re-parses nor allocates them.
@@ -374,6 +375,7 @@ impl Config {
             resource_metadata_url,
             auth_servers: Arc::from(auth_servers),
             required_scopes: Arc::new(required_scopes),
+            inflight: Arc::new(Mutex::new(HashMap::new())),
             jwks_cache: Arc::new(RwLock::new(HashMap::new())),
         };
 
@@ -667,6 +669,7 @@ mod tests {
             resource_metadata_url,
             auth_servers: Arc::from(auth_servers),
             required_scopes: Arc::new(HashMap::new()),
+            inflight: Arc::new(Mutex::new(HashMap::new())),
             jwks_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }

--- a/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
@@ -860,4 +860,85 @@ mod tests {
         assert!(entry.keys.keys.contains_key("new-key"));
         assert!(!entry.keys.keys.contains_key("old-key"));
     }
+
+    #[tokio::test]
+    async fn concurrent_cold_misses_trigger_one_upstream_fetch_pair() {
+        // 100 concurrent resolve_key calls for the same cold issuer must produce
+        // exactly one discovery fetch and one JWKS fetch. mockito's .expect(1)
+        // assertion enforces "exactly once."
+        let mut server = mockito::Server::new_async().await;
+
+        let discovery_json = format!(
+            r#"{{"issuer":"{}","jwks_uri":"{}/jwks","id_token_signing_alg_values_supported":["RS256"]}}"#,
+            server.url(),
+            server.url()
+        );
+        let jwks_json = format!(
+            r#"{{"keys":[{{"kty":"RSA","kid":"singleflight-key","alg":"RS256","n":"{}","e":"{}"}}]}}"#,
+            TEST_RSA_N, TEST_RSA_E
+        );
+
+        let discovery_mock = server
+            .mock("GET", "/.well-known/oauth-authorization-server")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&discovery_json)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let jwks_mock = server
+            .mock("GET", "/jwks")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&jwks_json)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let issuer_url = Url::parse(&server.url()).expect("valid URL");
+        let cache: Arc<RwLock<HashMap<Url, CachedJwks>>> = Arc::new(RwLock::new(HashMap::new()));
+        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(HashMap::new()));
+        let client = reqwest::Client::new();
+
+        // Spawn 100 tasks that all race to resolve the same key against the same
+        // cold cache. Each task constructs its own resolver borrowing the shared
+        // client/cache/inflight handles.
+        let mut handles = Vec::with_capacity(100);
+        for _ in 0..100 {
+            let client = client.clone();
+            let cache = Arc::clone(&cache);
+            let inflight = Arc::clone(&inflight);
+            let issuer_url = issuer_url.clone();
+            handles.push(tokio::spawn(async move {
+                let resolver = NetworkedKeyResolver::new(
+                    &client,
+                    Duration::from_secs(5),
+                    &inflight,
+                    &cache,
+                    Duration::from_secs(300),
+                );
+                resolver.resolve_key(&issuer_url, "singleflight-key").await
+            }));
+        }
+
+        let results = futures::future::join_all(handles).await;
+
+        // Every caller should observe the same Some(result).
+        for r in results {
+            let resolved = r.expect("task did not panic");
+            let (_jwk, _issuer) = resolved.expect("resolve_key returned None under singleflight");
+        }
+
+        // The hard assertion: exactly one upstream pair.
+        discovery_mock.assert();
+        jwks_mock.assert();
+
+        // And the inflight map self-evicted after the leader completed.
+        let inflight_guard = inflight.lock().expect("inflight not poisoned");
+        assert!(
+            inflight_guard.is_empty(),
+            "inflight slot should be removed after the leader's future resolved"
+        );
+    }
 }

--- a/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
@@ -72,10 +72,13 @@ impl<'a> NetworkedKeyResolver<'a> {
     }
 
     /// Reads the JWKS cache under the read lock and returns the resolved
-    /// `(jwk, issuer)` if a fresh entry with `key_id` exists. Returns `None`
-    /// for any combination of: no entry, stale entry, kid not in entry, or
-    /// lock poisoned (we treat poisoning as a miss; the next writer will
-    /// recover with `unwrap_or_else(|e| e.into_inner())`).
+    /// `(jwk, issuer)` if a fresh entry with `key_id` exists.
+    ///
+    /// **Invariant ownership:** this is the sole site that decides whether the
+    /// cache can serve a request without going to the network. After
+    /// `acquire_inflight_slot` resolves, callers re-invoke this method to do
+    /// their own per-`kid` lookup; we never decide "fresh-enough?" anywhere
+    /// else in this file.
     fn lookup_fresh(&self, server: &Url, key_id: &str) -> Option<(Jwk, String)> {
         let cache = self.jwks_cache.read().ok()?;
         let entry = cache.get(server)?;
@@ -92,6 +95,12 @@ impl<'a> NetworkedKeyResolver<'a> {
     ///
     /// The fetch future is responsible for removing its own slot from the map
     /// before resolving; we never leave a stale slot behind.
+    ///
+    /// **Invariant ownership:** this is the sole site that decides whether
+    /// this request triggers a new upstream fetch or joins an existing one.
+    /// At most one `Shared<BoxFuture<()>>` per issuer URL is alive in the
+    /// inflight map at any time, so `build_fetch_future` never races a peer
+    /// when writing to the cache.
     fn acquire_inflight_slot(&self, server: Url) -> InflightFetch {
         let mut guard = self.inflight.lock().unwrap_or_else(|e| e.into_inner());
 

--- a/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 use std::str::FromStr;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
+use futures::future::{BoxFuture, Shared};
 use jsonwebtoken::jwk::KeyAlgorithm;
 use jwks::{Jwk, Jwks};
 use serde::Deserialize;
@@ -35,6 +36,13 @@ impl CachedJwks {
         Some((jwk, self.issuer.clone()))
     }
 }
+
+///  A future that does one cold-cache JWKS fetch and self-evicts from the inflight map.
+#[allow(dead_code)]
+pub(super) type InflightFetch = Shared<BoxFuture<'static, ()>>;
+
+/// Map of in-flight cold fetches keyed by issuer URL.
+pub(super) type InflightMap = Mutex<HashMap<Url, InflightFetch>>;
 
 /// [`KeyResolver`] that fetches signing keys from the network via OIDC/OAuth
 /// discovery.

--- a/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
@@ -82,7 +82,7 @@ impl<'a> NetworkedKeyResolver<'a> {
     /// Returns the resolved `(jwk, issuer)` if the cache holds a fresh entry
     /// containing `key_id`.
     fn lookup_fresh(&self, server: &Url, key_id: &str) -> Option<(Jwk, String)> {
-        let cache = self.jwks_cache.read().ok()?;
+        let cache = self.jwks_cache.read().unwrap_or_else(|e| e.into_inner());
         let entry = cache.get(server)?;
         if !entry.is_fresh(self.ttl) {
             return None;
@@ -129,33 +129,21 @@ impl<'a> NetworkedKeyResolver<'a> {
         discovery_timeout: Duration,
     ) -> InflightFetch {
         async move {
-            let Some(metadata) = discover_metadata(&client, &server, discovery_timeout).await
-            else {
-                inflight
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner())
-                    .remove(&server);
-                return;
-            };
-            let Some(jwks) = fetch_jwks(&client, &metadata.jwks_uri, discovery_timeout).await
-            else {
-                inflight
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner())
-                    .remove(&server);
-                return;
-            };
-
-            let entry = CachedJwks {
-                keys: jwks,
-                issuer: metadata.issuer,
-                fetched_at: Instant::now(),
-                signing_algs: metadata.id_token_signing_alg_values_supported,
-            };
+            let entry = async {
+                let metadata = discover_metadata(&client, &server, discovery_timeout).await?;
+                let jwks = fetch_jwks(&client, &metadata.jwks_uri, discovery_timeout).await?;
+                Some(CachedJwks {
+                    keys: jwks,
+                    issuer: metadata.issuer,
+                    fetched_at: Instant::now(),
+                    signing_algs: metadata.id_token_signing_alg_values_supported,
+                })
+            }
+            .await;
 
             // Populate the cache before evicting the slot, so late arrivals
             // see the fresh entry instead of starting a new fetch.
-            {
+            if let Some(entry) = entry {
                 let mut cache = jwks_cache.write().unwrap_or_else(|e| e.into_inner());
                 cache.insert(server.clone(), entry);
             }
@@ -333,6 +321,8 @@ impl KeyResolver for NetworkedKeyResolver<'_> {
             SlotOutcome::Resolved(result) => return Some(result),
             SlotOutcome::Fetch(fetch) => fetch,
         };
+        // Driven by its awaiting callers, not spawned: if all callers are
+        // cancelled mid-fetch, the fetch pauses and the next caller resumes it.
         fetch.await;
 
         // Each caller looks up its own `kid` against the refreshed cache.
@@ -1065,6 +1055,175 @@ mod tests {
         assert!(
             inflight_guard.is_empty(),
             "no fetch should be started when the re-check hits"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_discovery_evicts_inflight_slot_and_next_call_retries() {
+        // A leader whose discovery fetch fails must remove its inflight slot so
+        // the next caller starts a fresh fetch instead of joining a dead one.
+        let mut server = mockito::Server::new_async().await;
+
+        let fail_rfc8414 = server
+            .mock("GET", "/.well-known/oauth-authorization-server")
+            .with_status(500)
+            .expect(1)
+            .create_async()
+            .await;
+        let fail_oidc = server
+            .mock("GET", "/.well-known/openid-configuration")
+            .with_status(500)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let issuer_url = Url::parse(&server.url()).expect("valid URL");
+        let cache: Arc<RwLock<HashMap<Url, CachedJwks>>> = Arc::new(RwLock::new(HashMap::new()));
+        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(HashMap::new()));
+        let client = reqwest::Client::new();
+        let resolver = NetworkedKeyResolver::new(
+            &client,
+            Duration::from_secs(5),
+            &inflight,
+            &cache,
+            Duration::from_secs(300),
+        );
+
+        let result = resolver.resolve_key(&issuer_url, "retry-key").await;
+
+        fail_rfc8414.assert();
+        fail_oidc.assert();
+        assert!(result.is_none(), "failed fetch should resolve to None");
+        {
+            let inflight_guard = inflight.lock().expect("inflight not poisoned");
+            assert!(
+                inflight_guard.is_empty(),
+                "failed fetch should evict its inflight slot"
+            );
+        }
+
+        // Bring the server back up; the retry must reach the network.
+        let discovery_json = format!(
+            r#"{{"issuer":"{}","jwks_uri":"{}/jwks","id_token_signing_alg_values_supported":["RS256"]}}"#,
+            server.url(),
+            server.url()
+        );
+        let jwks_json = format!(
+            r#"{{"keys":[{{"kty":"RSA","kid":"retry-key","alg":"RS256","n":"{}","e":"{}"}}]}}"#,
+            TEST_RSA_N, TEST_RSA_E
+        );
+        let discovery_mock = server
+            .mock("GET", "/.well-known/oauth-authorization-server")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&discovery_json)
+            .expect(1)
+            .create_async()
+            .await;
+        let jwks_mock = server
+            .mock("GET", "/jwks")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&jwks_json)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let result = resolver.resolve_key(&issuer_url, "retry-key").await;
+
+        discovery_mock.assert();
+        jwks_mock.assert();
+        assert!(
+            result.is_some(),
+            "retry after a failed fetch should succeed"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_jwks_fetch_evicts_inflight_slot_and_next_call_retries() {
+        // Discovery succeeds but the JWKS endpoint fails: the leader must still
+        // evict its inflight slot so the next caller retries.
+        let mut server = mockito::Server::new_async().await;
+
+        let discovery_json = format!(
+            r#"{{"issuer":"{}","jwks_uri":"{}/jwks","id_token_signing_alg_values_supported":["RS256"]}}"#,
+            server.url(),
+            server.url()
+        );
+        let discovery_mock = server
+            .mock("GET", "/.well-known/oauth-authorization-server")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&discovery_json)
+            .expect(1)
+            .create_async()
+            .await;
+        let jwks_fail = server
+            .mock("GET", "/jwks")
+            .with_status(500)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let issuer_url = Url::parse(&server.url()).expect("valid URL");
+        let cache: Arc<RwLock<HashMap<Url, CachedJwks>>> = Arc::new(RwLock::new(HashMap::new()));
+        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(HashMap::new()));
+        let client = reqwest::Client::new();
+        let resolver = NetworkedKeyResolver::new(
+            &client,
+            Duration::from_secs(5),
+            &inflight,
+            &cache,
+            Duration::from_secs(300),
+        );
+
+        let result = resolver.resolve_key(&issuer_url, "some-key").await;
+
+        discovery_mock.assert();
+        jwks_fail.assert();
+        assert!(result.is_none(), "failed JWKS fetch should resolve to None");
+        {
+            let inflight_guard = inflight.lock().expect("inflight not poisoned");
+            assert!(
+                inflight_guard.is_empty(),
+                "failed JWKS fetch should evict its inflight slot"
+            );
+            let cache_guard = cache.read().expect("cache not poisoned");
+            assert!(
+                cache_guard.is_empty(),
+                "failed fetch should not populate the cache"
+            );
+        }
+
+        // Bring the JWKS endpoint back up; the retry must reach the network.
+        let jwks_json = format!(
+            r#"{{"keys":[{{"kty":"RSA","kid":"some-key","alg":"RS256","n":"{}","e":"{}"}}]}}"#,
+            TEST_RSA_N, TEST_RSA_E
+        );
+        let discovery_retry = server
+            .mock("GET", "/.well-known/oauth-authorization-server")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&discovery_json)
+            .expect(1)
+            .create_async()
+            .await;
+        let jwks_mock = server
+            .mock("GET", "/jwks")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&jwks_json)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let result = resolver.resolve_key(&issuer_url, "some-key").await;
+
+        discovery_retry.assert();
+        jwks_mock.assert();
+        assert!(
+            result.is_some(),
+            "retry after a failed JWKS fetch should succeed"
         );
     }
 

--- a/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
@@ -71,14 +71,8 @@ impl<'a> NetworkedKeyResolver<'a> {
         }
     }
 
-    /// Reads the JWKS cache under the read lock and returns the resolved
-    /// `(jwk, issuer)` if a fresh entry with `key_id` exists.
-    ///
-    /// **Invariant ownership:** this is the sole site that decides whether the
-    /// cache can serve a request without going to the network. After
-    /// `acquire_inflight_slot` resolves, callers re-invoke this method to do
-    /// their own per-`kid` lookup; we never decide "fresh-enough?" anywhere
-    /// else in this file.
+    /// Returns the resolved `(jwk, issuer)` if the cache holds a fresh entry
+    /// containing `key_id`.
     fn lookup_fresh(&self, server: &Url, key_id: &str) -> Option<(Jwk, String)> {
         let cache = self.jwks_cache.read().ok()?;
         let entry = cache.get(server)?;
@@ -88,19 +82,9 @@ impl<'a> NetworkedKeyResolver<'a> {
         entry.lookup(key_id, server)
     }
 
-    /// Returns a future that completes when this issuer's cold fetch is done.
-    /// If a slot already exists for `server`, returns a clone of the in-flight
-    /// `Shared` future. Otherwise, builds a fresh fetch future, installs it
-    /// in the inflight map under `server`, and returns a clone.
-    ///
-    /// The fetch future is responsible for removing its own slot from the map
-    /// before resolving; we never leave a stale slot behind.
-    ///
-    /// **Invariant ownership:** this is the sole site that decides whether
-    /// this request triggers a new upstream fetch or joins an existing one.
-    /// At most one `Shared<BoxFuture<()>>` per issuer URL is alive in the
-    /// inflight map at any time, so `build_fetch_future` never races a peer
-    /// when writing to the cache.
+    /// Returns a future that completes when this issuer's cold fetch is done,
+    /// joining the in-flight fetch if one exists or starting a new one. At
+    /// most one fetch per issuer is ever in flight.
     fn acquire_inflight_slot(&self, server: Url) -> InflightFetch {
         let mut guard = self.inflight.lock().unwrap_or_else(|e| e.into_inner());
 
@@ -120,10 +104,8 @@ impl<'a> NetworkedKeyResolver<'a> {
         fetch
     }
 
-    /// Builds the one-shot future that runs discovery + JWKS fetch, inserts
-    /// into the cache, and removes its own slot from the inflight map before
-    /// resolving. Output is `()` — concurrent callers re-read the cache for
-    /// their own `kid` lookup.
+    /// Builds the one-shot future that fetches the issuer's keys, populates
+    /// the cache, and removes its own inflight slot before resolving.
     fn build_fetch_future(
         client: reqwest::Client,
         jwks_cache: Arc<RwLock<HashMap<Url, CachedJwks>>>,
@@ -132,8 +114,6 @@ impl<'a> NetworkedKeyResolver<'a> {
         discovery_timeout: Duration,
     ) -> InflightFetch {
         async move {
-            // Do the network work. `discover_metadata`/`fetch_jwks` log their
-            // own failures; we just decide whether to populate the cache.
             let Some(metadata) = discover_metadata(&client, &server, discovery_timeout).await
             else {
                 inflight
@@ -158,10 +138,8 @@ impl<'a> NetworkedKeyResolver<'a> {
                 signing_algs: metadata.id_token_signing_alg_values_supported,
             };
 
-            // Insert into the cache, then evict the inflight slot. Cache-then-
-            // evict ordering matters: a request arriving between these two
-            // operations sees the fresh cache entry on its warm-path read and
-            // does not become a new leader.
+            // Populate the cache before evicting the slot, so late arrivals
+            // see the fresh entry instead of starting a new fetch.
             {
                 let mut cache = jwks_cache.write().unwrap_or_else(|e| e.into_inner());
                 cache.insert(server.clone(), entry);
@@ -327,27 +305,19 @@ async fn fetch_jwks(client: &reqwest::Client, jwks_uri: &str, timeout: Duration)
 }
 
 impl KeyResolver for NetworkedKeyResolver<'_> {
-    /// On the warm path, returns from the in-memory cache without any network
-    /// call. On a cold or stale-entry path, exactly one fetch per issuer runs
-    /// process-wide regardless of inbound concurrency — concurrent callers
-    /// share an inflight slot keyed by issuer URL. The slot self-evicts as
-    /// the leader's future resolves, so a failed fetch does not poison the
-    /// next caller's retry. `discovery_timeout` still bounds each network
-    /// stage independently.
+    /// Resolves from the in-memory cache when fresh. On a cold or expired
+    /// entry, concurrent callers for the same issuer share a single upstream
+    /// fetch; a failed fetch does not block the next caller's retry.
     async fn resolve_key(&self, server: &Url, key_id: &str) -> Option<(Jwk, String)> {
-        // Warm path: in-memory lookup, no network.
         if let Some(result) = self.lookup_fresh(server, key_id) {
             return Some(result);
         }
 
-        // Cold path: become singleflight leader, or join as follower.
+        // Cold path: share one fetch per issuer across concurrent callers.
         let fetch = self.acquire_inflight_slot(server.clone());
         fetch.await;
 
-        // After the slot resolves, the leader has either populated the cache
-        // or failed. Either way, do our own per-`kid` lookup against the
-        // current cache state. Followers asking for a different `kid` than
-        // the leader get the right answer this way.
+        // Each caller looks up its own `kid` against the refreshed cache.
         self.lookup_fresh(server, key_id)
     }
 }

--- a/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
@@ -44,6 +44,14 @@ pub(super) type InflightFetch = Shared<BoxFuture<'static, ()>>;
 /// Map of in-flight cold fetches keyed by issuer URL.
 pub(super) type InflightMap = Mutex<HashMap<Url, InflightFetch>>;
 
+/// Result of acquiring the in-flight slot for an issuer.
+enum SlotOutcome {
+    /// The cache turned fresh in the miss-to-lock window; no fetch needed.
+    Resolved((Jwk, String)),
+    /// A cold fetch to await, joined or newly started.
+    Fetch(InflightFetch),
+}
+
 /// [`KeyResolver`] that fetches signing keys from the network via OIDC/OAuth
 /// discovery.
 pub(super) struct NetworkedKeyResolver<'a> {
@@ -82,14 +90,21 @@ impl<'a> NetworkedKeyResolver<'a> {
         entry.lookup(key_id, server)
     }
 
-    /// Returns a future that completes when this issuer's cold fetch is done,
-    /// joining the in-flight fetch if one exists or starting a new one. At
-    /// most one fetch per issuer is ever in flight.
-    fn acquire_inflight_slot(&self, server: Url) -> InflightFetch {
+    /// Returns the resolved key if the cache turned fresh while acquiring the
+    /// lock; otherwise a future that completes when this issuer's cold fetch
+    /// is done, joining the in-flight fetch if one exists or starting a new
+    /// one. At most one fetch per issuer is ever in flight.
+    fn acquire_inflight_slot(&self, server: Url, key_id: &str) -> SlotOutcome {
         let mut guard = self.inflight.lock().unwrap_or_else(|e| e.into_inner());
 
         if let Some(existing) = guard.get(&server) {
-            return existing.clone();
+            return SlotOutcome::Fetch(existing.clone());
+        }
+
+        // A fetch may have completed between the caller's cache miss and this
+        // lock; re-check so its fresh result isn't refetched.
+        if let Some(result) = self.lookup_fresh(&server, key_id) {
+            return SlotOutcome::Resolved(result);
         }
 
         let fetch = Self::build_fetch_future(
@@ -101,7 +116,7 @@ impl<'a> NetworkedKeyResolver<'a> {
         );
 
         guard.insert(server, fetch.clone());
-        fetch
+        SlotOutcome::Fetch(fetch)
     }
 
     /// Builds the one-shot future that fetches the issuer's keys, populates
@@ -314,7 +329,10 @@ impl KeyResolver for NetworkedKeyResolver<'_> {
         }
 
         // Cold path: share one fetch per issuer across concurrent callers.
-        let fetch = self.acquire_inflight_slot(server.clone());
+        let fetch = match self.acquire_inflight_slot(server.clone(), key_id) {
+            SlotOutcome::Resolved(result) => return Some(result),
+            SlotOutcome::Fetch(fetch) => fetch,
+        };
         fetch.await;
 
         // Each caller looks up its own `kid` against the refreshed cache.
@@ -997,6 +1015,105 @@ mod tests {
         assert!(
             inflight_guard.is_empty(),
             "inflight slot should be removed after the leader's future resolved"
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_slot_resolves_from_cache_without_starting_fetch() {
+        // Simulates a follower that missed the cache, then lost the race to the
+        // inflight lock against a leader that already populated the cache and
+        // evicted its slot: the re-check must resolve without a new fetch.
+        let client = reqwest::Client::new();
+
+        let jwks_json = format!(
+            r#"{{"keys":[{{"kty":"RSA","kid":"raced-key","alg":"RS256","n":"{}","e":"{}"}}]}}"#,
+            TEST_RSA_N, TEST_RSA_E
+        );
+        let jwks = make_test_jwks(&client, &jwks_json).await;
+
+        let issuer_url = Url::parse("https://auth.example.com").expect("valid URL");
+        let cache: Arc<RwLock<HashMap<Url, CachedJwks>>> = Arc::new(RwLock::new(HashMap::new()));
+        {
+            let mut guard = cache.write().unwrap();
+            guard.insert(
+                issuer_url.clone(),
+                CachedJwks {
+                    keys: jwks,
+                    issuer: "https://issuer.example.com".to_string(),
+                    fetched_at: Instant::now(),
+                    signing_algs: vec!["RS256".to_string()],
+                },
+            );
+        }
+        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(HashMap::new()));
+
+        let resolver = NetworkedKeyResolver::new(
+            &client,
+            Duration::from_secs(5),
+            &inflight,
+            &cache,
+            Duration::from_secs(300),
+        );
+
+        let outcome = resolver.acquire_inflight_slot(issuer_url, "raced-key");
+
+        let SlotOutcome::Resolved((_jwk, issuer)) = outcome else {
+            panic!("fresh cache should resolve without a fetch");
+        };
+        assert_eq!(issuer, "https://issuer.example.com");
+        let inflight_guard = inflight.lock().expect("inflight not poisoned");
+        assert!(
+            inflight_guard.is_empty(),
+            "no fetch should be started when the re-check hits"
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_slot_starts_fetch_when_fresh_cache_lacks_kid() {
+        // A fresh cache entry that lacks the requested kid must still start a
+        // fetch; the re-check only short-circuits on an actual key hit.
+        let client = reqwest::Client::new();
+
+        let jwks_json = format!(
+            r#"{{"keys":[{{"kty":"RSA","kid":"other-key","alg":"RS256","n":"{}","e":"{}"}}]}}"#,
+            TEST_RSA_N, TEST_RSA_E
+        );
+        let jwks = make_test_jwks(&client, &jwks_json).await;
+
+        let issuer_url = Url::parse("https://auth.example.com").expect("valid URL");
+        let cache: Arc<RwLock<HashMap<Url, CachedJwks>>> = Arc::new(RwLock::new(HashMap::new()));
+        {
+            let mut guard = cache.write().unwrap();
+            guard.insert(
+                issuer_url.clone(),
+                CachedJwks {
+                    keys: jwks,
+                    issuer: "https://issuer.example.com".to_string(),
+                    fetched_at: Instant::now(),
+                    signing_algs: vec!["RS256".to_string()],
+                },
+            );
+        }
+        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(HashMap::new()));
+
+        let resolver = NetworkedKeyResolver::new(
+            &client,
+            Duration::from_secs(5),
+            &inflight,
+            &cache,
+            Duration::from_secs(300),
+        );
+
+        let outcome = resolver.acquire_inflight_slot(issuer_url.clone(), "missing-key");
+
+        assert!(
+            matches!(outcome, SlotOutcome::Fetch(_)),
+            "unknown kid should start a fetch even with a fresh cache entry"
+        );
+        let inflight_guard = inflight.lock().expect("inflight not poisoned");
+        assert!(
+            inflight_guard.contains_key(&issuer_url),
+            "the new fetch should occupy the inflight slot"
         );
     }
 }

--- a/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
+use futures::FutureExt;
 use futures::future::{BoxFuture, Shared};
 use jsonwebtoken::jwk::KeyAlgorithm;
 use jwks::{Jwk, Jwks};
@@ -38,7 +39,6 @@ impl CachedJwks {
 }
 
 ///  A future that does one cold-cache JWKS fetch and self-evicts from the inflight map.
-#[allow(dead_code)]
 pub(super) type InflightFetch = Shared<BoxFuture<'static, ()>>;
 
 /// Map of in-flight cold fetches keyed by issuer URL.
@@ -49,7 +49,6 @@ pub(super) type InflightMap = Mutex<HashMap<Url, InflightFetch>>;
 pub(super) struct NetworkedKeyResolver<'a> {
     client: &'a reqwest::Client,
     discovery_timeout: Duration,
-    #[allow(dead_code)]
     inflight: &'a Arc<InflightMap>,
     jwks_cache: &'a Arc<RwLock<HashMap<Url, CachedJwks>>>,
     ttl: Duration,
@@ -70,6 +69,101 @@ impl<'a> NetworkedKeyResolver<'a> {
             jwks_cache,
             ttl,
         }
+    }
+
+    /// Reads the JWKS cache under the read lock and returns the resolved
+    /// `(jwk, issuer)` if a fresh entry with `key_id` exists. Returns `None`
+    /// for any combination of: no entry, stale entry, kid not in entry, or
+    /// lock poisoned (we treat poisoning as a miss; the next writer will
+    /// recover with `unwrap_or_else(|e| e.into_inner())`).
+    fn lookup_fresh(&self, server: &Url, key_id: &str) -> Option<(Jwk, String)> {
+        let cache = self.jwks_cache.read().ok()?;
+        let entry = cache.get(server)?;
+        if !entry.is_fresh(self.ttl) {
+            return None;
+        }
+        entry.lookup(key_id, server)
+    }
+
+    /// Returns a future that completes when this issuer's cold fetch is done.
+    /// If a slot already exists for `server`, returns a clone of the in-flight
+    /// `Shared` future. Otherwise, builds a fresh fetch future, installs it
+    /// in the inflight map under `server`, and returns a clone.
+    ///
+    /// The fetch future is responsible for removing its own slot from the map
+    /// before resolving; we never leave a stale slot behind.
+    fn acquire_inflight_slot(&self, server: Url) -> InflightFetch {
+        let mut guard = self.inflight.lock().unwrap_or_else(|e| e.into_inner());
+
+        if let Some(existing) = guard.get(&server) {
+            return existing.clone();
+        }
+
+        let fetch = Self::build_fetch_future(
+            self.client.clone(),
+            Arc::clone(self.jwks_cache),
+            Arc::clone(self.inflight),
+            server.clone(),
+            self.discovery_timeout,
+        );
+
+        guard.insert(server, fetch.clone());
+        fetch
+    }
+
+    /// Builds the one-shot future that runs discovery + JWKS fetch, inserts
+    /// into the cache, and removes its own slot from the inflight map before
+    /// resolving. Output is `()` — concurrent callers re-read the cache for
+    /// their own `kid` lookup.
+    fn build_fetch_future(
+        client: reqwest::Client,
+        jwks_cache: Arc<RwLock<HashMap<Url, CachedJwks>>>,
+        inflight: Arc<InflightMap>,
+        server: Url,
+        discovery_timeout: Duration,
+    ) -> InflightFetch {
+        async move {
+            // Do the network work. `discover_metadata`/`fetch_jwks` log their
+            // own failures; we just decide whether to populate the cache.
+            let Some(metadata) = discover_metadata(&client, &server, discovery_timeout).await
+            else {
+                inflight
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .remove(&server);
+                return;
+            };
+            let Some(jwks) = fetch_jwks(&client, &metadata.jwks_uri, discovery_timeout).await
+            else {
+                inflight
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .remove(&server);
+                return;
+            };
+
+            let entry = CachedJwks {
+                keys: jwks,
+                issuer: metadata.issuer,
+                fetched_at: Instant::now(),
+                signing_algs: metadata.id_token_signing_alg_values_supported,
+            };
+
+            // Insert into the cache, then evict the inflight slot. Cache-then-
+            // evict ordering matters: a request arriving between these two
+            // operations sees the fresh cache entry on its warm-path read and
+            // does not become a new leader.
+            {
+                let mut cache = jwks_cache.write().unwrap_or_else(|e| e.into_inner());
+                cache.insert(server.clone(), entry);
+            }
+            inflight
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .remove(&server);
+        }
+        .boxed()
+        .shared()
     }
 }
 
@@ -224,43 +318,28 @@ async fn fetch_jwks(client: &reqwest::Client, jwks_uri: &str, timeout: Duration)
 }
 
 impl KeyResolver for NetworkedKeyResolver<'_> {
-    /// `discovery_timeout` bounds each network stage (metadata fetch and JWKS
-    /// fetch) independently, so a cold-cache lookup can take up to 2×
-    /// `discovery_timeout` on the happy path. The JWKS fetch does not fall
-    /// back to alternate discovery URLs on failure; real providers advertise
-    /// the same `jwks_uri` from every well-known path.
+    /// On the warm path, returns from the in-memory cache without any network
+    /// call. On a cold or stale-entry path, exactly one fetch per issuer runs
+    /// process-wide regardless of inbound concurrency — concurrent callers
+    /// share an inflight slot keyed by issuer URL. The slot self-evicts as
+    /// the leader's future resolves, so a failed fetch does not poison the
+    /// next caller's retry. `discovery_timeout` still bounds each network
+    /// stage independently.
     async fn resolve_key(&self, server: &Url, key_id: &str) -> Option<(Jwk, String)> {
-        // Return immediately if the key is cached and fresh.
-        if let Ok(cache) = self.jwks_cache.read()
-            && let Some(entry) = cache.get(server)
-            && entry.is_fresh(self.ttl)
-            && let Some(result) = entry.lookup(key_id, server)
-        {
+        // Warm path: in-memory lookup, no network.
+        if let Some(result) = self.lookup_fresh(server, key_id) {
             return Some(result);
         }
 
-        let metadata = discover_metadata(self.client, server, self.discovery_timeout).await?;
-        let jwks = fetch_jwks(self.client, &metadata.jwks_uri, self.discovery_timeout).await?;
+        // Cold path: become singleflight leader, or join as follower.
+        let fetch = self.acquire_inflight_slot(server.clone());
+        fetch.await;
 
-        // Re-check before inserting; another request may have populated the
-        // cache during the network fetch. Recover from lock poison: inserting
-        // a fresh value is safe regardless of prior state.
-        let mut cache = self.jwks_cache.write().unwrap_or_else(|e| e.into_inner());
-        if let Some(entry) = cache.get(server)
-            && entry.is_fresh(self.ttl)
-            && let Some(result) = entry.lookup(key_id, server)
-        {
-            return Some(result);
-        }
-        let entry = CachedJwks {
-            keys: jwks,
-            issuer: metadata.issuer,
-            fetched_at: Instant::now(),
-            signing_algs: metadata.id_token_signing_alg_values_supported,
-        };
-        let result = entry.lookup(key_id, server);
-        cache.insert(server.clone(), entry);
-        result
+        // After the slot resolves, the leader has either populated the cache
+        // or failed. Either way, do our own per-`kid` lookup against the
+        // current cache state. Followers asking for a different `kid` than
+        // the leader get the right answer this way.
+        self.lookup_fresh(server, key_id)
     }
 }
 

--- a/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
@@ -49,6 +49,8 @@ pub(super) type InflightMap = Mutex<HashMap<Url, InflightFetch>>;
 pub(super) struct NetworkedKeyResolver<'a> {
     client: &'a reqwest::Client,
     discovery_timeout: Duration,
+    #[allow(dead_code)]
+    inflight: &'a Arc<InflightMap>,
     jwks_cache: &'a Arc<RwLock<HashMap<Url, CachedJwks>>>,
     ttl: Duration,
 }
@@ -57,12 +59,14 @@ impl<'a> NetworkedKeyResolver<'a> {
     pub fn new(
         client: &'a reqwest::Client,
         discovery_timeout: Duration,
+        inflight: &'a Arc<InflightMap>,
         jwks_cache: &'a Arc<RwLock<HashMap<Url, CachedJwks>>>,
         ttl: Duration,
     ) -> Self {
         Self {
             client,
             discovery_timeout,
+            inflight,
             jwks_cache,
             ttl,
         }
@@ -636,6 +640,8 @@ mod tests {
         );
         let jwks = make_test_jwks(&client, &jwks_json).await;
 
+        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(HashMap::new()));
+
         // Actual test server — any request reaching here means the warm path failed.
         let mut server = mockito::Server::new_async().await;
         let no_network = server
@@ -662,6 +668,7 @@ mod tests {
         let resolver = NetworkedKeyResolver::new(
             &client,
             Duration::from_secs(5),
+            &inflight,
             &cache,
             Duration::from_secs(300),
         );
@@ -683,6 +690,8 @@ mod tests {
             TEST_RSA_N, TEST_RSA_E
         );
         let jwks = make_test_jwks(&client, &jwks_json).await;
+
+        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(HashMap::new()));
 
         let mut server = mockito::Server::new_async().await;
         let no_network = server
@@ -709,6 +718,7 @@ mod tests {
         let resolver = NetworkedKeyResolver::new(
             &client,
             Duration::from_secs(5),
+            &inflight,
             &cache,
             Duration::from_secs(300),
         );
@@ -734,6 +744,8 @@ mod tests {
             TEST_RSA_N, TEST_RSA_E
         );
 
+        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(HashMap::new()));
+
         let discovery_mock = server
             .mock("GET", "/.well-known/oauth-authorization-server")
             .with_status(200)
@@ -758,6 +770,7 @@ mod tests {
         let resolver = NetworkedKeyResolver::new(
             &client,
             Duration::from_secs(5),
+            &inflight,
             &cache,
             Duration::from_secs(300),
         );
@@ -783,6 +796,8 @@ mod tests {
             TEST_RSA_N, TEST_RSA_E
         );
         let stale_jwks = make_test_jwks(&client, &stale_jwks_json).await;
+
+        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(HashMap::new()));
 
         let mut server = mockito::Server::new_async().await;
 
@@ -831,7 +846,8 @@ mod tests {
         }
 
         let ttl = Duration::from_millis(1);
-        let resolver = NetworkedKeyResolver::new(&client, Duration::from_secs(5), &cache, ttl);
+        let resolver =
+            NetworkedKeyResolver::new(&client, Duration::from_secs(5), &inflight, &cache, ttl);
 
         let result = resolver.resolve_key(&issuer_url, "new-key").await;
 


### PR DESCRIPTION
## Summary

When many requests arrive at once for an issuer whose JWKS isn't cached yet (or whose cached entry just expired), each request previously triggered its own OAuth discovery + JWKS fetch. That meant that N concurrent requests meant N identical upstream round-trips, even if it was from the same issuer. This PR brings N of requests into one.

- Adds an in-flight fetch map (`Arc<Mutex<HashMap<Url, Shared<BoxFuture<()>>>>>`) to `AuthState`, threaded into `NetworkedKeyResolver`.
- On a cache miss, the first caller becomes the "leader": it installs a shared `future` keyed by issuer URL, does the network work, populates the JWKS cache, and evicts its own slot before resolving. Concurrent callers ("followers") clone that shared future and `await` it instead of fetching.
- Followers re-read the cache for their own `kid` afterward 

## Note: Stacked on #777

This base branch is `gocamille/add-jwks-cache`, not `main`. When #777 merges, this will be retargeted to `main`.