### PR TITLE
feat: add graphos schema source for non-federated graphs

### DIFF
--- a/.changeset/graphos_schema_source_for_non_federated_graphs.md
+++ b/.changeset/graphos_schema_source_for_non_federated_graphs.md
@@ -4,4 +4,4 @@ default: minor
 
 # Add a GraphOS schema source for non-federated graphs
 
-Uplink only distributes composed supergraphs, so non-federated (monograph) graphs had no live schema source and required a manually maintained local file. The new `schema.source: graphos` option fetches the latest published schema for the configured graph variant from the GraphOS Platform API, reusing the existing `graphos` credentials. The server polls the schema hash periodically and re-fetches the document only when it changes, so a republish is picked up without a restart.
+Uplink only distributes composed supergraphs, so non-federated (monograph) graphs had no live schema source and required a manually maintained local file. The new `schema.source: graphos` option fetches the latest published schema for the configured graph variant from the GraphOS Platform API, reusing the existing `graphos` credentials. The server polls the schema hash periodically, re-fetches the document only when it changes, and applies a republish without a restart.

--- a/.changeset/graphos_schema_source_for_non_federated_graphs.md
+++ b/.changeset/graphos_schema_source_for_non_federated_graphs.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Add a GraphOS schema source for non-federated graphs
+
+Uplink only distributes composed supergraphs, so non-federated (monograph) graphs had no live schema source and required a manually maintained local file. The new `schema.source: graphos` option fetches the latest published schema for the configured graph variant from the GraphOS Platform API, reusing the existing `graphos` credentials. The server polls the schema hash periodically and re-fetches the document only when it changes, so a republish is picked up without a restart.

--- a/crates/apollo-mcp-registry/src/platform_api.rs
+++ b/crates/apollo-mcp-registry/src/platform_api.rs
@@ -78,7 +78,16 @@ where
     let response_body: graphql_client::Response<Query::ResponseData> =
         res.json().await.map_err(RequestError::Request)?;
     match response_body.data {
-        Some(data) => Ok(data),
+        Some(data) => {
+            // A GraphQL response can carry errors alongside partial data: a field
+            // error nulls its field and reports the reason in `errors` while data
+            // is still present. Log them so the cause isn't lost when a caller
+            // later trips over the nulled field.
+            if let Some(errors) = response_body.errors.filter(|errors| !errors.is_empty()) {
+                tracing::warn!("GraphQL response returned errors: {}", join_errors(errors));
+            }
+            Ok(data)
+        }
         None => Err(RequestError::Response(graphql_errors_message(
             response_body.errors,
         ))),
@@ -89,16 +98,19 @@ where
 /// failures such as invalid keys as HTTP 200 with only `errors`, so these
 /// messages are often the only diagnostic available.
 fn graphql_errors_message(errors: Option<Vec<graphql_client::Error>>) -> String {
-    let messages = errors
-        .unwrap_or_default()
+    match errors.filter(|errors| !errors.is_empty()) {
+        Some(errors) => join_errors(errors),
+        None => "missing data".to_string(),
+    }
+}
+
+/// Join GraphQL error messages into a single comma-separated string.
+fn join_errors(errors: Vec<graphql_client::Error>) -> String {
+    errors
         .into_iter()
         .map(|error| error.message)
-        .collect::<Vec<_>>();
-    if messages.is_empty() {
-        "missing data".to_string()
-    } else {
-        messages.join(", ")
-    }
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Configuration for polling Apollo Uplink.

--- a/crates/apollo-mcp-registry/src/platform_api.rs
+++ b/crates/apollo-mcp-registry/src/platform_api.rs
@@ -77,9 +77,28 @@ where
 
     let response_body: graphql_client::Response<Query::ResponseData> =
         res.json().await.map_err(RequestError::Request)?;
-    response_body
-        .data
-        .ok_or(RequestError::Response("missing data".to_string()))
+    match response_body.data {
+        Some(data) => Ok(data),
+        None => Err(RequestError::Response(graphql_errors_message(
+            response_body.errors,
+        ))),
+    }
+}
+
+/// Summarize the `errors` of a GraphQL response with no `data`. GraphOS reports
+/// failures such as invalid keys as HTTP 200 with only `errors`, so these
+/// messages are often the only diagnostic available.
+fn graphql_errors_message(errors: Option<Vec<graphql_client::Error>>) -> String {
+    let messages = errors
+        .unwrap_or_default()
+        .into_iter()
+        .map(|error| error.message)
+        .collect::<Vec<_>>();
+    if messages.is_empty() {
+        "missing data".to_string()
+    } else {
+        messages.join(", ")
+    }
 }
 
 /// Configuration for polling Apollo Uplink.
@@ -216,6 +235,33 @@ mod test {
 
         let error = RequestError::Request(reqwest_error);
         assert!(error.is_transient());
+    }
+
+    #[test]
+    fn graphql_errors_message_joins_error_messages() {
+        let errors = vec![
+            graphql_client::Error {
+                message: "Unauthorized".to_string(),
+                locations: None,
+                path: None,
+                extensions: None,
+            },
+            graphql_client::Error {
+                message: "Invalid key".to_string(),
+                locations: None,
+                path: None,
+                extensions: None,
+            },
+        ];
+        assert_eq!(
+            graphql_errors_message(Some(errors)),
+            "Unauthorized, Invalid key"
+        );
+    }
+
+    #[test]
+    fn graphql_errors_message_falls_back_when_no_errors() {
+        assert_eq!(graphql_errors_message(None), "missing data");
     }
 
     #[test]

--- a/crates/apollo-mcp-registry/src/platform_api.rs
+++ b/crates/apollo-mcp-registry/src/platform_api.rs
@@ -1,11 +1,86 @@
-use secrecy::SecretString;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, InvalidHeaderValue};
+use secrecy::{ExposeSecret, SecretString};
 use std::fmt::Debug;
