### PR TITLE
Cache JWKS per issuer and rate-limit refreshes

### DIFF
--- a/.changeset/rate_limit_jwks_refresh.md
+++ b/.changeset/rate_limit_jwks_refresh.md
@@ -1,0 +1,9 @@
+---
+default: minor
+---
+
+# Rate-limit JWKS refreshes per issuer
+
+Apollo MCP Server now allows at most one JWKS refresh per issuer per configurable window (`jwks_min_refresh_interval`, default 60 seconds). When a token arrives with a `kid` that is not in the cached JWKS and the window is exhausted, the request is rejected with 401 immediately — no outbound HTTP is made. Concurrent misses within an allowed refresh still coalesce into a single upstream fetch.
+
+This closes the request-amplification vector where an attacker rotating unique bogus `kid`s could drive one upstream discovery + JWKS fetch pair per request.

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -236,6 +236,14 @@ pub struct Config {
     #[serde(deserialize_with = "humantime_serde::deserialize", default)]
     #[schemars(with = "Option<String>")]
     pub jwks_cache_ttl: Option<Duration>,
+
+    /// Minimum time between JWKS refreshes for a single issuer. A token whose
+    /// `kid` is not in the cached JWKS triggers at most one refresh per issuer
+    /// per this interval; further misses inside the window are rejected with
+    /// 401 without any outbound request. Defaults to 60 seconds.
+    #[serde(deserialize_with = "humantime_serde::deserialize", default)]
+    #[schemars(with = "Option<String>")]
+    pub jwks_min_refresh_interval: Option<Duration>,
 }
 
 /// TLS configuration for OAuth server connections
@@ -403,6 +411,11 @@ const DEFAULT_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(5);
 /// Default TTL for cached JWKS entries when `transport.auth.jwks_cache_ttl`
 /// is not configured.
 const DEFAULT_JWKS_CACHE_TTL: Duration = Duration::from_secs(600); // 10 min
+
+/// Default minimum interval between JWKS refreshes per issuer when
+/// `transport.auth.jwks_min_refresh_interval` is not configured.
+#[allow(dead_code)] // consumed in Step 3
+const DEFAULT_JWKS_MIN_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
 
 /// MCP discovery methods that are allowed without authentication when
 /// `allow_anonymous_mcp_discovery` is enabled.
@@ -653,6 +666,7 @@ mod tests {
             tls: TlsConfig::default(),
             discovery_timeout: None,
             jwks_cache_ttl: None,
+            jwks_min_refresh_interval: None,
             discovery_headers: HeaderMap::new(),
         }
     }
@@ -1200,6 +1214,42 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
 
             let config: Config = serde_yaml::from_str(y).unwrap();
             assert_eq!(config.jwks_cache_ttl, None);
+        }
+
+        #[test]
+        fn yaml_deserialization_with_jwks_min_refresh_interval() {
+            let y = r#"
+              servers:
+                - http://localhost:1234
+              audiences:
+                - test-audience
+              resource: http://localhost:4000
+              scopes:
+                - read
+              jwks_min_refresh_interval: 30s
+            "#;
+
+            let config: Config = serde_yaml::from_str(y).unwrap();
+            assert_eq!(
+                config.jwks_min_refresh_interval,
+                Some(Duration::from_secs(30))
+            );
+        }
+
+        #[test]
+        fn yaml_deserialization_without_jwks_min_refresh_interval_defaults_to_none() {
+            let y = r#"
+              servers:
+                - http://localhost:1234
+              audiences:
+                - test-audience
+              resource: http://localhost:4000
+              scopes:
+                - read
+            "#;
+
+            let config: Config = serde_yaml::from_str(y).unwrap();
+            assert_eq!(config.jwks_min_refresh_interval, None);
         }
 
         #[tokio::test]

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -16,7 +16,7 @@ use axum_extra::{
     headers::{Authorization, authorization::Bearer},
 };
 use http::Method;
-use networked_key_resolver::{CachedJwks, InflightMap, NetworkedKeyResolver};
+use networked_key_resolver::{CachedJwks, InflightMap, IssuerFetchState, NetworkedKeyResolver};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -375,7 +375,7 @@ impl Config {
             resource_metadata_url,
             auth_servers: Arc::from(auth_servers),
             required_scopes: Arc::new(required_scopes),
-            inflight: Arc::new(Mutex::new(HashMap::new())),
+            inflight: Arc::new(Mutex::new(IssuerFetchState::default())),
             jwks_cache: Arc::new(RwLock::new(HashMap::new())),
         };
 
