### PR TITLE
chore: upgrade rmcp to 3

### DIFF
--- a/.changeset/cap_protocol_version_negotiation_on_stateful_transports.md
+++ b/.changeset/cap_protocol_version_negotiation_on_stateful_transports.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+# Cap protocol version negotiation on stateful transports
+
+On stateful streamable HTTP sessions and stdio, rmcp's handshake re-negotiated the protocol version after this server's `initialize` handler ran, echoing back any version in rmcp's `KNOWN_VERSIONS` regardless of whether this server implements it. A stateful client requesting `2026-07-28`, a revision rmcp has a constant for but this server doesn't yet handle (SEP-2243 headers and discovery), was told the server supports it and could send follow-up requests the server couldn't serve.
+
+The rmcp upgrade to 3.2.0 adds a `ServerHandler::supported_protocol_versions` hook that rmcp's re-negotiation now consults on every transport. This server overrides it to the versions it actually implements, so the cap at the newest supported protocol version now holds consistently across stateless and stateful streamable HTTP and stdio.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ The project is a Rust workspace with three crates:
 
 ## Key Dependencies
 
-- `rmcp 2.1` - MCP protocol implementation (aligned with MCP 2025-11-25)
+- `rmcp 3.2` - MCP protocol implementation (aligned with MCP 2025-11-25)
 - `apollo-compiler`, `apollo-federation` - GraphQL parsing and schema handling
 - `axum 0.8` - HTTP server
 - `tokio` - Async runtime

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
  "axum-extra",
  "axum-otel-metrics",
  "axum-tracing-opentelemetry",
- "base64",
+ "base64 0.22.1",
  "bon",
  "chrono",
  "clap",
@@ -537,6 +537,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "base64ct"
@@ -1056,6 +1062,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,6 +1098,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,6 +1130,17 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core 0.24.1",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1847,7 +1887,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http",
@@ -2048,7 +2088,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2421,7 +2461,7 @@ version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
  "hmac",
@@ -2444,7 +2484,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4cf2e9dd754c698b41139c2ec88304249ecf3dd15cabfeddd48665cdf5c0c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "jsonwebtoken",
  "reqwest",
  "serde",
@@ -3195,7 +3235,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -3730,7 +3770,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -3855,18 +3895,19 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
+checksum = "42b6914fac0be956fe704a38239c3f44a9f841d1b06a5713d2f638065593f5b5"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "futures",
  "http",
  "http-body",
  "http-body-util",
+ "indexmap",
  "pastey",
  "pin-project-lite",
  "rand 0.10.0",