+use std::sync::OnceLock;
 use std::time::Duration;
 use url::Url;
 
 pub mod operation_collections;
+pub mod schema;
 
 const DEFAULT_PLATFORM_API: &str = "https://graphql.api.apollographql.com/api/graphql";
+
+/// Errors returned by Platform API requests
+#[derive(Debug, thiserror::Error)]
+pub enum RequestError {
+    #[error(transparent)]
+    HeaderValue(InvalidHeaderValue),
+
+    #[error(transparent)]
+    Request(reqwest::Error),
+
+    #[error("Error in response: {0}")]
+    Response(String),
+}
+
+impl RequestError {
+    /// Returns `true` if the error is transient according to the Platform API fetch policy.
+    pub fn is_transient(&self) -> bool {
+        matches!(self, RequestError::Request(req_err) if
+            req_err.is_connect()
+            || req_err.is_timeout()
+            || req_err.is_request()
+            || req_err.status().is_some_and(|status| {
+                status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+            })
+        )
+    }
+}
+
+/// Shared HTTP client so polling requests reuse connections.
+fn http_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
+
+/// Send a GraphQL request to the Platform API and deserialize the response data.
+pub(crate) async fn graphql_request<Query>(
+    request_body: &graphql_client::QueryBody<Query::Variables>,
+    platform_api_config: &PlatformApiConfig,
+) -> Result<Query::ResponseData, RequestError>
+where
+    Query: graphql_client::GraphQLQuery,
+{
+    let res = http_client()
+        .post(platform_api_config.registry_url.clone())
+        .headers(HeaderMap::from_iter([
+            (
+                HeaderName::from_static("apollographql-client-name"),
+                HeaderValue::from_static("apollo-mcp-server"),
+            ),
+            (
+                HeaderName::from_static("apollographql-client-version"),
+                HeaderValue::from_static(env!("CARGO_PKG_VERSION")),
+            ),
+            (
+                HeaderName::from_static("x-api-key"),
+                HeaderValue::from_str(platform_api_config.apollo_key.expose_secret())
+                    .map_err(RequestError::HeaderValue)?,
+            ),
+        ]))
+        .timeout(platform_api_config.timeout)
+        .json(request_body)
+        .send()
+        .await
+        .and_then(reqwest::Response::error_for_status)
+        .map_err(RequestError::Request)?;
+
+    let response_body: graphql_client::Response<Query::ResponseData> =
+        res.json().await.map_err(RequestError::Request)?;
+    response_body
+        .data
+        .ok_or(RequestError::Response("missing data".to_string()))
+}
 
 /// Configuration for polling Apollo Uplink.
 #[derive(Clone, Debug)]
