### PR TITLE
docs: fix stale graphql/ paths to examples/ in docs links

### DIFF
--- a/docs/source/debugging.mdx
+++ b/docs/source/debugging.mdx
@@ -17,10 +17,10 @@ You can inspect a local Apollo MCP Server by running it with MCP Inspector.
 operations:
   source: local
   paths:
-    - <absolute path to this git repo>/graphql/weather/operations/
+    - <absolute path to this git repo>/examples/weather/operations/
 schema:
   source: local
-  path: <absolute path to this git repo>/graphql/weather/api.graphql
+  path: <absolute path to this git repo>/examples/weather/api.graphql
 transport:
   type: stdio
 ```
@@ -58,10 +58,10 @@ You can also deploy the server as a container using the instructions in [Deployi
 operations:
   source: local
   paths:
-    - <absolute path to this git repo>/graphql/weather/operations/
+    - <absolute path to this git repo>/examples/weather/operations/
 schema:
   source: local
-  path: <absolute path to this git repo>/graphql/weather/api.graphql
+  path: <absolute path to this git repo>/examples/weather/api.graphql
 transport:
   type: streamable_http
   address: 127.0.0.1

--- a/docs/source/define-tools.mdx
+++ b/docs/source/define-tools.mdx
@@ -107,7 +107,7 @@ Apollo MCP Server supports reading GraphQL operations from Apollo-formatted [per
 
 Set the persisted query manifest file for the MCP Server with the `operations` option. The MCP Server supports hot reloading of persisted query manifests, so changes to manifests are applied without restarting.
 
-An example manifest is available in the [GitHub repo](https://github.com/apollographql/apollo-mcp-server/tree/main/graphql/weather/persisted_queries).
+An example manifest is available in the [GitHub repo](https://github.com/apollographql/apollo-mcp-server/tree/main/examples/weather/persisted_queries).
 
 ```yaml title="Example config for using persisted query manifest"
 operations:

--- a/docs/source/deploy.mdx
+++ b/docs/source/deploy.mdx
@@ -73,7 +73,7 @@ docker run \
   --name apollo-mcp-server \
   -p 8000:8000 \
   -v <path/to>/mcp_config.yaml:/config.yaml \
-  -v $PWD/graphql/TheSpaceDevs:/data \
+  -v $PWD/examples/TheSpaceDevs:/data \
   --pull always \
   ghcr.io/apollographql/apollo-mcp-server:latest /config.yaml
 ```

--- a/docs/source/guides/auth-auth0.mdx
+++ b/docs/source/guides/auth-auth0.mdx
@@ -77,10 +77,10 @@ Your Auth0 setup is now complete. You have an API with an audience and a connect
 Configure the MCP server to use the Auth0 instance for authentication.
 
 1. Open the example repo you cloned earlier.
-1. In the `graphql/TheSpaceDevs` directory, open the `config.yaml` file.
+1. In the `examples/TheSpaceDevs` directory, open the `config.yaml` file.
 1. Add the following `auth` configuration under the `transport` key:
 
-   ```yaml title="graphql/TheSpaceDevs/config.yaml"
+   ```yaml title="examples/TheSpaceDevs/config.yaml"
    transport:
      type: streamable_http
 
@@ -106,10 +106,10 @@ Configure your GraphOS Router to validate JWTs issued by Auth0. This involves se
 
 #### Define authorization and authentication rules in the router
 
-1. In the `graphql/TheSpaceDevs` directory, create a new file called `router.yaml`.
+1. In the `examples/TheSpaceDevs` directory, create a new file called `router.yaml`.
 1. Paste the following configuration, replacing `<AUTH0 DOMAIN>` with your Auth0 domain:
 
-   ```yaml title="graphql/TheSpaceDevs/router.yaml"
+   ```yaml title="examples/TheSpaceDevs/router.yaml"
    authorization:
      require_authentication: true # Enforces authentication on all requests
    authentication:
@@ -154,9 +154,9 @@ You need a graph's credentials and a valid GraphOS plan to use the router's auth
 
    ```sh
    APOLLO_GRAPH_REF=<YOUR_APOLLO_GRAPH_REF> APOLLO_KEY=<YOUR_APOLLO_KEY> \
-   rover dev --supergraph-config ./graphql/TheSpaceDevs/supergraph.yaml \
-   --router-config ./graphql/TheSpaceDevs/router.yaml \
-   --mcp ./graphql/TheSpaceDevs/config.yaml
+   rover dev --supergraph-config ./examples/TheSpaceDevs/supergraph.yaml \
+   --router-config ./examples/TheSpaceDevs/router.yaml \
+   --mcp ./examples/TheSpaceDevs/config.yaml
    ```
 
 1. Test the router by navigating to `http://localhost:4000` in your browser. You should see the Explorer, where you can run GraphQL queries against the router.


### PR DESCRIPTION

The example directories were moved from `graphql/` to `examples/` a while back, but a handful of docs still pointed at the old location.