@@ -670,7 +670,7 @@ mod tests {
             resource_metadata_url,
             auth_servers: Arc::from(auth_servers),
             required_scopes: Arc::new(HashMap::new()),
-            inflight: Arc::new(Mutex::new(HashMap::new())),
+            inflight: Arc::new(Mutex::new(IssuerFetchState::default())),
             jwks_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -414,7 +414,6 @@ const DEFAULT_JWKS_CACHE_TTL: Duration = Duration::from_secs(600); // 10 min
 
 /// Default minimum interval between JWKS refreshes per issuer when
 /// `transport.auth.jwks_min_refresh_interval` is not configured.
-#[allow(dead_code)] // consumed in Step 3
 const DEFAULT_JWKS_MIN_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
 
 /// MCP discovery methods that are allowed without authentication when
@@ -559,6 +558,10 @@ async fn oauth_validate(
 
     let jwks_cache_ttl = auth_config.jwks_cache_ttl.unwrap_or(DEFAULT_JWKS_CACHE_TTL);
 
+    let jwks_min_refresh_interval = auth_config
+        .jwks_min_refresh_interval
+        .unwrap_or(DEFAULT_JWKS_MIN_REFRESH_INTERVAL);
+
     let validator = TokenValidator {
         audiences: &auth_config.audiences,
         issuers: &auth_config.issuers,
@@ -570,6 +573,7 @@ async fn oauth_validate(
             &auth_state.inflight,
             &auth_state.jwks_cache,
             jwks_cache_ttl,
+            jwks_min_refresh_interval,
         ),
     };
     let token = token.ok_or_else(|| {

--- a/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
@@ -63,6 +63,8 @@ pub(super) struct NetworkedKeyResolver<'a> {
     inflight: &'a Arc<InflightMap>,
     jwks_cache: &'a Arc<RwLock<HashMap<Url, CachedJwks>>>,
     ttl: Duration,
+    #[allow(dead_code)] // consumed in Step 5
+    min_refresh_interval: Duration,
 }
 
 impl<'a> NetworkedKeyResolver<'a> {
@@ -72,6 +74,7 @@ impl<'a> NetworkedKeyResolver<'a> {
         inflight: &'a Arc<InflightMap>,
         jwks_cache: &'a Arc<RwLock<HashMap<Url, CachedJwks>>>,
         ttl: Duration,
+        min_refresh_interval: Duration,
     ) -> Self {
         Self {
             client,
@@ -79,6 +82,7 @@ impl<'a> NetworkedKeyResolver<'a> {
             inflight,
             jwks_cache,
             ttl,
+            min_refresh_interval,
         }
     }
 
@@ -743,6 +747,7 @@ mod tests {
             &inflight,
             &cache,
             Duration::from_secs(300),
+            Duration::from_secs(60),
         );
 
         let result = resolver.resolve_key(&issuer_url, "cached-key").await;
@@ -793,6 +798,7 @@ mod tests {
             &inflight,
             &cache,
             Duration::from_secs(300),
+            Duration::from_secs(60),
         );
 
         let result = resolver.resolve_key(&issuer_url, "no-alg-key").await;
@@ -845,6 +851,7 @@ mod tests {
             &inflight,
             &cache,
             Duration::from_secs(300),
+            Duration::from_secs(60),
         );
 
         let result = resolver.resolve_key(&issuer_url, "fresh-key").await;
@@ -918,8 +925,14 @@ mod tests {
         }
 
         let ttl = Duration::from_millis(1);
-        let resolver =
-            NetworkedKeyResolver::new(&client, Duration::from_secs(5), &inflight, &cache, ttl);
+        let resolver = NetworkedKeyResolver::new(
+            &client,
+            Duration::from_secs(5),
+            &inflight,
+            &cache,
+            ttl,
+            Duration::from_secs(60),
+        );
 
         let result = resolver.resolve_key(&issuer_url, "new-key").await;
 
@@ -989,6 +1002,7 @@ mod tests {
                     &inflight,
                     &cache,
                     Duration::from_secs(300),
+                    Duration::from_secs(60),
                 );
                 resolver.resolve_key(&issuer_url, "singleflight-key").await
             }));

--- a/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
@@ -41,8 +41,19 @@ impl CachedJwks {
 ///  A future that does one cold-cache JWKS fetch and self-evicts from the inflight map.
 pub(super) type InflightFetch = Shared<BoxFuture<'static, ()>>;
 
-/// Map of in-flight cold fetches keyed by issuer URL.
-pub(super) type InflightMap = Mutex<HashMap<Url, InflightFetch>>;
+/// Per-issuer fetch coordination state, guarded by one mutex so the
+/// join-or-start-or-reject decision in `acquire_inflight_slot` is atomic.
+#[derive(Default)]
+pub(super) struct IssuerFetchState {
+    /// In-flight cold fetches keyed by issuer URL.
+    slots: HashMap<Url, InflightFetch>,
+    /// When each issuer's most recent fetch was started. Bounded by the
+    /// configured server list; never evicted.
+    #[allow(dead_code)] // consumed in Step 5
+    last_attempt: HashMap<Url, Instant>,
+}
+
+pub(super) type InflightMap = Mutex<IssuerFetchState>;
 
 /// [`KeyResolver`] that fetches signing keys from the network via OIDC/OAuth
 /// discovery.
@@ -88,7 +99,7 @@ impl<'a> NetworkedKeyResolver<'a> {
     fn acquire_inflight_slot(&self, server: Url) -> InflightFetch {
         let mut guard = self.inflight.lock().unwrap_or_else(|e| e.into_inner());
 
-        if let Some(existing) = guard.get(&server) {
+        if let Some(existing) = guard.slots.get(&server) {
             return existing.clone();
         }
 
@@ -100,7 +111,7 @@ impl<'a> NetworkedKeyResolver<'a> {
             self.discovery_timeout,
         );
 
-        guard.insert(server, fetch.clone());
+        guard.slots.insert(server, fetch.clone());
         fetch
     }
 
@@ -119,6 +130,7 @@ impl<'a> NetworkedKeyResolver<'a> {
                 inflight
                     .lock()
                     .unwrap_or_else(|e| e.into_inner())
+                    .slots
                     .remove(&server);
                 return;
             };
@@ -127,6 +139,7 @@ impl<'a> NetworkedKeyResolver<'a> {
                 inflight
                     .lock()
                     .unwrap_or_else(|e| e.into_inner())
+                    .slots
                     .remove(&server);
                 return;
             };
@@ -147,6 +160,7 @@ impl<'a> NetworkedKeyResolver<'a> {
             inflight
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
+                .slots
                 .remove(&server);
         }
         .boxed()
@@ -698,7 +712,7 @@ mod tests {
         );
         let jwks = make_test_jwks(&client, &jwks_json).await;
 
-        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(HashMap::new()));
+        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(IssuerFetchState::default()));
 
         // Actual test server — any request reaching here means the warm path failed.
         let mut server = mockito::Server::new_async().await;
@@ -749,7 +763,7 @@ mod tests {
         );
         let jwks = make_test_jwks(&client, &jwks_json).await;
 
-        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(HashMap::new()));
+        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(IssuerFetchState::default()));
 
         let mut server = mockito::Server::new_async().await;
         let no_network = server
@@ -802,7 +816,7 @@ mod tests {
             TEST_RSA_N, TEST_RSA_E
         );
 
-        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(HashMap::new()));
+        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(IssuerFetchState::default()));
 
         let discovery_mock = server
             .mock("GET", "/.well-known/oauth-authorization-server")