@@ -47,6 +122,101 @@ mod test {
     use super::*;
     use secrecy::{ExposeSecret, SecretString};
     use std::time::Duration;
+    use wiremock::matchers::any;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn response_error_is_not_transient() {
+        let error = RequestError::Response("permission denied".to_string());
+        assert!(!error.is_transient());
+    }
+
+    #[test]
+    fn header_value_error_is_not_transient() {
+        let invalid_value = reqwest::header::HeaderValue::from_bytes(b"\0invalid").unwrap_err();
+        let error = RequestError::HeaderValue(invalid_value);
+        assert!(!error.is_transient());
+    }
+
+    #[tokio::test]
+    async fn client_error_404_is_not_transient() {
+        let mock_server = MockServer::start().await;
+        Mock::given(any())
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&mock_server)
+            .await;
+
+        let result = reqwest::get(mock_server.uri()).await.unwrap();
+        let reqwest_error = result.error_for_status().unwrap_err();
+
+        let error = RequestError::Request(reqwest_error);
+        assert!(!error.is_transient());
+    }
+
+    #[tokio::test]
+    async fn connection_error_is_transient() {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_millis(1))
+            .build()
+            .unwrap();
+
+        let result = client.get("http://192.0.2.1:1").send().await;
+        let reqwest_error = result.unwrap_err();
+
+        let error = RequestError::Request(reqwest_error);
+        assert!(error.is_transient());
+    }
+
+    #[tokio::test]
+    async fn timeout_error_is_transient() {
+        let mock_server = MockServer::start().await;
+        Mock::given(any())
+            .respond_with(ResponseTemplate::new(200).set_delay(std::time::Duration::from_secs(10)))
+            .mount(&mock_server)
+            .await;
+
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_millis(1))
+            .build()
+            .unwrap();
+
+        let result = client.get(mock_server.uri()).send().await;
+        let reqwest_error = result.unwrap_err();
+        assert!(reqwest_error.is_timeout());
+
+        let error = RequestError::Request(reqwest_error);
+        assert!(error.is_transient());
+    }
+
+    #[tokio::test]
+    async fn server_error_is_transient() {
+        let mock_server = MockServer::start().await;
+        Mock::given(any())
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&mock_server)
+            .await;
+
+        let result = reqwest::get(mock_server.uri()).await.unwrap();
+        let reqwest_error = result.error_for_status().unwrap_err();
+
+        let error = RequestError::Request(reqwest_error);
+        assert!(error.is_transient());
+    }
+
+    #[tokio::test]
+    async fn rate_limit_429_is_transient() {
+        let mock_server = MockServer::start().await;
+        Mock::given(any())
+            .respond_with(ResponseTemplate::new(429))
+            .mount(&mock_server)
+            .await;
+
+        let result = reqwest::get(mock_server.uri()).await.unwrap();
+        let reqwest_error = result.error_for_status().unwrap_err();
+
+        let error = RequestError::Request(reqwest_error);
+        assert!(error.is_transient());
+    }
 
     #[test]
     fn platform_api_config_with_none_endpoints() {

--- a/crates/apollo-mcp-registry/src/platform_api/operation_collections/collection_poller.rs
+++ b/crates/apollo-mcp-registry/src/platform_api/operation_collections/collection_poller.rs
@@ -1,7 +1,5 @@
 use futures::Stream;
 use graphql_client::GraphQLQuery;
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
-use secrecy::ExposeSecret;
 use std::collections::HashMap;
 use std::pin::Pin;
 use tokio::sync::mpsc::channel;
@@ -9,7 +7,7 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use super::error::CollectionError;
 use super::event::CollectionEvent;
-use crate::platform_api::PlatformApiConfig;
+use crate::platform_api::{PlatformApiConfig, graphql_request};
 use operation_collection_default_polling_query::{
     OperationCollectionDefaultPollingQueryVariant as PollingDefaultGraphVariant,
     OperationCollectionDefaultPollingQueryVariantOnGraphVariantMcpDefaultCollection as PollingDefaultCollection,
@@ -336,7 +334,10 @@ impl CollectionSource {
                         tracing::error!(
                             "Failed to fetch operation collection with permanent error: {err}"
                         );
-                        if let Err(e) = sender.send(CollectionEvent::CollectionError(err)).await {
+                        if let Err(e) = sender
+                            .send(CollectionEvent::CollectionError(err.into()))
+                            .await
+                        {
                             tracing::debug!(
                                 "failed to send error to collection stream. This is likely to be because the server is shutting down: {e}"
                             );
@@ -467,7 +468,10 @@ impl CollectionSource {
                         tracing::error!(
                             "Failed to fetch operation collection with permanent error: {err}"
                         );
-                        if let Err(e) = sender.send(CollectionEvent::CollectionError(err)).await {
+                        if let Err(e) = sender
+                            .send(CollectionEvent::CollectionError(err.into()))
+                            .await
+                        {
                             tracing::debug!(
                                 "failed to send error to collection stream. This is likely to be because the server is shutting down: {e}"
                             );
@@ -594,45 +598,6 @@ async fn poll_operation_collection_default(
             "Default collection not found".to_string(),
         )),
     }
-}
-
-async fn graphql_request<Query>(
-    request_body: &graphql_client::QueryBody<Query::Variables>,
-    platform_api_config: &PlatformApiConfig,
-) -> Result<Query::ResponseData, CollectionError>
-where
-    Query: graphql_client::GraphQLQuery,
-    <Query as graphql_client::GraphQLQuery>::ResponseData: std::fmt::Debug,
-{
-    let res = reqwest::Client::new()
-        .post(platform_api_config.registry_url.clone())
-        .headers(HeaderMap::from_iter(vec![
-            (
-                HeaderName::from_static("apollographql-client-name"),
-                HeaderValue::from_static("apollo-mcp-server"),
-            ),
-            (
-                HeaderName::from_static("apollographql-client-version"),
-                HeaderValue::from_static(env!("CARGO_PKG_VERSION")),
-            ),
-            (
-                HeaderName::from_static("x-api-key"),
-                HeaderValue::from_str(platform_api_config.apollo_key.expose_secret())
-                    .map_err(CollectionError::HeaderValue)?,
-            ),
-        ]))
-        .timeout(platform_api_config.timeout)
-        .json(request_body)
-        .send()
-        .await
-        .and_then(reqwest::Response::error_for_status)
-        .map_err(CollectionError::Request)?;
-
-    let response_body: graphql_client::Response<Query::ResponseData> =
-        res.json().await.map_err(CollectionError::Request)?;
-    response_body
-        .data
-        .ok_or(CollectionError::Response("missing data".to_string()))
 }
 
 #[cfg(test)]

--- a/crates/apollo-mcp-registry/src/platform_api/operation_collections/error.rs
+++ b/crates/apollo-mcp-registry/src/platform_api/operation_collections/error.rs
@@ -46,4 +46,24 @@ mod tests {
         let error = CollectionError::from(RequestError::HeaderValue(invalid_value));
         assert!(matches!(error, CollectionError::HeaderValue(_)));
     }
+
+    #[tokio::test]
+    async fn from_request_error_maps_request() {
+        use wiremock::matchers::any;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        Mock::given(any())
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&mock_server)
+            .await;
+        let reqwest_error = reqwest::get(mock_server.uri())
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap_err();
+
+        let error = CollectionError::from(RequestError::Request(reqwest_error));
+        assert!(matches!(error, CollectionError::Request(_)));
+    }
 }

--- a/crates/apollo-mcp-registry/src/platform_api/operation_collections/error.rs
+++ b/crates/apollo-mcp-registry/src/platform_api/operation_collections/error.rs
@@ -1,5 +1,7 @@
 use reqwest::header::{InvalidHeaderName, InvalidHeaderValue};
 
+use crate::platform_api::RequestError;
+
 #[derive(Debug, thiserror::Error)]
 pub enum CollectionError {
     #[error(transparent)]
@@ -18,129 +20,30 @@ pub enum CollectionError {
     InvalidVariables(String),
 }
 
-impl CollectionError {
-    /// Returns `true` if the error is transient according to the Platform API fetch policy.
-    pub(super) fn is_transient(&self) -> bool {
-        matches!(self, CollectionError::Request(req_err) if
-            req_err.is_connect()
-            || req_err.is_timeout()
-            || req_err.is_request()
-            || req_err.status().is_some_and(|status| {
-                status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS
-            })
-        )
+impl From<RequestError> for CollectionError {
+    fn from(error: RequestError) -> Self {
+        match error {
+            RequestError::HeaderValue(e) => CollectionError::HeaderValue(e),
+            RequestError::Request(e) => CollectionError::Request(e),
+            RequestError::Response(message) => CollectionError::Response(message),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wiremock::matchers::any;
-    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
-    fn response_error_is_not_transient() {
-        let error = CollectionError::Response("permission denied".to_string());
-        assert!(!error.is_transient());
+    fn from_request_error_maps_response_message() {
+        let error = CollectionError::from(RequestError::Response("missing data".to_string()));
+        assert!(matches!(error, CollectionError::Response(message) if message == "missing data"));
     }
 
     #[test]
-    fn header_name_error_is_not_transient() {
-        let invalid_name = reqwest::header::HeaderName::from_bytes(b"\0invalid").unwrap_err();
-        let error = CollectionError::HeaderName(invalid_name);
-        assert!(!error.is_transient());
-    }
-
-    #[test]
-    fn header_value_error_is_not_transient() {
+    fn from_request_error_maps_header_value() {
         let invalid_value = reqwest::header::HeaderValue::from_bytes(b"\0invalid").unwrap_err();
-        let error = CollectionError::HeaderValue(invalid_value);
-        assert!(!error.is_transient());
-    }
-
-    #[test]
-    fn invalid_variables_error_is_not_transient() {
-        let error = CollectionError::InvalidVariables("bad json".to_string());
-        assert!(!error.is_transient());
-    }
-
-    #[tokio::test]
-    async fn client_error_404_is_not_transient() {
-        let mock_server = MockServer::start().await;
-        Mock::given(any())
-            .respond_with(ResponseTemplate::new(404))
-            .mount(&mock_server)
-            .await;
-
-        let result = reqwest::get(mock_server.uri()).await.unwrap();
-        let reqwest_error = result.error_for_status().unwrap_err();
-
-        let error = CollectionError::Request(reqwest_error);
-        assert!(!error.is_transient());
-    }
-
-    #[tokio::test]
-    async fn connection_error_is_transient() {
-        let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_millis(1))
-            .build()
-            .unwrap();
-
-        let result = client.get("http://192.0.2.1:1").send().await;
-        let reqwest_error = result.unwrap_err();
-
-        let error = CollectionError::Request(reqwest_error);
-        assert!(error.is_transient());
-    }
-
-    #[tokio::test]
-    async fn timeout_error_is_transient() {
-        let mock_server = MockServer::start().await;
-        Mock::given(any())
-            .respond_with(ResponseTemplate::new(200).set_delay(std::time::Duration::from_secs(10)))
-            .mount(&mock_server)
-            .await;
-
-        let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_millis(1))
-            .build()
-            .unwrap();
-
-        let result = client.get(mock_server.uri()).send().await;
-        let reqwest_error = result.unwrap_err();
-        assert!(reqwest_error.is_timeout());
-
-        let error = CollectionError::Request(reqwest_error);
-        assert!(error.is_transient());
-    }
-
-    #[tokio::test]
-    async fn server_error_is_transient() {
-        let mock_server = MockServer::start().await;
-        Mock::given(any())
-            .respond_with(ResponseTemplate::new(500))
-            .mount(&mock_server)
-            .await;
-
-        let result = reqwest::get(mock_server.uri()).await.unwrap();
-        let reqwest_error = result.error_for_status().unwrap_err();
-
-        let error = CollectionError::Request(reqwest_error);
-        assert!(error.is_transient());
-    }
-
-    #[tokio::test]
-    async fn rate_limit_429_is_transient() {
-        let mock_server = MockServer::start().await;
-        Mock::given(any())
-            .respond_with(ResponseTemplate::new(429))
-            .mount(&mock_server)
-            .await;
-
-        let result = reqwest::get(mock_server.uri()).await.unwrap();
-        let reqwest_error = result.error_for_status().unwrap_err();
-
-        let error = CollectionError::Request(reqwest_error);
-        assert!(error.is_transient());
+        let error = CollectionError::from(RequestError::HeaderValue(invalid_value));
+        assert!(matches!(error, CollectionError::HeaderValue(_)));
     }
 }

--- a/crates/apollo-mcp-registry/src/platform_api/schema.rs
+++ b/crates/apollo-mcp-registry/src/platform_api/schema.rs
@@ -437,6 +437,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn polling_continues_after_permanent_error() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(FULL_QUERY))
+            .respond_with(json_response(schema_response(
+                "hash-1",
+                "type Query { hello: String }",
+            )))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+
+        // A permanent error mid-polling (here, the publication disappearing)
+        // must keep the last-known-good schema and keep polling, unlike the
+        // same error at startup which ends the stream.
+        Mock::given(method("POST"))
+            .and(body_string_contains(HASH_QUERY))
+            .respond_with(json_response(no_publication_response()))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(HASH_QUERY))
+            .respond_with(json_response(hash_response("hash-2")))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(FULL_QUERY))
+            .respond_with(json_response(schema_response(
+                "hash-2",
+                "type Query { hello: String, world: String }",
+            )))
+            .mount(&mock_server)
+            .await;
+
+        let mut stream =
+            stream_published_schema("graph@main".to_string(), platform_api_config(&mock_server));
+
+        assert_update_sdl(
+            next_event(&mut stream).await,
+            "type Query { hello: String }",
+        );
+        assert_update_sdl(
+            next_event(&mut stream).await,
+            "type Query { hello: String, world: String }",
+        );
+    }
+
+    #[tokio::test]
     async fn transient_error_at_startup_retries() {
         let mock_server = MockServer::start().await;
 

--- a/crates/apollo-mcp-registry/src/platform_api/schema.rs
+++ b/crates/apollo-mcp-registry/src/platform_api/schema.rs
@@ -1,0 +1,493 @@
+//! Schema source backed by the GraphOS Platform API.
+//!
+//! Polls the latest schema publication for a graph variant. Unlike Uplink,
+//! which only distributes composed supergraphs, this works for non-federated
+//! (monograph) graphs, whose published schema never reaches Uplink.
+
+use std::pin::Pin;
+
+use futures::Stream;
+use graphql_client::GraphQLQuery;
+use tokio::sync::mpsc::channel;
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::platform_api::{PlatformApiConfig, RequestError, graphql_request};
+use crate::uplink::schema::SchemaState;
+use crate::uplink::schema::event::Event;
+
+type GraphQLDocument = String;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "src/platform_api/schema/schema.graphql",
+    schema_path = "src/platform_api/platform-api.graphql",
+    request_derives = "Debug",
+    response_derives = "PartialEq, Debug, Deserialize"
+)]
+struct PublishedSchemaQuery;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "src/platform_api/schema/schema.graphql",
+    schema_path = "src/platform_api/platform-api.graphql",
+    request_derives = "Debug",
+    response_derives = "PartialEq, Debug, Deserialize"
+)]
+struct PublishedSchemaHashQuery;
+
+/// The latest schema publication of a graph variant
+struct PublishedSchema {
+    hash: String,
+    document: String,
+}
+
+/// Stream schema updates for a graph variant from the GraphOS Platform API.
+///
+/// The latest publication is fetched once at startup, then the schema hash is
+/// polled at the configured interval and the document is re-fetched only when
+/// the hash changes. Transient errors are retried; a permanent error before
+/// the first successful fetch ends the stream.
+pub fn stream_published_schema(
+    graph_ref: String,
+    platform_api_config: PlatformApiConfig,
+) -> Pin<Box<dyn Stream<Item = Event> + Send>> {
+    let (sender, receiver) = channel(2);
+    tokio::task::spawn(async move {
+        let mut current_hash = loop {
+            match fetch_published_schema(&graph_ref, &platform_api_config).await {
+                Ok(published) => {
+                    if !send_update(&sender, published.document).await {
+                        return;
+                    }
+                    break published.hash;
+                }
+                Err(err) if err.is_transient() => {
+                    tracing::warn!(
+                        "Failed to fetch published schema with transient error, will retry: {err}"
+                    );
+                    tokio::time::sleep(platform_api_config.poll_interval).await;
+                }
+                Err(err) => {
+                    tracing::error!("Failed to fetch published schema with permanent error: {err}");
+                    return;
+                }
+            }
+        };
+
+        loop {
+            tokio::time::sleep(platform_api_config.poll_interval).await;
+            match fetch_published_schema_hash(&graph_ref, &platform_api_config).await {
+                Ok(hash) if hash == current_hash => {
+                    tracing::debug!("published schema unchanged");
+                }
+                Ok(_) => match fetch_published_schema(&graph_ref, &platform_api_config).await {
+                    Ok(published) => {
+                        // Track the hash from the full fetch, not the poll: a
+                        // publish can land between the two requests, and the
+                        // stored hash must match the document actually emitted.
+                        current_hash = published.hash;
+                        if !send_update(&sender, published.document).await {
+                            break;
+                        }
+                    }
+                    Err(err) => {
+                        tracing::warn!("Failed to fetch published schema, will retry: {err}");
+                    }
+                },
+                Err(err) => {
+                    tracing::warn!("Failed to poll published schema, will retry: {err}");
+                }
+            }
+        }
+    });
+    Box::pin(ReceiverStream::new(receiver))
+}
+
+/// Send a schema update to the stream, returning `false` if the receiver is gone.
+async fn send_update(sender: &tokio::sync::mpsc::Sender<Event>, sdl: String) -> bool {
+    sender
+        .send(Event::UpdateSchema(SchemaState {
+            sdl,
+            launch_id: None,
+        }))
+        .await
+        .inspect_err(|e| {
+            tracing::debug!(
+                "failed to push to schema stream. This is likely to be because the server is shutting down: {e}"
+            );
+        })
+        .is_ok()
+}
+
+async fn fetch_published_schema(
+    graph_ref: &str,
+    platform_api_config: &PlatformApiConfig,
+) -> Result<PublishedSchema, RequestError> {
+    let response = graphql_request::<PublishedSchemaQuery>(
+        &PublishedSchemaQuery::build_query(published_schema_query::Variables {
+            graph_ref: graph_ref.to_string(),
+        }),
+        platform_api_config,
+    )
+    .await?;
+
+    match response.variant {
+        Some(published_schema_query::PublishedSchemaQueryVariant::GraphVariant(variant)) => variant
+            .latest_publication
+            .map(|publication| PublishedSchema {
+                hash: publication.schema.hash,
+                document: publication.schema.document,
+            })
+            .ok_or_else(|| RequestError::Response(format!("no schema published for {graph_ref}"))),
+        Some(published_schema_query::PublishedSchemaQueryVariant::InvalidRefFormat(err)) => {
+            Err(RequestError::Response(err.message))
+        }
+        None => Err(RequestError::Response(format!("{graph_ref} not found"))),
+    }
+}
+
+async fn fetch_published_schema_hash(
+    graph_ref: &str,
+    platform_api_config: &PlatformApiConfig,
+) -> Result<String, RequestError> {
+    let response = graphql_request::<PublishedSchemaHashQuery>(
+        &PublishedSchemaHashQuery::build_query(published_schema_hash_query::Variables {
+            graph_ref: graph_ref.to_string(),
+        }),
+        platform_api_config,
+    )
+    .await?;
+
+    match response.variant {
+        Some(published_schema_hash_query::PublishedSchemaHashQueryVariant::GraphVariant(
+            variant,
+        )) => variant
+            .latest_publication
+            .map(|publication| publication.schema.hash)
+            .ok_or_else(|| RequestError::Response(format!("no schema published for {graph_ref}"))),
+        Some(published_schema_hash_query::PublishedSchemaHashQueryVariant::InvalidRefFormat(
+            err,
+        )) => Err(RequestError::Response(err.message)),
+        None => Err(RequestError::Response(format!("{graph_ref} not found"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use secrecy::SecretString;
+    use std::time::Duration;
+    use tokio::time::timeout;
+    use url::Url;
+    use wiremock::matchers::{body_string_contains, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const FULL_QUERY: &str = r#""operationName":"PublishedSchemaQuery""#;
+    const HASH_QUERY: &str = r#""operationName":"PublishedSchemaHashQuery""#;
+
+    fn schema_response(hash: &str, document: &str) -> String {
+        serde_json::json!({
+            "data": {
+                "variant": {
+                    "__typename": "GraphVariant",
+                    "latestPublication": {
+                        "schema": {
+                            "hash": hash,
+                            "document": document
+                        }
+                    }
+                }
+            }
+        })
+        .to_string()
+    }
+
+    fn hash_response(hash: &str) -> String {
+        serde_json::json!({
+            "data": {
+                "variant": {
+                    "__typename": "GraphVariant",
+                    "latestPublication": {
+                        "schema": {
+                            "hash": hash
+                        }
+                    }
+                }
+            }
+        })
+        .to_string()
+    }
+
+    fn invalid_ref_response() -> String {
+        serde_json::json!({
+            "data": {
+                "variant": {
+                    "__typename": "InvalidRefFormat",
+                    "message": "invalid graph ref"
+                }
+            }
+        })
+        .to_string()
+    }
+
+    fn no_publication_response() -> String {
+        serde_json::json!({
+            "data": {
+                "variant": {
+                    "__typename": "GraphVariant",
+                    "latestPublication": null
+                }
+            }
+        })
+        .to_string()
+    }
+
+    fn platform_api_config(mock_server: &MockServer) -> PlatformApiConfig {
+        PlatformApiConfig::new(
+            SecretString::from("test-key"),
+            Duration::from_millis(10),
+            Duration::from_secs(5),
+            Some(Url::parse(&mock_server.uri()).unwrap()),
+        )
+    }
+
+    fn json_response(body: String) -> ResponseTemplate {
+        ResponseTemplate::new(200)
+            .insert_header("content-type", "application/json")
+            .set_body_string(body)
+    }
+
+    async fn next_event(stream: &mut Pin<Box<dyn Stream<Item = Event> + Send>>) -> Event {
+        timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("expected next schema event before timeout")
+            .expect("expected schema stream to remain open")
+    }
+
+    fn assert_update_sdl(event: Event, expected_sdl: &str) {
+        let Event::UpdateSchema(state) = event else {
+            panic!("expected schema update, got {event:?}");
+        };
+        assert_eq!(state.sdl, expected_sdl);
+    }
+
+    #[tokio::test]
+    async fn initial_load_succeeds() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(FULL_QUERY))
+            .respond_with(json_response(schema_response(
+                "hash-1",
+                "type Query { hello: String }",
+            )))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut stream =
+            stream_published_schema("graph@main".to_string(), platform_api_config(&mock_server));
+
+        assert_update_sdl(
+            next_event(&mut stream).await,
+            "type Query { hello: String }",
+        );
+    }
+
+    #[tokio::test]
+    async fn hash_change_triggers_reload() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(FULL_QUERY))
+            .respond_with(json_response(schema_response(
+                "hash-1",
+                "type Query { hello: String }",
+            )))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(HASH_QUERY))
+            .respond_with(json_response(hash_response("hash-2")))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(FULL_QUERY))
+            .respond_with(json_response(schema_response(
+                "hash-2",
+                "type Query { hello: String, world: String }",
+            )))
+            .mount(&mock_server)
+            .await;
+
+        let mut stream =
+            stream_published_schema("graph@main".to_string(), platform_api_config(&mock_server));
+
+        assert_update_sdl(
+            next_event(&mut stream).await,
+            "type Query { hello: String }",
+        );
+        assert_update_sdl(
+            next_event(&mut stream).await,
+            "type Query { hello: String, world: String }",
+        );
+    }
+
+    #[tokio::test]
+    async fn unchanged_hash_emits_no_update() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(FULL_QUERY))
+            .respond_with(json_response(schema_response(
+                "hash-1",
+                "type Query { hello: String }",
+            )))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(HASH_QUERY))
+            .respond_with(json_response(hash_response("hash-1")))
+            .mount(&mock_server)
+            .await;
+
+        let mut stream =
+            stream_published_schema("graph@main".to_string(), platform_api_config(&mock_server));
+
+        assert_update_sdl(
+            next_event(&mut stream).await,
+            "type Query { hello: String }",
+        );
+
+        // Several poll intervals pass with an unchanged hash; no update is emitted
+        assert!(
+            timeout(Duration::from_millis(100), stream.next())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn polling_continues_after_transient_error() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(FULL_QUERY))
+            .respond_with(json_response(schema_response(
+                "hash-1",
+                "type Query { hello: String }",
+            )))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(HASH_QUERY))
+            .respond_with(ResponseTemplate::new(500))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(HASH_QUERY))
+            .respond_with(json_response(hash_response("hash-2")))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(FULL_QUERY))
+            .respond_with(json_response(schema_response(
+                "hash-2",
+                "type Query { hello: String, world: String }",
+            )))
+            .mount(&mock_server)
+            .await;
+
+        let mut stream =
+            stream_published_schema("graph@main".to_string(), platform_api_config(&mock_server));
+
+        assert_update_sdl(
+            next_event(&mut stream).await,
+            "type Query { hello: String }",
+        );
+        assert_update_sdl(
+            next_event(&mut stream).await,
+            "type Query { hello: String, world: String }",
+        );
+    }
+
+    #[tokio::test]
+    async fn transient_error_at_startup_retries() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(FULL_QUERY))
+            .respond_with(ResponseTemplate::new(500))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(FULL_QUERY))
+            .respond_with(json_response(schema_response(
+                "hash-1",
+                "type Query { hello: String }",
+            )))
+            .mount(&mock_server)
+            .await;
+
+        let mut stream =
+            stream_published_schema("graph@main".to_string(), platform_api_config(&mock_server));
+
+        assert_update_sdl(
+            next_event(&mut stream).await,
+            "type Query { hello: String }",
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_ref_ends_stream() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(FULL_QUERY))
+            .respond_with(json_response(invalid_ref_response()))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut stream =
+            stream_published_schema("bad ref".to_string(), platform_api_config(&mock_server));
+
+        let event = timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("expected stream to end before timeout");
+        assert!(event.is_none());
+    }
+
+    #[tokio::test]
+    async fn no_publication_ends_stream() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(FULL_QUERY))
+            .respond_with(json_response(no_publication_response()))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut stream =
+            stream_published_schema("graph@main".to_string(), platform_api_config(&mock_server));
+
+        let event = timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("expected stream to end before timeout");
+        assert!(event.is_none());
+    }
+}

