### PR TITLE
fix: reject auth under stdio transport

### DIFF
--- a/.changeset/reject_auth_under_stdio_transport.md
+++ b/.changeset/reject_auth_under_stdio_transport.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Reject auth configuration under the stdio transport
+
+An `auth` block nested under a `stdio` transport was parsed successfully and then silently dropped, so an operator could believe authentication was configured while the server ran with none of it applied. Apollo MCP Server now rejects misplaced keys such as `auth` under `stdio` at config parse time, matching how top-level `auth` and the `streamable_http` transport already reject unknown fields. Configurations that place `auth` under `streamable_http` (the normal case) are unaffected.

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -51,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
     // For stdio transport, spawn a background config watcher that exits the process
     // when the config file changes, since the stdio event loop blocks and never
     // polls the config watch stream in the state machine.
-    if matches!(config.transport, Transport::Stdio) {
+    if matches!(config.transport, Transport::Stdio {}) {
         if let Some(ref path) = config_path {
             spawn_stdio_config_watcher(path.clone());
         }

--- a/crates/apollo-mcp-server/src/runtime/config.rs
+++ b/crates/apollo-mcp-server/src/runtime/config.rs
@@ -180,6 +180,30 @@ mod test {
     }
 
     #[test]
+    fn it_rejects_auth_under_stdio_transport() {
+        let yaml = r#"
+            transport:
+              type: stdio
+              auth:
+                servers:
+                  - https://auth-server.com
+        "#;
+        let result = serde_yaml::from_str::<Config>(yaml);
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("unknown field"), "unexpected error: {err}");
+        assert!(err.contains("auth"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn it_accepts_stdio_transport_without_extra_fields() {
+        let yaml = r#"
+            transport:
+              type: stdio
+        "#;
+        serde_yaml::from_str::<Config>(yaml).unwrap();
+    }
+
+    #[test]
     fn it_rejects_auth_at_top_level() {
         // This is the exact scenario from the issue: auth placed at top level
         // instead of nested under transport

--- a/crates/apollo-mcp-server/src/server.rs
+++ b/crates/apollo-mcp-server/src/server.rs
@@ -78,12 +78,13 @@ pub struct Server {
     instructions: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, Default, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum Transport {
     /// Use standard IO for server <> client communication
-    #[default]
-    Stdio,
+    // Struct variant, not unit: `deny_unknown_fields` only rejects misplaced keys
+    // (e.g. a stdio `auth` block) on struct variants, not unit ones.
+    Stdio {},
 
     /// Host the MCP server on the configuration, using streamable HTTP messages.
     StreamableHttp {
@@ -108,6 +109,12 @@ pub enum Transport {
         #[serde(default)]
         host_validation: HostValidationConfig,
     },
+}
+
+impl Default for Transport {
+    fn default() -> Self {
+        Transport::Stdio {}
+    }
 }
 
 impl Transport {

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -253,7 +253,7 @@ impl Starting {
                     }
                 });
             }
-            Transport::Stdio => {
+            Transport::Stdio {} => {
                 info!("Starting MCP server in stdio mode");
                 let service = running
                     .clone()


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-558 -->

An `auth` block nested under a `stdio` transport was parsed successfully and then silently dropped, so an operator could believe authentication was configured while the server ran with none of it applied. The root cause is that `Transport` is an internally tagged enum, and serde only enforces `deny_unknown_fields` on struct variants, not on the `Stdio` unit variant, so extra keys under `stdio` were ignored instead of rejected. This changes `Stdio` into an empty struct variant so misplaced keys now fail to parse, matching how top-level `auth` and the `streamable_http` transport already reject unknown fields.