@@ -3886,15 +3927,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
+checksum = "cdf1c49bd4d52014b94db0877410db273c2008f01628b0252a2e9460ad9b7fda"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.1",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.114",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4505,9 +4546,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.1"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
 dependencies = [
  "bytes",
  "futures-util",
@@ -4581,6 +4622,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4608,7 +4660,7 @@ checksum = "64a966cb0e76e311f09cf18507c9af192f15d34886ee43d7ba7c7e3803660c43"
 dependencies = [
  "aho-corasick",
  "arc-swap",
- "base64",
+ "base64 0.22.1",
  "bitpacking",
  "bon",
  "byteorder",
@@ -5057,7 +5109,7 @@ checksum = "a286e33f82f8a1ee2df63f4fa35c0becf4a85a0cb03091a15fd7bf0b402dc94a"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -5968,7 +6020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
  "axum-extra",
  "axum-otel-metrics",
  "axum-tracing-opentelemetry",
- "base64",
+ "base64 0.22.1",
  "bon",
  "chrono",
  "clap",
@@ -537,6 +537,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "base64ct"
@@ -1847,7 +1853,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http",
@@ -2048,7 +2054,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2421,7 +2427,7 @@ version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
  "hmac",
@@ -2444,7 +2450,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4cf2e9dd754c698b41139c2ec88304249ecf3dd15cabfeddd48665cdf5c0c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "jsonwebtoken",
  "reqwest",
  "serde",
@@ -3195,7 +3201,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -3730,7 +3736,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -3855,12 +3861,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
+checksum = "fcd2b6dd3b18129368955f32661a7718969e8c152c7d8866434c09cf15a512e0"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "futures",
@@ -3886,9 +3892,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
+checksum = "e1aa4b9345795260a43fc23d6d05e096407c8b953903f673af7c4404b49fb2d6"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -4505,9 +4511,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.1"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
 dependencies = [
  "bytes",
  "futures-util",
@@ -4608,7 +4614,7 @@ checksum = "64a966cb0e76e311f09cf18507c9af192f15d34886ee43d7ba7c7e3803660c43"
 dependencies = [
  "aho-corasick",
  "arc-swap",
- "base64",
+ "base64 0.22.1",
  "bitpacking",
  "bon",
  "byteorder",
@@ -5057,7 +5063,7 @@ checksum = "a286e33f82f8a1ee2df63f4fa35c0becf4a85a0cb03091a15fd7bf0b402dc94a"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -5968,7 +5974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ insta = { version = "1.43.1", features = [
   "yaml",
   "glob",
 ] }
-rmcp = { version = "2.1", features = [
+rmcp = { version = "3.2.0", features = [
   "server",
   "transport-io",
   "transport-streamable-http-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ insta = { version = "1.43.1", features = [
   "yaml",
   "glob",
 ] }
-rmcp = { version = "2.1", features = [
+rmcp = { version = "3.0.0", features = [
   "server",
   "transport-io",
   "transport-streamable-http-server",

--- a/crates/apollo-mcp-server/src/apps/resource.rs
+++ b/crates/apollo-mcp-server/src/apps/resource.rs
@@ -1,5 +1,5 @@
 use rmcp::ErrorData;
-use rmcp::model::{Meta, Resource, ResourceContents};
+use rmcp::model::{MetaObject, Resource, ResourceContents};
 use serde_json::json;
 use url::Url;
 
@@ -85,10 +85,10 @@ pub(crate) async fn get_app_resource(
 
     // Most properties now are listed under _meta.ui.* but some openai specific properties are still at the root
     // So, we will populate both and then nest "ui" into "meta" later in this function
-    let mut meta: Option<Meta> = None;
-    let mut ui: Option<Meta> = None;
+    let mut meta: Option<MetaObject> = None;
+    let mut ui: Option<MetaObject> = None;
     if let Some(csp) = &app.csp_settings {
-        ui.get_or_insert_with(Meta::new).insert(
+        ui.get_or_insert_with(MetaObject::new).insert(
             "csp".into(),
             json!({
                 "connectDomains": csp.connect_domains,
@@ -100,7 +100,7 @@ pub(crate) async fn get_app_resource(
 
         // Openai has a weird bug where it won't merge these settings with the MCP ones... so we just have to set both.
         if matches!(app_target, AppTarget::AppsSDK) {
-            meta.get_or_insert_with(Meta::new).insert(
+            meta.get_or_insert_with(MetaObject::new).insert(
                 "openai/widgetCSP".into(),
                 json!({
                     "connect_domains": csp.connect_domains,
@@ -116,21 +116,21 @@ pub(crate) async fn get_app_resource(
         if let Some(description) = &widget_settings.description
             && matches!(app_target, AppTarget::AppsSDK)
         {
-            meta.get_or_insert_with(Meta::new).insert(
+            meta.get_or_insert_with(MetaObject::new).insert(
                 "openai/widgetDescription".into(),
                 serde_json::to_value(description).unwrap_or_default(),
             );
         }
 
         if let Some(domain) = &widget_settings.domain {
-            ui.get_or_insert_with(Meta::new).insert(
+            ui.get_or_insert_with(MetaObject::new).insert(
                 "domain".into(),
                 serde_json::to_value(domain).unwrap_or_default(),
             );
         }
 
         if let Some(prefers_border) = &widget_settings.prefers_border {
-            ui.get_or_insert_with(Meta::new).insert(
+            ui.get_or_insert_with(MetaObject::new).insert(
                 "prefersBorder".into(),
                 serde_json::to_value(prefers_border).unwrap_or_default(),
             );
@@ -138,7 +138,7 @@ pub(crate) async fn get_app_resource(
             // ChatGPT currently ignores _meta.ui.prefersBorder, so we set
             // this field to ensure this setting is honored
             if matches!(app_target, AppTarget::AppsSDK) {
-                meta.get_or_insert_with(Meta::new).insert(
+                meta.get_or_insert_with(MetaObject::new).insert(
                     "openai/widgetPrefersBorder".into(),
                     serde_json::to_value(prefers_border).unwrap_or_default(),
                 );
@@ -146,7 +146,7 @@ pub(crate) async fn get_app_resource(
         }
     }
 
-    meta.get_or_insert_with(Meta::new)
+    meta.get_or_insert_with(MetaObject::new)
         .insert("ui".into(), serde_json::to_value(ui).unwrap_or_default());
 
     Ok(ResourceContents::TextResourceContents {

--- a/crates/apollo-mcp-server/src/apps/tool.rs
+++ b/crates/apollo-mcp-server/src/apps/tool.rs
@@ -7,7 +7,7 @@ use http::request::Parts;
 use opentelemetry::Context;
 use opentelemetry::trace::FutureExt;
 use parking_lot::Mutex;
-use rmcp::model::{CallToolResult, ContentBlock, JsonObject, Meta, Tool};
+use rmcp::model::{CallToolResult, ContentBlock, JsonObject, MetaObject, Tool};
 use serde_json::{Map, Value, json};
 use url::Url;
 
@@ -219,7 +219,7 @@ fn nest_app_tool_result(
     result.structured_content = Some(wrapped_restricted);
 
     // Attach tool name (and full structured content if private fields exist) to meta
-    let meta = result.meta.get_or_insert_with(Meta::new);
+    let meta = result.meta.get_or_insert_with(MetaObject::new);
     meta.insert("toolName".into(), Value::String(tool_name.to_string()));
     if let Some(full_m) = full_map {
         meta.insert("structuredContent".into(), Value::Object(full_m));
@@ -246,9 +246,9 @@ fn filter_inputs_for_operation(
 
 /// This makes the tool executable from the app but hidden from the LLM
 pub(crate) fn make_tool_private(mut tool: Tool) -> Tool {
-    let meta = tool.meta.get_or_insert_with(Meta::new);
+    let meta = tool.meta.get_or_insert_with(MetaObject::new);
 
-    let mut ui = Meta::new();
+    let mut ui = MetaObject::new();
     ui.insert("visibility".into(), json!(["app"]));
     meta.insert("ui".into(), serde_json::to_value(ui).unwrap_or_default());
 
@@ -258,8 +258,8 @@ pub(crate) fn make_tool_private(mut tool: Tool) -> Tool {
 // Attach tool meta data when requested to allow swapping between app targets (Apps SDK, MCP Apps)
 pub(crate) fn attach_tool_metadata(app: &App, tool: &AppTool, app_target: &AppTarget) -> Tool {
     let mut inner_tool = tool.tool.clone();
-    let meta = inner_tool.meta.get_or_insert_with(Meta::new);
-    let mut ui = Meta::new();
+    let meta = inner_tool.meta.get_or_insert_with(MetaObject::new);
+    let mut ui = MetaObject::new();
 
     ui.insert("resourceUri".to_string(), app.uri.to_string().into());
     ui.insert("visibility".to_string(), json!(["model", "app"]));
@@ -669,7 +669,7 @@ mod tests {
 
     #[test]
     fn make_tool_private_adds_ui_meta_for_mcp_apps_when_tool_has_existing_meta() {
-        let mut existing_meta = Meta::new();
+        let mut existing_meta = MetaObject::new();
         existing_meta.insert("my-awesome-key".into(), "my-awesome-value".into());
         let mut tool = Tool::new("GetId", "a description", JsonObject::new());
         tool.meta = Some(existing_meta);
@@ -818,7 +818,7 @@ mod tests {
             prefetch_operations: vec![],
         };
 
-        let mut existing_meta = Meta::new();
+        let mut existing_meta = MetaObject::new();
         existing_meta.insert("custom-key".into(), "custom-value".into());
 
         let mut tool_def = Tool::new("TestTool", "description", JsonObject::new());
@@ -920,7 +920,7 @@ mod tests {
             prefetch_operations: vec![],
         };
 
-        let mut existing_meta = Meta::new();
+        let mut existing_meta = MetaObject::new();
         existing_meta.insert("custom-key".into(), "custom-value".into());
 
         let mut tool_def = Tool::new("TestTool", "description", JsonObject::new());
@@ -993,7 +993,7 @@ mod tests {
         let restricted = json!({"data": {"fieldA": "a"}});
         let full = json!({"data": {"fieldA": "a", "fieldB": "secret"}});
 
-        let mut meta = Meta::new();
+        let mut meta = MetaObject::new();
         meta.insert("structuredContent".into(), full.clone());
 
         let mut result = CallToolResult::success(vec![]);
@@ -1019,7 +1019,7 @@ mod tests {
         let restricted_primary = json!({"data": {"fieldA": "a"}});
         let full_primary = json!({"data": {"fieldA": "a", "fieldB": "secret"}});
 
-        let mut primary_meta = Meta::new();
+        let mut primary_meta = MetaObject::new();
         primary_meta.insert("structuredContent".into(), full_primary.clone());
 
         let mut result = CallToolResult::success(vec![]);
@@ -1029,7 +1029,7 @@ mod tests {
         let restricted_prefetch = json!({"data": {"x": 1}});
         let full_prefetch = json!({"data": {"x": 1, "y": 2}});
 
-        let mut prefetch_meta = Meta::new();
+        let mut prefetch_meta = MetaObject::new();
         prefetch_meta.insert("structuredContent".into(), full_prefetch.clone());
 
         let mut prefetch_result = CallToolResult::success(vec![]);
@@ -1073,7 +1073,7 @@ mod tests {
         let restricted_prefetch = json!({"data": {"x": 1}});
         let full_prefetch = json!({"data": {"x": 1, "y": 2}});
 
-        let mut prefetch_meta = Meta::new();
+        let mut prefetch_meta = MetaObject::new();
         prefetch_meta.insert("structuredContent".into(), full_prefetch.clone());
 
         let mut prefetch_result = CallToolResult::success(vec![]);
@@ -1111,7 +1111,7 @@ mod tests {
         let restricted_primary = json!({"data": {"fieldA": "a"}});
         let full_primary = json!({"data": {"fieldA": "a", "fieldB": "secret"}});
 
-        let mut primary_meta = Meta::new();
+        let mut primary_meta = MetaObject::new();
         primary_meta.insert("structuredContent".into(), full_primary.clone());
 
         let mut result = CallToolResult::success(vec![]);
@@ -1165,7 +1165,7 @@ mod tests {
         let full = json!({"data": {"fieldA": "a", "fieldB": "secret"}});
         let extra = json!({"widgetUrl": "https://example.com"});
 
-        let mut meta = Meta::new();
+        let mut meta = MetaObject::new();
         meta.insert("structuredContent".into(), full.clone());
 
         let mut result = CallToolResult::success(vec![]);

--- a/crates/apollo-mcp-server/src/graphql.rs
+++ b/crates/apollo-mcp-server/src/graphql.rs
@@ -10,7 +10,7 @@ use opentelemetry::KeyValue;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, Extension};
 use reqwest_tracing::{OtelName, TracingMiddleware};
-use rmcp::model::{CallToolResult, ContentBlock, Meta};
+use rmcp::model::{CallToolResult, ContentBlock, MetaObject};
 use serde_json::{Map, Value};
 use url::Url;
 
@@ -126,7 +126,7 @@ pub trait Executable {
                 // - full response is preserved in meta for the client to access
                 let (structured_content, meta) = if let Some(tree) = private_fields.as_ref() {
                     let restricted = filter_private_fields(&json, tree);
-                    let mut meta = Meta::new();
+                    let mut meta = MetaObject::new();
                     meta.insert("structuredContent".into(), json);
                     (restricted, Some(meta))
                 } else {

--- a/crates/apollo-mcp-server/src/operations/operation.rs
+++ b/crates/apollo-mcp-server/src/operations/operation.rs
@@ -895,7 +895,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -1040,7 +1039,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -1196,7 +1194,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -1355,7 +1352,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -1511,7 +1507,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -1664,7 +1659,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -1827,7 +1821,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -2005,7 +1998,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -2148,7 +2140,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -2406,7 +2397,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -2552,7 +2542,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -2702,7 +2691,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -2841,7 +2829,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -3384,7 +3371,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -3517,7 +3503,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -4096,7 +4081,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -4290,7 +4274,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -4499,7 +4482,6 @@ mod tests {
                         ),
                     },
                 ),
-                execution: None,
                 icons: None,
                 meta: None,
             },
@@ -4633,7 +4615,6 @@ mod tests {
                         ),
                     },
                 ),
-                execution: None,
                 icons: None,
                 meta: None,
             },
@@ -4769,7 +4750,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }

--- a/crates/apollo-mcp-server/src/operations/operation.rs
+++ b/crates/apollo-mcp-server/src/operations/operation.rs
@@ -885,7 +885,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -1030,7 +1029,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -1186,7 +1184,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -1345,7 +1342,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -1501,7 +1497,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -1654,7 +1649,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -1817,7 +1811,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -1995,7 +1988,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -2138,7 +2130,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -2396,7 +2387,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -2542,7 +2532,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -2692,7 +2681,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -2831,7 +2819,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -3374,7 +3361,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -3507,7 +3493,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -4086,7 +4071,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -4280,7 +4264,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }
@@ -4489,7 +4472,6 @@ mod tests {
                         ),
                     },
                 ),
-                execution: None,
                 icons: None,
                 meta: None,
             },
@@ -4623,7 +4605,6 @@ mod tests {
                         ),
                     },
                 ),
-                execution: None,
                 icons: None,
                 meta: None,
             },
@@ -4759,7 +4740,6 @@ mod tests {
                     ),
                 },
             ),
-            execution: None,
             icons: None,
             meta: None,
         }

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -1,5 +1,6 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use apollo_compiler::{Schema, validation::Valid};
 use opentelemetry::KeyValue;
@@ -7,9 +8,10 @@ use parking_lot::Mutex;
 use reqwest::header::HeaderMap;
 use rmcp::ErrorData;
 use rmcp::model::{
-    ClientCapabilities, Extensions, GetPromptRequestParams, GetPromptResult, Implementation,
-    ListPromptsResult, ListResourcesResult, PromptMessage, PromptsCapability, ReadResourceResult,
-    ResourcesCapability, Role, ToolsCapability,
+    CallToolResponse, ClientCapabilities, Extensions, GetPromptRequestParams, GetPromptResponse,
+    GetPromptResult, Implementation, ListPromptsResult, ListResourcesResult, PromptMessage,
+    PromptsCapability, ReadResourceResponse, ReadResourceResult, ResourcesCapability, Role,
+    ToolsCapability,
 };
 use rmcp::{
     Peer, RoleServer, ServerHandler, ServiceError,
@@ -289,10 +291,8 @@ impl Running {
             let app = self.apps.iter().find(|app| app.name == app_name);
 
             match app {
-                Some(app) => ListToolsResult {
-                    next_cursor: None,
-                    tools: self
-                        .operations
+                Some(app) => ListToolsResult::with_all_items(
+                    self.operations
                         .read()
                         .await
                         .iter()
@@ -311,8 +311,7 @@ impl Running {
                                 .collect::<Vec<_>>(),
                         )
                         .collect(),
-                    meta: None,
-                },
+                ),
                 None => {
                     return Err(McpError::new(
                         ErrorCode::INVALID_REQUEST,
@@ -322,10 +321,8 @@ impl Running {
                 }
             }
         } else {
-            ListToolsResult {
-                next_cursor: None,
-                tools: self
-                    .operations
+            ListToolsResult::with_all_items(
+                self.operations
                     .read()
                     .await
                     .iter()
@@ -336,8 +333,7 @@ impl Running {
                     .chain(self.explorer_tool.as_ref().iter().map(|e| e.tool.clone()))
                     .chain(self.validate_tool.as_ref().iter().map(|e| e.tool.clone()))
                     .collect(),
-                meta: None,
-            }
+            )
         };
 
         if !self.client_supports_output_schema(protocol_version) {
@@ -527,11 +523,7 @@ impl Running {
             vec![]
         };
 
-        Ok(ListResourcesResult {
-            resources,
-            next_cursor: None,
-            meta: None,
-        })
+        Ok(ListResourcesResult::with_all_items(resources))
     }
 
     async fn read_resource_impl(
@@ -622,10 +614,9 @@ pub(crate) const MAX_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersi
 /// Echoes the client-requested protocol version when this server supports
 /// it, otherwise falls back to [`MAX_SUPPORTED_PROTOCOL_VERSION`].
 ///
-/// Unlike rmcp's `negotiate_protocol_version`, this caps at the version the
-/// server implements: rmcp's `KNOWN_VERSIONS` includes versions the SDK has
-/// constants for but that this server doesn't yet handle (e.g. `2026-07-28`
-/// SEP-2243 headers and discovery).
+/// rmcp's own re-negotiation (which runs after `initialize` on every
+/// transport, keyed off [`ServerHandler::supported_protocol_versions`]) caps
+/// at the same version, so the two stay in agreement.
 fn negotiate_protocol_version(client_requested: &ProtocolVersion) -> ProtocolVersion {
     if ProtocolVersion::KNOWN_VERSIONS.contains(client_requested)
         && *client_requested <= MAX_SUPPORTED_PROTOCOL_VERSION
@@ -669,12 +660,29 @@ impl ServerHandler for Running {
         let mut peers = self.peers.write().await;
         peers.push(context.peer);
         // Echo the client's requested protocol version when supported,
-        // falling back to our max supported version otherwise (#794). This
-        // result stands only on stateless HTTP; on stateful sessions
-        // rmcp's handshake re-negotiates and can override it (#803).
+        // falling back to our max supported version otherwise (#794). rmcp's
+        // handshake re-negotiates this after `initialize` on every
+        // transport, but `supported_protocol_versions` below keeps that
+        // re-negotiation capped at the same version (closes #803).
         let mut info = self.get_info();
         info.protocol_version = negotiate_protocol_version(&request.protocol_version);
         Ok(info)
+    }
+
+    /// Narrows rmcp's re-negotiation (run on every transport after
+    /// `initialize`) to the versions this server implements, so it can't
+    /// override our cap at [`MAX_SUPPORTED_PROTOCOL_VERSION`] with a newer
+    /// version from rmcp's `KNOWN_VERSIONS` (e.g. `2026-07-28`'s SEP-2243
+    /// headers and discovery, which this server doesn't yet handle).
+    fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
+        static SUPPORTED: LazyLock<Vec<ProtocolVersion>> = LazyLock::new(|| {
+            ProtocolVersion::KNOWN_VERSIONS
+                .iter()
+                .filter(|version| **version <= MAX_SUPPORTED_PROTOCOL_VERSION)
+                .cloned()
+                .collect()
+        });
+        Cow::Borrowed(&SUPPORTED)
     }
 
     #[tracing::instrument(skip_all, parent = get_parent_span(&context), fields(apollo.mcp.tool_name = request.name.as_ref(), apollo.mcp.request_id = %context.id.clone(), apollo.mcp.tool_arguments = tracing::field::Empty, apollo.mcp.tool_result = tracing::field::Empty))]
@@ -682,7 +690,7 @@ impl ServerHandler for Running {
         &self,
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, McpError> {
+    ) -> Result<CallToolResponse, McpError> {
         let span = tracing::Span::current();
         if let Some(args) = &request.arguments
             && let Ok(json) = serde_json::to_string(args)
@@ -707,7 +715,7 @@ impl ServerHandler for Running {
             }
         }
 
-        result
+        result.map(Into::into)
     }
 
     #[tracing::instrument(skip_all, parent = get_parent_span(&context))]
@@ -738,12 +746,13 @@ impl ServerHandler for Running {
         &self,
         request: rmcp::model::ReadResourceRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<ReadResourceResult, ErrorData> {
+    ) -> Result<ReadResourceResponse, ErrorData> {
         let peer_info = context.peer.peer_info();
         let client_capabilities = peer_info.as_ref().map(|info| &info.capabilities);
 
         self.read_resource_impl(request, context.extensions, client_capabilities)
             .await
+            .map(Into::into)
     }
 
     #[tracing::instrument(skip_all)]
@@ -760,8 +769,8 @@ impl ServerHandler for Running {
         &self,
         request: GetPromptRequestParams,
         _context: RequestContext<RoleServer>,
-    ) -> Result<GetPromptResult, McpError> {
-        self.get_prompt_impl(request)
+    ) -> Result<GetPromptResponse, McpError> {
+        self.get_prompt_impl(request).map(Into::into)
     }
 
     // `logging` is deprecated by SEP-2577, but we still override this handler so
@@ -2641,7 +2650,7 @@ mod integration_tests {
             StreamableHttpService::new(
                 move || Ok(running.clone()),
                 session_manager,
-                StreamableHttpServerConfig::default().with_stateful_mode(true),
+                StreamableHttpServerConfig::default().with_legacy_session_mode(true),
             )
         }
 
@@ -2901,6 +2910,59 @@ mod integration_tests {
             let _ = server.await;
         }
 
+        #[tokio::test]
+        async fn stdio_caps_at_max_supported_when_client_requests_newer_known_version() {
+            // Mirrors `stateless_caps_at_max_supported_when_client_requests_newer_known_version`
+            // for the stdio transport: rmcp's generic `serve()` negotiates through
+            // the same `supported_protocol_versions` hook (service/server.rs), a
+            // different code path from `StreamableHttpService`'s tower layer. This
+            // proves the cap holds there too, closing the one transport #803's fix
+            // didn't yet have a regression test for.
+            use rmcp::ServiceExt as _;
+            use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
+
+            let running = create_running_with_output_schema();
+
+            let (server_io, client_io) = tokio::io::duplex(4096);
+            let (server_r, server_w) = tokio::io::split(server_io);
+            let (client_r, mut client_w) = tokio::io::split(client_io);
+
+            let server = tokio::spawn(async move {
+                let service = running
+                    .serve((server_r, server_w))
+                    .await
+                    .expect("stdio serve should complete the initialize handshake");
+                let _ = service.waiting().await;
+            });
+
+            let mut request = json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2026-07-28",
+                    "capabilities": {},
+                    "clientInfo": { "name": "test-client", "version": "1.0.0" }
+                }
+            })
+            .to_string();
+            request.push('\n');
+            client_w.write_all(request.as_bytes()).await.unwrap();
+
+            let mut reader = BufReader::new(client_r);
+            let mut response_line = String::new();
+            reader.read_line(&mut response_line).await.unwrap();
+            let body: serde_json::Value = serde_json::from_str(&response_line).unwrap();
+            assert_eq!(
+                body["result"]["protocolVersion"],
+                MAX_SUPPORTED_PROTOCOL_VERSION.as_str()
+            );
+
+            drop(reader);
+            drop(client_w);
+            let _ = server.await;
+        }
+
         fn create_stateless_service(
             running: Running,
             session_manager: Arc<LocalSessionManager>,
@@ -2908,7 +2970,7 @@ mod integration_tests {
             StreamableHttpService::new(
                 move || Ok(running.clone()),
                 session_manager,
-                StreamableHttpServerConfig::default().with_stateful_mode(false),
+                StreamableHttpServerConfig::default().with_legacy_session_mode(false),
             )
         }
 
@@ -2973,14 +3035,18 @@ mod integration_tests {
         }
 
         #[tokio::test]
-        async fn stateful_echoes_newer_known_version_due_to_rmcp_override() {
-            // Known upstream divergence, tracked in #803: on stateful paths
-            // rmcp's handshake re-negotiates after our `initialize` handler
-            // and echoes any version in its KNOWN_VERSIONS, overriding our
-            // cap at MAX_SUPPORTED_PROTOCOL_VERSION. This test pins that
-            // behavior so an rmcp upgrade that changes it is caught; if it
-            // starts failing, re-check whether the cap now holds on all
-            // transports and close #803 accordingly.
+        async fn legacy_session_mode_enabled_still_caps_at_max_supported_when_client_requests_newer_known_version()
+         {
+            // Requesting protocol version 2026-07-28 always uses the
+            // stateless/discover lifecycle regardless of `legacy_session_mode`
+            // (SEP-2567), so this exercises the same `NegotiatingStatelessHttpService`
+            // path as `stateless_caps_at_max_supported_when_client_requests_newer_known_version`,
+            // not a distinct legacy-session handshake. This pins that enabling
+            // `legacy_session_mode` doesn't accidentally exempt that request from
+            // the cap (closes #803);
+            // `stdio_caps_at_max_supported_when_client_requests_newer_known_version`
+            // covers the one code path (rmcp's generic `serve()`) that isn't
+            // routed through `StreamableHttpService`.
             let running = create_running_with_output_schema();
             let service = create_service(running, LocalSessionManager::default().into());
 
@@ -2991,7 +3057,10 @@ mod integration_tests {
 
             assert_eq!(response.status(), StatusCode::OK);
             let body = extract_json_body(response).await;
-            assert_eq!(body["result"]["protocolVersion"], "2026-07-28");
+            assert_eq!(
+                body["result"]["protocolVersion"],
+                MAX_SUPPORTED_PROTOCOL_VERSION.as_str()
+            );
         }
 
         #[test]
@@ -3089,7 +3158,7 @@ mod integration_tests {
             StreamableHttpService::new(
                 move || Ok(running.clone()),
                 session_manager,
-                StreamableHttpServerConfig::default().with_stateful_mode(true),
+                StreamableHttpServerConfig::default().with_legacy_session_mode(true),
             )
         }
 
@@ -3321,7 +3390,7 @@ mod integration_tests {
             StreamableHttpService::new(
                 move || Ok(running.clone()),
                 LocalSessionManager::default().into(),
-                StreamableHttpServerConfig::default().with_stateful_mode(stateful_mode),
+                StreamableHttpServerConfig::default().with_legacy_session_mode(stateful_mode),
             )
         }
 
@@ -3332,7 +3401,7 @@ mod integration_tests {
             StreamableHttpService::new(
                 move || Ok(running.clone()),
                 session_manager,
-                StreamableHttpServerConfig::default().with_stateful_mode(true),
+                StreamableHttpServerConfig::default().with_legacy_session_mode(true),
             )
         }
 
@@ -3641,7 +3710,7 @@ mod integration_tests {
             StreamableHttpService::new(
                 move || Ok(running.clone()),
                 session_manager,
-                StreamableHttpServerConfig::default().with_stateful_mode(true),
+                StreamableHttpServerConfig::default().with_legacy_session_mode(true),
             )
         }
 
@@ -3799,7 +3868,7 @@ mod integration_tests {
             StreamableHttpService::new(
                 move || Ok(running.clone()),
                 session_manager,
-                StreamableHttpServerConfig::default().with_stateful_mode(true),
+                StreamableHttpServerConfig::default().with_legacy_session_mode(true),
             )
         }
 

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -7,9 +7,10 @@ use parking_lot::Mutex;
 use reqwest::header::HeaderMap;
 use rmcp::ErrorData;
 use rmcp::model::{
-    ClientCapabilities, Extensions, GetPromptRequestParams, GetPromptResult, Implementation,
-    ListPromptsResult, ListResourcesResult, PromptMessage, PromptsCapability, ReadResourceResult,
-    ResourcesCapability, Role, ToolsCapability,
+    CallToolResponse, ClientCapabilities, Extensions, GetPromptRequestParams, GetPromptResponse,
+    GetPromptResult, Implementation, ListPromptsResult, ListResourcesResult, PromptMessage,
+    PromptsCapability, ReadResourceResponse, ReadResourceResult, ResourcesCapability, Role,
+    ToolsCapability,
 };
 use rmcp::{
     Peer, RoleServer, ServerHandler, ServiceError,
@@ -289,10 +290,8 @@ impl Running {
             let app = self.apps.iter().find(|app| app.name == app_name);
 
             match app {
-                Some(app) => ListToolsResult {
-                    next_cursor: None,
-                    tools: self
-                        .operations
+                Some(app) => ListToolsResult::with_all_items(
+                    self.operations
                         .read()
                         .await
                         .iter()
@@ -311,8 +310,7 @@ impl Running {
                                 .collect::<Vec<_>>(),
                         )
                         .collect(),
-                    meta: None,
-                },
+                ),
                 None => {
                     return Err(McpError::new(
                         ErrorCode::INVALID_REQUEST,
@@ -322,10 +320,8 @@ impl Running {
                 }
             }
         } else {
-            ListToolsResult {
-                next_cursor: None,
-                tools: self
-                    .operations
+            ListToolsResult::with_all_items(
+                self.operations
                     .read()
                     .await
                     .iter()
@@ -336,8 +332,7 @@ impl Running {
                     .chain(self.explorer_tool.as_ref().iter().map(|e| e.tool.clone()))
                     .chain(self.validate_tool.as_ref().iter().map(|e| e.tool.clone()))
                     .collect(),
-                meta: None,
-            }
+            )
         };
 
         if !self.client_supports_output_schema(protocol_version) {
@@ -527,11 +522,7 @@ impl Running {
             vec![]
         };
 
-        Ok(ListResourcesResult {
-            resources,
-            next_cursor: None,
-            meta: None,
-        })
+        Ok(ListResourcesResult::with_all_items(resources))
     }
 
     async fn read_resource_impl(
@@ -649,7 +640,7 @@ impl ServerHandler for Running {
         &self,
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, McpError> {
+    ) -> Result<CallToolResponse, McpError> {
         let span = tracing::Span::current();
         if let Some(args) = &request.arguments
             && let Ok(json) = serde_json::to_string(args)
@@ -674,7 +665,7 @@ impl ServerHandler for Running {
             }
         }
 
-        result
+        result.map(Into::into)
     }
 
     #[tracing::instrument(skip_all, parent = get_parent_span(&context))]
@@ -705,12 +696,13 @@ impl ServerHandler for Running {
         &self,
         request: rmcp::model::ReadResourceRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<ReadResourceResult, ErrorData> {
+    ) -> Result<ReadResourceResponse, ErrorData> {
         let peer_info = context.peer.peer_info();
         let client_capabilities = peer_info.as_ref().map(|info| &info.capabilities);
 
         self.read_resource_impl(request, context.extensions, client_capabilities)
             .await
+            .map(Into::into)
     }
 
     #[tracing::instrument(skip_all)]
@@ -727,8 +719,8 @@ impl ServerHandler for Running {
         &self,
         request: GetPromptRequestParams,
         _context: RequestContext<RoleServer>,
-    ) -> Result<GetPromptResult, McpError> {
-        self.get_prompt_impl(request)
+    ) -> Result<GetPromptResponse, McpError> {
+        self.get_prompt_impl(request).map(Into::into)
     }
 
     // `logging` is deprecated by SEP-2577, but we still override this handler so
@@ -2567,7 +2559,7 @@ mod integration_tests {
             StreamableHttpService::new(
                 move || Ok(running.clone()),
                 session_manager,
-                StreamableHttpServerConfig::default().with_stateful_mode(true),
+                StreamableHttpServerConfig::default().with_legacy_session_mode(true),
             )
         }
 
@@ -2897,7 +2889,7 @@ mod integration_tests {
             StreamableHttpService::new(
                 move || Ok(running.clone()),
                 session_manager,
-                StreamableHttpServerConfig::default().with_stateful_mode(true),
+                StreamableHttpServerConfig::default().with_legacy_session_mode(true),
             )
         }
 
@@ -3129,7 +3121,7 @@ mod integration_tests {
             StreamableHttpService::new(
                 move || Ok(running.clone()),
                 LocalSessionManager::default().into(),
-                StreamableHttpServerConfig::default().with_stateful_mode(stateful_mode),
+                StreamableHttpServerConfig::default().with_legacy_session_mode(stateful_mode),
             )
         }
 
@@ -3140,7 +3132,7 @@ mod integration_tests {
             StreamableHttpService::new(
                 move || Ok(running.clone()),
                 session_manager,
-                StreamableHttpServerConfig::default().with_stateful_mode(true),
+                StreamableHttpServerConfig::default().with_legacy_session_mode(true),
             )
         }
 
@@ -3449,7 +3441,7 @@ mod integration_tests {
             StreamableHttpService::new(
                 move || Ok(running.clone()),
                 session_manager,
-                StreamableHttpServerConfig::default().with_stateful_mode(true),
+                StreamableHttpServerConfig::default().with_legacy_session_mode(true),
             )
         }
 
@@ -3607,7 +3599,7 @@ mod integration_tests {
             StreamableHttpService::new(
                 move || Ok(running.clone()),
                 session_manager,
-                StreamableHttpServerConfig::default().with_stateful_mode(true),
+                StreamableHttpServerConfig::default().with_legacy_session_mode(true),
             )
         }
 

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -205,7 +205,7 @@ impl Starting {
                 let running = running.clone();
                 let listen_address = SocketAddr::new(address, port);
                 let http_config = host_validation.apply_to(
-                    StreamableHttpServerConfig::default().with_stateful_mode(stateful_mode),
+                    StreamableHttpServerConfig::default().with_legacy_session_mode(stateful_mode),
                 );
                 let service = StreamableHttpService::new(
                     move || Ok(running.clone()),


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-508 -->

Upgrades rmcp from 2.1 to 3.2.0, the latest release.

This is a major version jump, so it touches several APIs: `Meta` is renamed to `MetaObject`, `Tool` drops its `execution` field, `ListToolsResult`/`ListResourcesResult` are now built with `with_all_items` instead of constructed by hand, the corresponding `ServerHandler` methods return `CallToolResponse`/`ReadResourceResponse`/`GetPromptResponse` instead of their `*Result` types (mapped in via `Into::into`), and `StreamableHttpServerConfig::with_stateful_mode` is renamed to `with_legacy_session_mode`.

It also adds a `ServerHandler::supported_protocol_versions` hook that rmcp consults whenever it re-negotiates the protocol version after `initialize`, on every transport. This server overrides it to cap at the newest protocol version it implements (2025-11-25), closing a gap where stateful sessions and stdio could echo back a version from rmcp's `KNOWN_VERSIONS` that this server doesn't actually support, such as `2026-07-28`.

Closes #803