--- a/crates/apollo-mcp-registry/src/platform_api/schema.rs
+++ b/crates/apollo-mcp-registry/src/platform_api/schema.rs
@@ -90,12 +90,26 @@ pub fn stream_published_schema(
                             break;
                         }
                     }
+                    Err(err) if err.is_transient() => {
+                        tracing::warn!(
+                            "Failed to fetch published schema with transient error, will retry: {err}"
+                        );
+                    }
                     Err(err) => {
-                        tracing::warn!("Failed to fetch published schema, will retry: {err}");
+                        tracing::error!(
+                            "Failed to fetch published schema with permanent error, keeping current schema and retrying: {err}"
+                        );
                     }
                 },
+                Err(err) if err.is_transient() => {
+                    tracing::warn!(
+                        "Failed to poll published schema with transient error, will retry: {err}"
+                    );
+                }
                 Err(err) => {
-                    tracing::warn!("Failed to poll published schema, will retry: {err}");
+                    tracing::error!(
+                        "Failed to poll published schema with permanent error, keeping current schema and retrying: {err}"
+                    );
                 }
             }
         }
@@ -464,6 +478,32 @@ mod tests {
 
         let mut stream =
             stream_published_schema("bad ref".to_string(), platform_api_config(&mock_server));
+
+        let event = timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("expected stream to end before timeout");
+        assert!(event.is_none());
+    }
+
+    #[tokio::test]
+    async fn graphql_errors_at_startup_end_stream() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains(FULL_QUERY))
+            .respond_with(json_response(
+                serde_json::json!({
+                    "data": null,
+                    "errors": [{ "message": "Unauthorized" }]
+                })
+                .to_string(),
+            ))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut stream =
+            stream_published_schema("graph@main".to_string(), platform_api_config(&mock_server));
 
         let event = timeout(Duration::from_secs(2), stream.next())
             .await