@@ -855,7 +869,7 @@ mod tests {
         );
         let stale_jwks = make_test_jwks(&client, &stale_jwks_json).await;
 
-        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(HashMap::new()));
+        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(IssuerFetchState::default()));
 
         let mut server = mockito::Server::new_async().await;
 
@@ -956,7 +970,7 @@ mod tests {
 
         let issuer_url = Url::parse(&server.url()).expect("valid URL");
         let cache: Arc<RwLock<HashMap<Url, CachedJwks>>> = Arc::new(RwLock::new(HashMap::new()));
-        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(HashMap::new()));
+        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(IssuerFetchState::default()));
         let client = reqwest::Client::new();
 
         // Spawn 100 tasks that all race to resolve the same key against the same
@@ -995,7 +1009,7 @@ mod tests {
         // And the inflight map self-evicted after the leader completed.
         let inflight_guard = inflight.lock().expect("inflight not poisoned");
         assert!(
-            inflight_guard.is_empty(),
+            inflight_guard.slots.is_empty(),
             "inflight slot should be removed after the leader's future resolved"
         );
     }

--- a/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
@@ -1027,4 +1027,131 @@ mod tests {
             "inflight slot should be removed after the leader's future resolved"
         );
     }
+
+    #[tokio::test]
+    async fn kid_miss_inside_refresh_window_returns_none_without_network() {
+        // One cold fetch populates the cache and consumes the refresh window.
+        // A subsequent request for an unknown kid inside the window must be
+        // rejected (None) with zero additional upstream requests — mockito's
+        // .expect(1) on each mock enforces "no second fetch."
+        let mut server = mockito::Server::new_async().await;
+
+        let discovery_json = format!(
+            r#"{{"issuer":"{}","jwks_uri":"{}/jwks","id_token_signing_alg_values_supported":["RS256"]}}"#,
+            server.url(),
+            server.url()
+        );
+        let jwks_json = format!(
+            r#"{{"keys":[{{"kty":"RSA","kid":"known-key","alg":"RS256","n":"{}","e":"{}"}}]}}"#,
+            TEST_RSA_N, TEST_RSA_E
+        );
+
+        let discovery_mock = server
+            .mock("GET", "/.well-known/oauth-authorization-server")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&discovery_json)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let jwks_mock = server
+            .mock("GET", "/jwks")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&jwks_json)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let issuer_url = Url::parse(&server.url()).expect("valid URL");
+        let cache: Arc<RwLock<HashMap<Url, CachedJwks>>> = Arc::new(RwLock::new(HashMap::new()));
+        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(IssuerFetchState::default()));
+        let client = reqwest::Client::new();
+        let resolver = NetworkedKeyResolver::new(
+            &client,
+            Duration::from_secs(5),
+            &inflight,
+            &cache,
+            Duration::from_secs(300),
+            Duration::from_secs(60),
+        );
+
+        // Cold fetch: allowed, consumes the window.
+        let first = resolver.resolve_key(&issuer_url, "known-key").await;
+        assert!(first.is_some(), "cold fetch for a known kid should resolve");
+
+        // Unknown kid inside the window: rejected, no second fetch.
+        let second = resolver.resolve_key(&issuer_url, "bogus-kid").await;
+        assert!(
+            second.is_none(),
+            "kid miss inside the refresh window should be rejected"
+        );
+
+        // A known kid still resolves from the warm cache.
+        let third = resolver.resolve_key(&issuer_url, "known-key").await;
+        assert!(third.is_some(), "warm hits are unaffected by the rate limit");
+
+        discovery_mock.assert();
+        jwks_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn thousand_unique_kid_misses_trigger_one_upstream_fetch_pair() {
+        // The AMS-534 acceptance criterion: 1000 inbound requests with random
+        // kids inside one refresh window produce exactly one upstream
+        // discovery + JWKS fetch pair for the issuer.
+        let mut server = mockito::Server::new_async().await;
+
+        let discovery_json = format!(
+            r#"{{"issuer":"{}","jwks_uri":"{}/jwks","id_token_signing_alg_values_supported":["RS256"]}}"#,
+            server.url(),
+            server.url()
+        );
+        let jwks_json = format!(
+            r#"{{"keys":[{{"kty":"RSA","kid":"real-key","alg":"RS256","n":"{}","e":"{}"}}]}}"#,
+            TEST_RSA_N, TEST_RSA_E
+        );
+
+        let discovery_mock = server
+            .mock("GET", "/.well-known/oauth-authorization-server")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&discovery_json)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let jwks_mock = server
+            .mock("GET", "/jwks")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&jwks_json)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let issuer_url = Url::parse(&server.url()).expect("valid URL");
+        let cache: Arc<RwLock<HashMap<Url, CachedJwks>>> = Arc::new(RwLock::new(HashMap::new()));
+        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(IssuerFetchState::default()));
+        let client = reqwest::Client::new();
+        let resolver = NetworkedKeyResolver::new(
+            &client,
+            Duration::from_secs(5),
+            &inflight,
+            &cache,
+            Duration::from_secs(300),
+            Duration::from_secs(60),
+        );
+
+        for i in 0..1000 {
+            let kid = format!("attacker-kid-{i}");
+            let result = resolver.resolve_key(&issuer_url, &kid).await;
+            assert!(result.is_none(), "bogus kid {kid} must not resolve");
+        }
+
+        // The hard assertion: exactly one upstream pair for 1000 misses.
+        discovery_mock.assert();
+        jwks_mock.assert();
+    }
 }

