### PR TITLE
ci: add workflow to clean up stale PRs and issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,35 @@
+name: Clean Up Stale PRs and Issues
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    name: Clean Up
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-stale: 60
+          days-before-close: 14
+          exempt-issue-labels: keep,security,pinned
+          exempt-pr-labels: keep,security,pinned
+          exempt-draft-pr: true
+          stale-issue-message: >
+            This issue has had no activity for 60 days and is now marked as stale.
+            It will be closed in 14 days if there is no further activity. Add the
+            `keep` label to keep it open.
+          close-issue-message: >
+            Closing this issue after 14 days of inactivity since it was marked stale.
+            Feel free to reopen if it is still relevant.
+          stale-pr-message: >
+            This pull request has had no activity for 60 days and is now marked as stale.
+            It will be closed in 14 days if there is no further activity. Add the
+            `keep` label to keep it open.
+          close-pr-message: >
+            Closing this pull request after 14 days of inactivity since it was marked stale.
+            Feel free to reopen if you plan to continue the work.


### PR DESCRIPTION
Adds a scheduled GitHub Actions workflow that keeps the issue and PR backlog tidy by marking inactive items stale and closing them if they stay quiet. It runs `actions/stale@v10` daily so that items with no activity for 60 days get a `Stale` label plus an explanatory comment, and are closed 14 days later if still inactive.