--- a/crates/apollo-mcp-registry/src/platform_api/schema/schema.graphql
+++ b/crates/apollo-mcp-registry/src/platform_api/schema/schema.graphql
@@ -1,0 +1,32 @@
+query PublishedSchemaQuery($graphRef: ID!) {
+    variant(ref: $graphRef) {
+        __typename
+        ... on GraphVariant {
+            latestPublication {
+                schema {
+                    hash
+                    document
+                }
+            }
+        }
+        ... on InvalidRefFormat {
+            message
+        }
+    }
+}
+
+query PublishedSchemaHashQuery($graphRef: ID!) {
+    variant(ref: $graphRef) {
+        __typename
+        ... on GraphVariant {
+            latestPublication {
+                schema {
+                    hash
+                }
+            }
+        }
+        ... on InvalidRefFormat {
+            message
+        }
+    }
+}

--- a/crates/apollo-mcp-registry/src/uplink/schema.rs
+++ b/crates/apollo-mcp-registry/src/uplink/schema.rs
@@ -8,6 +8,8 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::time::Duration;
 
+use crate::platform_api::PlatformApiConfig;
+use crate::platform_api::schema::stream_published_schema;
 use crate::uplink::UplinkConfig;
 use crate::uplink::stream_from_uplink;
 use derive_more::Display;
