### PR TITLE
fix: retry transient platform api errors

### DIFF
--- a/.changeset/retry_transient_platform_api_errors.md
+++ b/.changeset/retry_transient_platform_api_errors.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Retry transient Platform API errors instead of failing startup
+
+HTTP error responses from the GraphOS Platform API were parsed as JSON before their status was checked, so a 5xx or 429 surfaced as a body decode error that the retry policy classified as permanent. A transient GraphOS failure during the initial operation collection fetch therefore stopped the server at startup instead of retrying. The server now checks the response status first, so 5xx and 429 responses are correctly treated as transient and retried.

--- a/crates/apollo-mcp-registry/src/platform_api/operation_collections/collection_poller.rs
+++ b/crates/apollo-mcp-registry/src/platform_api/operation_collections/collection_poller.rs
@@ -625,6 +625,7 @@ where
         .json(request_body)
         .send()
         .await
+        .and_then(reqwest::Response::error_for_status)
         .map_err(CollectionError::Request)?;
 
     let response_body: graphql_client::Response<Query::ResponseData> =
@@ -899,6 +900,55 @@ mod tests {
         assert_update_body(
             next_event(&mut stream, &mock_server).await,
             "query GetUser { user { id name } }",
+        );
+    }
+
+    #[tokio::test]
+    async fn collection_id_initial_load_retries_after_server_error() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(
+                r#""operationName":"OperationCollectionQuery""#,
+            ))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(
+                r#""operationName":"OperationCollectionPollingQuery""#,
+            ))
+            .respond_with(json_response(collection_poll_response(
+                "2024-01-01T00:00:00Z",
+            )))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(
+                r#""operationName":"OperationCollectionEntriesQuery""#,
+            ))
+            .respond_with(json_response(entries_response(
+                "2024-01-01T00:00:00Z",
+                "query GetUser { user { name } }",
+            )))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut stream = CollectionSource::Id(
+            "collection-id".to_string(),
+            platform_api_config(&mock_server),
+        )
+        .into_stream();
+
+        // A 500 on the initial fetch is transient: the stream must recover via
+        // polling instead of emitting a permanent CollectionError.
+        assert_update_body(
+            next_event(&mut stream, &mock_server).await,
+            "query GetUser { user { name } }",
         );
     }
 


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-564 -->

HTTP error responses from the GraphOS Platform API were parsed as JSON before their status was checked, so a 5xx or 429 surfaced as a body decode error carrying no status code. `CollectionError::is_transient` classifies transience by status, so these responses were treated as permanent, and a transient GraphOS blip during the initial operation collection fetch stopped the server at startup instead of retrying (the status-code branch of the retry policy was unreachable in practice). This change checks the response status with `error_for_status()` before parsing, so 5xx and 429 are classified as transient and retried, while 4xx responses remain permanent with a clearer error than the previous decode failure.