--- a/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
@@ -1175,4 +1175,184 @@ mod tests {
         discovery_mock.assert();
         jwks_mock.assert();
     }
+
+    #[tokio::test]
+    async fn refresh_allowed_again_after_window_elapses() {
+        // Back-date last_attempt past the window instead of sleeping, so the
+        // test is deterministic. The second fetch must then be allowed.
+        let mut server = mockito::Server::new_async().await;
+
+        let discovery_json = format!(
+            r#"{{"issuer":"{}","jwks_uri":"{}/jwks","id_token_signing_alg_values_supported":["RS256"]}}"#,
+            server.url(),
+            server.url()
+        );
+        let jwks_json = format!(
+            r#"{{"keys":[{{"kty":"RSA","kid":"rotated-key","alg":"RS256","n":"{}","e":"{}"}}]}}"#,
+            TEST_RSA_N, TEST_RSA_E
+        );
+
+        let discovery_mock = server
+            .mock("GET", "/.well-known/oauth-authorization-server")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&discovery_json)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let jwks_mock = server
+            .mock("GET", "/jwks")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&jwks_json)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let issuer_url = Url::parse(&server.url()).expect("valid URL");
+        let cache: Arc<RwLock<HashMap<Url, CachedJwks>>> = Arc::new(RwLock::new(HashMap::new()));
+        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(IssuerFetchState::default()));
+
+        // Simulate a refresh that happened 120s ago with a 60s window.
+        {
+            let mut guard = inflight.lock().expect("inflight not poisoned");
+            guard
+                .last_attempt
+                .insert(issuer_url.clone(), Instant::now() - Duration::from_secs(120));
+        }
+
+        let client = reqwest::Client::new();
+        let resolver = NetworkedKeyResolver::new(
+            &client,
+            Duration::from_secs(5),
+            &inflight,
+            &cache,
+            Duration::from_secs(300),
+            Duration::from_secs(60),
+        );
+
+        let result = resolver.resolve_key(&issuer_url, "rotated-key").await;
+
+        discovery_mock.assert();
+        jwks_mock.assert();
+        assert!(
+            result.is_some(),
+            "fetch should be allowed once the window has elapsed"
+        );
+    }
+
+    #[tokio::test]
+    async fn rate_limit_is_per_issuer_not_global() {
+        // Exhausting issuer A's window must not block issuer B's fetch.
+        let mut server_b = mockito::Server::new_async().await;
+
+        let discovery_json = format!(
+            r#"{{"issuer":"{}","jwks_uri":"{}/jwks","id_token_signing_alg_values_supported":["RS256"]}}"#,
+            server_b.url(),
+            server_b.url()
+        );
+        let jwks_json = format!(
+            r#"{{"keys":[{{"kty":"RSA","kid":"issuer-b-key","alg":"RS256","n":"{}","e":"{}"}}]}}"#,
+            TEST_RSA_N, TEST_RSA_E
+        );
+
+        let discovery_mock = server_b
+            .mock("GET", "/.well-known/oauth-authorization-server")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&discovery_json)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let jwks_mock = server_b
+            .mock("GET", "/jwks")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&jwks_json)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let issuer_a = Url::parse("https://issuer-a.example.com").expect("valid URL");
+        let issuer_b = Url::parse(&server_b.url()).expect("valid URL");
+        let cache: Arc<RwLock<HashMap<Url, CachedJwks>>> = Arc::new(RwLock::new(HashMap::new()));
+        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(IssuerFetchState::default()));
+
+        // Issuer A's window was just consumed.
+        {
+            let mut guard = inflight.lock().expect("inflight not poisoned");
+            guard.last_attempt.insert(issuer_a.clone(), Instant::now());
+        }
+
+        let client = reqwest::Client::new();
+        let resolver = NetworkedKeyResolver::new(
+            &client,
+            Duration::from_secs(5),
+            &inflight,
+            &cache,
+            Duration::from_secs(300),
+            Duration::from_secs(60),
+        );
+
+        // Issuer A: rejected without touching the network (its host does not
+        // even resolve, so any attempted fetch would fail loudly or hang).
+        let a = resolver.resolve_key(&issuer_a, "any-kid").await;
+        assert!(a.is_none(), "issuer A is inside its window");
+
+        // Issuer B: its own window is untouched; fetch proceeds.
+        let b = resolver.resolve_key(&issuer_b, "issuer-b-key").await;
+        discovery_mock.assert();
+        jwks_mock.assert();
+        assert!(b.is_some(), "issuer B has an independent refresh window");
+    }
+
+    #[tokio::test]
+    async fn failed_fetch_consumes_the_refresh_window() {
+        // An unreachable issuer is retried at most once per window: the first
+        // call attempts (and fails) discovery; the second call inside the
+        // window makes zero requests. mockito .expect(...) counts enforce it.
+        let mut server = mockito::Server::new_async().await;
+
+        // Both discovery URLs fail — one hit each on the first attempt only.
+        let rfc8414_mock = server
+            .mock("GET", "/.well-known/oauth-authorization-server")
+            .with_status(500)
+            .expect(1)
+            .create_async()
+            .await;
+        let oidc_mock = server
+            .mock("GET", "/.well-known/openid-configuration")
+            .with_status(500)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let issuer_url = Url::parse(&server.url()).expect("valid URL");
+        let cache: Arc<RwLock<HashMap<Url, CachedJwks>>> = Arc::new(RwLock::new(HashMap::new()));
+        let inflight: Arc<InflightMap> = Arc::new(Mutex::new(IssuerFetchState::default()));
+        let client = reqwest::Client::new();
+        let resolver = NetworkedKeyResolver::new(
+            &client,
+            Duration::from_secs(5),
+            &inflight,
+            &cache,
+            Duration::from_secs(300),
+            Duration::from_secs(60),
+        );
+
+        let first = resolver.resolve_key(&issuer_url, "any-kid").await;
+        assert!(first.is_none(), "fetch against a failing issuer returns None");
+
+        let second = resolver.resolve_key(&issuer_url, "any-kid").await;
+        assert!(
+            second.is_none(),
+            "second attempt inside the window is rejected without HTTP"
+        );
+
+        // Exactly one hit per discovery URL across both calls.
+        rfc8414_mock.assert();
+        oidc_mock.assert();
+    }
 }