@@ -65,6 +67,14 @@ pub enum SchemaSource {
     /// Apollo managed federation.
     #[display("Registry")]
     Registry(UplinkConfig),
+
+    /// The latest published schema of a graph variant, fetched from the GraphOS
+    /// Platform API. Unlike Uplink, this supports non-federated graphs.
+    #[display("PlatformApi")]
+    PlatformApi {
+        graph_ref: String,
+        platform_api_config: PlatformApiConfig,
+    },
 
     /// A list of URLs to fetch the schema from.
     #[display("URLs")]
@@ -168,6 +178,10 @@ impl SchemaSource {
                     })
                     .boxed()
             }
+            SchemaSource::PlatformApi {
+                graph_ref,
+                platform_api_config,
+            } => stream_published_schema(graph_ref, platform_api_config),
             SchemaSource::URLs { urls } => {
                 futures::stream::once(async move {
                     fetch_supergraph_from_first_viable_url(&urls).await
@@ -283,6 +297,49 @@ mod tests {
 
         // First update fails because the file is invalid.
         assert!(matches!(stream.next().await.unwrap(), NoMoreSchema));
+    }
+
+    #[test(tokio::test)]
+    async fn schema_by_platform_api() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/json")
+                    .set_body_string(
+                        serde_json::json!({
+                            "data": {
+                                "variant": {
+                                    "__typename": "GraphVariant",
+                                    "latestPublication": {
+                                        "schema": {
+                                            "hash": "hash-1",
+                                            "document": "type Query { hello: String }"
+                                        }
+                                    }
+                                }
+                            }
+                        })
+                        .to_string(),
+                    ),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let mut stream = SchemaSource::PlatformApi {
+            graph_ref: "graph@main".to_string(),
+            platform_api_config: PlatformApiConfig::new(
+                secrecy::SecretString::from("test-key"),
+                Duration::from_secs(10),
+                Duration::from_secs(5),
+                Some(Url::parse(&mock_server.uri()).unwrap()),
+            ),
+        }
+        .into_stream();
+
+        assert!(
+            matches!(stream.next().await.unwrap(), UpdateSchema(schema) if schema.sdl == "type Query { hello: String }")
+        );
     }
 
     const SCHEMA_1: &str = "schema1";

--- a/crates/apollo-mcp-server/src/main.rs
+++ b/crates/apollo-mcp-server/src/main.rs
@@ -100,6 +100,10 @@ fn build_server(config_path: Option<&std::path::Path>) -> anyhow::Result<Server>
     let schema_source = match config.schema {
         runtime::SchemaSource::Local { path } => SchemaSource::File { path, watch: true },
         runtime::SchemaSource::Uplink => SchemaSource::Registry(config.graphos.uplink_config()?),
+        runtime::SchemaSource::Graphos => SchemaSource::PlatformApi {
+            graph_ref: config.graphos.graph_ref()?,
+            platform_api_config: config.graphos.platform_api_config()?,
+        },
     };
 
     let operation_source = match config.operations {

--- a/crates/apollo-mcp-server/src/runtime/schema_source.rs
+++ b/crates/apollo-mcp-server/src/runtime/schema_source.rs
@@ -13,4 +13,19 @@ pub enum SchemaSource {
     /// Fetch the schema from uplink
     #[default]
     Uplink,
+
+    /// Fetch the latest published schema from the GraphOS Platform API.
+    /// Unlike uplink, this works for non-federated graphs.
+    Graphos,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_graphos_source() {
+        let source: SchemaSource = serde_yaml::from_str("source: graphos").unwrap();
+        assert!(matches!(source, SchemaSource::Graphos));
+    }
 }

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -245,11 +245,11 @@ The default value for `source` is `"uplink"`.
 | Local   | `source` | `"local"`   | Load schema from local file                                                                                                                            |
 | Local   | `path`   | `FilePath`  | Path to the GraphQL schema                                                                                                                             |
 | Uplink  | `source` | `"uplink"`  | Fetch the schema from uplink. Note: This requires an Apollo key and graph reference                                                                    |
-| GraphOS | `source` | `"graphos"` | Fetch the latest published schema from the GraphOS Platform API. Unlike `uplink`, this works for non-federated graphs. Note: This requires an Apollo key and graph reference |
+| GraphOS | `source` | `"graphos"` | Fetch the latest published schema from the GraphOS Platform API. Use this source for non-federated graphs, which uplink can't serve. Note: This requires an Apollo key and graph reference |
 
 <Note>
 
-When using `source: graphos`, MCP Server polls GraphOS for schema changes periodically, so a new schema publication is picked up without a restart.
+When you use `source: graphos`, MCP Server polls GraphOS for schema changes periodically and applies a new schema publication without a restart.
 
 </Note>
 

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -240,11 +240,18 @@ These fields are under the top-level `overrides` key.
 These fields are under the top-level `schema` key. The available fields depend on the value of the nested `source` key.
 The default value for `source` is `"uplink"`.
 
-| Source | Option   | Type       | Description                                                                         |
-| :----- | :------- | :--------- | :---------------------------------------------------------------------------------- |
-| Local  | `source` | `"local"`  | Load schema from local file                                                         |
-| Local  | `path`   | `FilePath` | Path to the GraphQL schema                                                          |
-| Uplink | `source` | `"uplink"` | Fetch the schema from uplink. Note: This requires an Apollo key and graph reference |
+| Source  | Option   | Type        | Description                                                                                                                                            |
+| :------ | :------- | :---------- | :------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Local   | `source` | `"local"`   | Load schema from local file                                                                                                                            |
+| Local   | `path`   | `FilePath`  | Path to the GraphQL schema                                                                                                                             |
+| Uplink  | `source` | `"uplink"`  | Fetch the schema from uplink. Note: This requires an Apollo key and graph reference                                                                    |
+| GraphOS | `source` | `"graphos"` | Fetch the latest published schema from the GraphOS Platform API. Unlike `uplink`, this works for non-federated graphs. Note: This requires an Apollo key and graph reference |
+
+<Note>
+
+When using `source: graphos`, MCP Server polls GraphOS for schema changes periodically, so a new schema publication is picked up without a restart.
+
+</Note>
 
 ### Transport
 


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-552 -->

Non-federated, or monograph, graphs do not have a live schema path today. Uplink only distributes composed supergraphs, and monographs never compose, so the only option has been a manually maintained local file.

This PR adds a `schema` configuration with `source` set to `graphos`. It fetches the latest publication for the configured variant from the Platform API using the existing `graphos` credentials. That gives registered monographs live schema delivery and tool generation.

## Testing

Manually testing a canary build with GraphOS MCP Server