### PR TITLE
fix: stop writing release container build cache to avoid reserve-cache failures

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -5,6 +5,12 @@ on:
     types: [closed]
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Full version tag to publish, including the leading v (e.g. v1.16.0)
+        required: true
+        type: string
   workflow_call:
     inputs:
       version:
@@ -18,7 +24,7 @@ env:
 
 jobs:
   get-version:
-    # Run on PR merge from release branch or workflow_call
+    # Run on PR merge from release branch, workflow_dispatch, or workflow_call
     if: (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')) || inputs.version
     runs-on: ubuntu-latest
     outputs:
@@ -94,8 +100,6 @@ jobs:
           labels: |
             org.opencontainers.image.created=${{ steps.timestamp.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           build-args: |
             SOURCE_DATE_EPOCH=${{ steps.timestamp.outputs.epoch }}
 


### PR DESCRIPTION
<img width="3330" height="2172" alt="2026-07-09 at 10 15 26" src="https://github.com/user-attachments/assets/31148be0-cf4a-4c9e-857b-513ea49bbd36" />

https://github.com/apollographql/apollo-mcp-server/actions/runs/28965513008

The Release Container workflow was failing on every attempt with `error writing layer blob: failed to reserve cache` during the GitHub Actions cache export. The amd64 and arm64 matrix legs build concurrently and both wrote to the same unscoped gha cache scope, so they raced to reserve the same arch-independent layer blob and one leg always lost, which failed the whole build before the multiarch bundle and registry publish could run. This is a reservation conflict, not a capacity problem, so it kept happening even after we cleared the cache. 

This PR drops the gha build cache from the release build entirely (both `cache-to` and `cache-from`), since nothing populates that scope once the write is gone and a clean build keeps the published image reproducible. 

It also adds a `workflow_dispatch` trigger so a specific version can be rebuilt and published on demand, which is how we recover the v1.16.0 container that the broken build never produced. Pass the full version tag including the leading v, for example v1.16.0, since it flows straight into the image tags and the publish guards.