--- a/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
@@ -86,7 +86,7 @@ impl<'a> NetworkedKeyResolver<'a> {
     /// Returns the resolved `(jwk, issuer)` if the cache holds a fresh entry
     /// containing `key_id`.
     fn lookup_fresh(&self, server: &Url, key_id: &str) -> Option<(Jwk, String)> {
-        let cache = self.jwks_cache.read().ok()?;
+        let cache = self.jwks_cache.read().unwrap_or_else(|e| e.into_inner());
         let entry = cache.get(server)?;
         if !entry.is_fresh(self.ttl) {
             return None;

--- a/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
@@ -41,14 +41,13 @@ impl CachedJwks {
 ///  A future that does one cold-cache JWKS fetch and self-evicts from the inflight map.
 pub(super) type InflightFetch = Shared<BoxFuture<'static, ()>>;
 
-/// Per-issuer fetch coordination state, guarded by one mutex so the
-/// join-or-start-or-reject decision in `acquire_inflight_slot` is atomic.
+/// Per-issuer fetch coordination state, guarded by a single mutex.
 #[derive(Default)]
 pub(super) struct IssuerFetchState {
     /// In-flight cold fetches keyed by issuer URL.
     slots: HashMap<Url, InflightFetch>,
-    /// When each issuer's most recent fetch was started. Bounded by the
-    /// configured server list; never evicted.
+    /// When each issuer's most recent fetch started. Bounded by the
+    /// configured server list.
     last_attempt: HashMap<Url, Instant>,
 }
 
@@ -98,13 +97,10 @@ impl<'a> NetworkedKeyResolver<'a> {
     /// Returns a future that completes when this issuer's fetch is done, or
     /// `None` if starting a fetch is not allowed right now.
     ///
-    /// **Invariant ownership:** this is the sole site that decides whether
-    /// this request triggers a new upstream fetch, joins an existing one, or
-    /// is refused. At most one fetch per issuer is ever in flight, and at
-    /// most one fetch per issuer starts per `min_refresh_interval`. Joining
-    /// an in-flight fetch is always allowed — it adds no upstream traffic.
-    /// The window is consumed when a fetch *starts* (even if it later fails),
-    /// so an unreachable issuer is retried at most once per window.
+    /// Sole owner of the fetch decision: at most one fetch per issuer is in
+    /// flight, and at most one starts per `min_refresh_interval`. Joining an
+    /// in-flight fetch is always allowed. The window is consumed when a
+    /// fetch starts, even if it later fails.
     fn acquire_inflight_slot(&self, server: Url) -> Option<InflightFetch> {
         let mut guard = self.inflight.lock().unwrap_or_else(|e| e.into_inner());
 
@@ -335,23 +331,19 @@ async fn fetch_jwks(client: &reqwest::Client, jwks_uri: &str, timeout: Duration)
 }
 
 impl KeyResolver for NetworkedKeyResolver<'_> {
-    /// Resolves from the in-memory cache when fresh. On a cold or expired
-    /// entry, concurrent callers for the same issuer share a single upstream
-    /// fetch, and at most one fetch per issuer starts per
-    /// `min_refresh_interval` — a miss inside the window is answered from the
-    /// cache alone (no outbound request), which for an unknown `kid` means
-    /// `None` and a 401 from the middleware.
+    /// Resolves from the in-memory cache when fresh. Concurrent misses for
+    /// the same issuer share a single upstream fetch, and at most one fetch
+    /// per issuer starts per `min_refresh_interval`; a miss inside the
+    /// window is answered from the cache alone, with no outbound request.
     async fn resolve_key(&self, server: &Url, key_id: &str) -> Option<(Jwk, String)> {
         if let Some(result) = self.lookup_fresh(server, key_id) {
             return Some(result);
         }
 
-        // Cold path: join or start the issuer's single fetch, unless the
-        // per-issuer refresh window is exhausted.
         let Some(fetch) = self.acquire_inflight_slot(server.clone()) else {
-            // Rate limited: no network. Re-read the cache before rejecting —
-            // a refresh that completed between our first lookup and the slot
-            // check may have just populated it with our `kid`.
+            // Rate limited: re-read the cache before rejecting, since a
+            // refresh finishing after the first lookup may have added this
+            // `kid`.
             return self.lookup_fresh(server, key_id);
         };
         fetch.await;
@@ -1051,10 +1043,9 @@ mod tests {
 
     #[tokio::test]
     async fn kid_miss_inside_refresh_window_returns_none_without_network() {
-        // One cold fetch populates the cache and consumes the refresh window.
-        // A subsequent request for an unknown kid inside the window must be
-        // rejected (None) with zero additional upstream requests — mockito's
-        // .expect(1) on each mock enforces "no second fetch."
+        // After a cold fetch consumes the refresh window, an unknown kid
+        // inside the window must be rejected with no additional upstream
+        // requests.
         let mut server = mockito::Server::new_async().await;
 
         let discovery_json = format!(
@@ -1122,9 +1113,8 @@ mod tests {
 
     #[tokio::test]
     async fn thousand_unique_kid_misses_trigger_one_upstream_fetch_pair() {
-        // The AMS-534 acceptance criterion: 1000 inbound requests with random
-        // kids inside one refresh window produce exactly one upstream
-        // discovery + JWKS fetch pair for the issuer.
+        // 1000 requests with unique bogus kids inside one refresh window
+        // must produce exactly one upstream discovery + JWKS fetch pair.
         let mut server = mockito::Server::new_async().await;
 
         let discovery_json = format!(
@@ -1181,8 +1171,9 @@ mod tests {
 
     #[tokio::test]
     async fn refresh_allowed_again_after_window_elapses() {
-        // Back-date last_attempt past the window instead of sleeping, so the
-        // test is deterministic. The second fetch must then be allowed.
+        // A fetch must be allowed again once the refresh window has elapsed.
+        // Back-dates last_attempt instead of sleeping, so the test is
+        // deterministic.
         let mut server = mockito::Server::new_async().await;
 
         let discovery_json = format!(
@@ -1300,8 +1291,8 @@ mod tests {
             Duration::from_secs(60),
         );
 
-        // Issuer A: rejected without touching the network (its host does not
-        // even resolve, so any attempted fetch would fail loudly or hang).
+        // Issuer A is inside its window: rejected without touching the
+        // network.
         let a = resolver.resolve_key(&issuer_a, "any-kid").await;
         assert!(a.is_none(), "issuer A is inside its window");
 
@@ -1314,9 +1305,9 @@ mod tests {
 
     #[tokio::test]
     async fn failed_fetch_consumes_the_refresh_window() {
-        // An unreachable issuer is retried at most once per window: the first
-        // call attempts (and fails) discovery; the second call inside the
-        // window makes zero requests. mockito .expect(...) counts enforce it.
+        // A failing issuer is retried at most once per window: the first
+        // call attempts discovery and fails; the second call inside the
+        // window makes zero requests.
         let mut server = mockito::Server::new_async().await;
 
         // Both discovery URLs fail — one hit each on the first attempt only.

--- a/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
@@ -49,7 +49,6 @@ pub(super) struct IssuerFetchState {
     slots: HashMap<Url, InflightFetch>,
     /// When each issuer's most recent fetch was started. Bounded by the
     /// configured server list; never evicted.
-    #[allow(dead_code)] // consumed in Step 5
     last_attempt: HashMap<Url, Instant>,
 }
 
@@ -63,7 +62,6 @@ pub(super) struct NetworkedKeyResolver<'a> {
     inflight: &'a Arc<InflightMap>,
     jwks_cache: &'a Arc<RwLock<HashMap<Url, CachedJwks>>>,
     ttl: Duration,
-    #[allow(dead_code)] // consumed in Step 5
     min_refresh_interval: Duration,
 }
 
@@ -97,14 +95,27 @@ impl<'a> NetworkedKeyResolver<'a> {
         entry.lookup(key_id, server)
     }
 
-    /// Returns a future that completes when this issuer's cold fetch is done,
-    /// joining the in-flight fetch if one exists or starting a new one. At
-    /// most one fetch per issuer is ever in flight.
-    fn acquire_inflight_slot(&self, server: Url) -> InflightFetch {
+    /// Returns a future that completes when this issuer's fetch is done, or
+    /// `None` if starting a fetch is not allowed right now.
+    ///
+    /// **Invariant ownership:** this is the sole site that decides whether
+    /// this request triggers a new upstream fetch, joins an existing one, or
+    /// is refused. At most one fetch per issuer is ever in flight, and at
+    /// most one fetch per issuer starts per `min_refresh_interval`. Joining
+    /// an in-flight fetch is always allowed — it adds no upstream traffic.
+    /// The window is consumed when a fetch *starts* (even if it later fails),
+    /// so an unreachable issuer is retried at most once per window.
+    fn acquire_inflight_slot(&self, server: Url) -> Option<InflightFetch> {
         let mut guard = self.inflight.lock().unwrap_or_else(|e| e.into_inner());
 
         if let Some(existing) = guard.slots.get(&server) {
-            return existing.clone();
+            return Some(existing.clone());
+        }
+
+        if let Some(last) = guard.last_attempt.get(&server)
+            && last.elapsed() < self.min_refresh_interval
+        {
+            return None;
         }
 
         let fetch = Self::build_fetch_future(
@@ -115,8 +126,9 @@ impl<'a> NetworkedKeyResolver<'a> {
             self.discovery_timeout,
         );
 
+        guard.last_attempt.insert(server.clone(), Instant::now());
         guard.slots.insert(server, fetch.clone());
-        fetch
+        Some(fetch)
     }
 
     /// Builds the one-shot future that fetches the issuer's keys, populates
@@ -325,14 +337,23 @@ async fn fetch_jwks(client: &reqwest::Client, jwks_uri: &str, timeout: Duration)
 impl KeyResolver for NetworkedKeyResolver<'_> {
     /// Resolves from the in-memory cache when fresh. On a cold or expired
     /// entry, concurrent callers for the same issuer share a single upstream
-    /// fetch; a failed fetch does not block the next caller's retry.
+    /// fetch, and at most one fetch per issuer starts per
+    /// `min_refresh_interval` — a miss inside the window is answered from the
+    /// cache alone (no outbound request), which for an unknown `kid` means
+    /// `None` and a 401 from the middleware.
     async fn resolve_key(&self, server: &Url, key_id: &str) -> Option<(Jwk, String)> {
         if let Some(result) = self.lookup_fresh(server, key_id) {
             return Some(result);
         }
 
-        // Cold path: share one fetch per issuer across concurrent callers.
-        let fetch = self.acquire_inflight_slot(server.clone());
+        // Cold path: join or start the issuer's single fetch, unless the
+        // per-issuer refresh window is exhausted.
+        let Some(fetch) = self.acquire_inflight_slot(server.clone()) else {
+            // Rate limited: no network. Re-read the cache before rejecting —
+            // a refresh that completed between our first lookup and the slot
+            // check may have just populated it with our `kid`.
+            return self.lookup_fresh(server, key_id);
+        };
         fetch.await;
 
         // Each caller looks up its own `kid` against the refreshed cache.

--- a/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
+++ b/crates/apollo-mcp-server/src/auth/networked_key_resolver.rs
@@ -1111,7 +1111,10 @@ mod tests {
 
         // A known kid still resolves from the warm cache.
         let third = resolver.resolve_key(&issuer_url, "known-key").await;
-        assert!(third.is_some(), "warm hits are unaffected by the rate limit");
+        assert!(
+            third.is_some(),
+            "warm hits are unaffected by the rate limit"
+        );
 
         discovery_mock.assert();
         jwks_mock.assert();
@@ -1217,9 +1220,10 @@ mod tests {
         // Simulate a refresh that happened 120s ago with a 60s window.
         {
             let mut guard = inflight.lock().expect("inflight not poisoned");
-            guard
-                .last_attempt
-                .insert(issuer_url.clone(), Instant::now() - Duration::from_secs(120));
+            guard.last_attempt.insert(
+                issuer_url.clone(),
+                Instant::now() - Duration::from_secs(120),
+            );
         }
 
         let client = reqwest::Client::new();
@@ -1343,7 +1347,10 @@ mod tests {
         );
 
         let first = resolver.resolve_key(&issuer_url, "any-kid").await;
-        assert!(first.is_none(), "fetch against a failing issuer returns None");
+        assert!(
+            first.is_none(),
+            "fetch against a failing issuer returns None"
+        );
 
         let second = resolver.resolve_key(&issuer_url, "any-kid").await;
         assert!(

--- a/docs/source/auth.mdx
+++ b/docs/source/auth.mdx
@@ -242,13 +242,37 @@ transport:
 **Behavior:**
 
 - On a fresh hit where the requested `kid` is present, the cached JWKS is used and no network calls are made.
-- When there is no cached entry, the cached entry is stale, or the requested `kid` is not present in the cached entry, the next request may trigger a discovery + JWKS fetch and repopulate the cache. Newly rotated keys are picked up the next time a refresh fires for that issuer.
+- When there is no cached entry, the cached entry is stale, or the requested `kid` is not present in the cached entry, the next request may trigger a discovery + JWKS fetch and repopulate the cache — subject to the per-issuer refresh rate limit below. Newly rotated keys are picked up the next time a refresh fires for that issuer.
 - The cache is process-local. Each replica warms its own cache independently after startup.
 
 **Considerations:**
 
 - Increase the TTL for stable identity providers to further reduce auth latency and load on the authorization server's discovery and JWKS endpoints.
 - Decrease the TTL if your identity provider rotates signing keys frequently and you cannot tolerate keys that were rotated mid-TTL still being accepted until the next miss. Note that revocation of a still-cached `kid` is not picked up until the entry expires.
+
+### JWKS refresh rate limit
+
+A token whose `kid` is not in the cached JWKS cannot be validated without refreshing the key set — but refreshing on _every_ miss would let a client presenting tokens with fabricated `kid` values drive one upstream discovery + JWKS round trip per request. Apollo MCP Server therefore allows at most one JWKS refresh per issuer per `jwks_min_refresh_interval` (default: 60 seconds). Concurrent requests during an allowed refresh share that single fetch.
+
+When a request misses the cache and the issuer's refresh window is exhausted, the request is rejected with `401 Unauthorized` immediately — no outbound request is made. The standard `WWW-Authenticate` challenge tells the client to retry.
+
+```yaml title="mcp.yaml"
+transport:
+  type: streamable_http
+  auth:
+    servers:
+      - https://auth.example.com
+    jwks_min_refresh_interval: 60s # At most one JWKS refresh per issuer per interval (default: 60s)
+```
+
+**Behavior:**
+
+- The limit is per-issuer and global across all clients. It applies only to starting a new upstream refresh; cached-key lookups are never limited, and requests arriving while a refresh is already in flight simply wait for it.
+- A refresh consumes the window when it starts, whether or not it succeeds, so an unreachable authorization server is retried at most once per interval instead of once per request.
+
+**Considerations:**
+
+- **Rotation latency tradeoff.** If your identity provider rotates in a new signing key immediately after a refresh consumed the window, tokens signed with the new key are rejected with 401 until the window elapses (at most `jwks_min_refresh_interval`). Lower the interval if your provider rotates keys frequently and your clients cannot tolerate that retry delay; raise it to further cap upstream load. This knob is independent of `jwks_cache_ttl`: the TTL bounds how long _known_ keys are trusted without re-checking (higher TTL = less upstream load, slower revocation pickup), while the refresh interval bounds how fast _unknown_ keys can be discovered (lower interval = faster rotation pickup, higher upstream load ceiling).
 
 ### OIDC Discovery compatibility
 

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -318,6 +318,7 @@ These fields are under the top-level `transport` key, nested under the `auth` ke
 | `discovery_timeout`               | `Duration`            | `5s`          | Timeout for authorization server metadata discovery requests. Supports human-readable durations (e.g., "5s", "10s", "30s").                                                                                      |
 | `discovery_headers`               | `Map<string, string>` | `{}`          | Custom headers to include in OIDC discovery and JWKS requests. Useful when upstream OAuth servers or WAFs require headers like `User-Agent`. See [discovery headers](/apollo-mcp-server/auth#discovery-headers). |
 | `jwks_cache_ttl`                  | `Duration`            | `10m`         | How long a cached JWKS entry stays fresh before the next request forces a re-fetch. See [JWKS cache](/apollo-mcp-server/auth#jwks-cache).                                                                        |
+| `jwks_min_refresh_interval`       | `Duration`            | `60s`         | Minimum time between JWKS refreshes per issuer. Cache misses inside the window are rejected with 401 without an upstream request. See [JWKS refresh rate limit](/apollo-mcp-server/auth#jwks-refresh-rate-limit). |
 | `tls.ca_cert`                     | `string`              |               | Path to a CA certificate to trust (PEM format).                                                                                                                                                                  |
 | `tls.danger_accept_invalid_certs` | `bool`                | `false`       | Accepts invalid TLS certificates. Set this to `true` for development or testing purposes only.                                                                                                                   |
 
@@ -372,6 +373,9 @@ transport:
 
     # How long a cached JWKS entry stays fresh before a re-fetch (default: 10m).
     jwks_cache_ttl: 10m
+
+    # At most one JWKS refresh per issuer per interval (default: 60s).
+    jwks_min_refresh_interval: 60s
 
     # Allow unauthenticated clients to call MCP discovery methods
     # (initialize, tools/list, resources/list). All other methods still require auth.


### PR DESCRIPTION
## Summary

Before this change, the server fetched the issuer's JWKS from the network on every token validation. That adds latency to every authenticated request and puts unnecessary load on the identity provider. This PR fixes that, in three layers:

- **Per-issuer JWKS cache.** Keys are cached with a TTL (`jwks_cache_ttl`, default 10m), so validating a token with a known `kid` costs zero network calls while the cache is fresh.
- **Cold-miss coalescing.** If many requests hit an empty cache at once, they share a single in-flight fetch instead of each starting their own.
- **Refresh rate limit.** A token with an unknown `kid` can still trigger a refresh (that's how key rotation gets picked up), but at most once per issuer per `jwks_min_refresh_interval` (default 60s). Within the window, unknown kids just fail auth with no network call.

### Tradeoff worth knowing

`jwks_min_refresh_interval` bounds how quickly a newly rotated signing key is picked up. The docs cover how to tune it if an IdP rotates aggressively.

## Testing

All assertions are hard counts against a mock server (e.g. 1000 unique bogus kids → exactly one upstream fetch; warm path --> zero requests). No sleeps — expiry tests back-date timestamps.

## Note: Stacked on #783

This base branch is `gocamille/add-jwks-cache`, not `main`. When #783 merges, this will be retargeted to `main`.