### PR TITLE
feat: Advertise a server icon in initialize

### DIFF
--- a/.changeset/server_info_icons.md
+++ b/.changeset/server_info_icons.md
@@ -1,0 +1,12 @@
+---
+default: minor
+---
+
+# Advertise a server icon in `initialize`
+
+Server operators can now configure `server_info.icons`, letting the MCP
+`initialize` response advertise one or more icons that clients render
+alongside the server's name. Each entry mirrors the fields of the MCP
+[`Icon`](https://modelcontextprotocol.io/specification/2025-11-25/schema#icon)
+object: `src`, `mime_type`, `sizes`, and `theme`. No icon is advertised
+by default.

--- a/crates/apollo-mcp-server/src/runtime.rs
+++ b/crates/apollo-mcp-server/src/runtime.rs
@@ -215,6 +215,7 @@ mod test {
                     title: None,
                     website_url: None,
                     description: None,
+                    icons: [],
                 },
                 instructions: None,
                 custom_scalars: None,

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -814,6 +814,9 @@ impl ServerHandler for Running {
         if let Some(u) = self.server_info.website_url() {
             impl_ = impl_.with_website_url(u);
         }
+        if let Some(icons) = self.server_info.icons() {
+            impl_ = impl_.with_icons(icons);
+        }
         let mut result = InitializeResult::new(capabilities)
             .with_protocol_version(protocol_version)
             .with_server_info(impl_);
@@ -2183,6 +2186,7 @@ mod tests {
                 title: Some("Custom GraphQL Server".to_string()),
                 website_url: Some("https://my-server.example.com/docs".to_string()),
                 description: Some("A custom MCP server for testing".to_string()),
+                icons: vec![],
             };
 
             let running = Running {
@@ -2231,6 +2235,70 @@ mod tests {
             let info = running.get_info();
 
             assert_eq!(info.protocol_version, MAX_SUPPORTED_PROTOCOL_VERSION);
+        }
+
+        #[test]
+        fn get_info_omits_icons_by_default() {
+            let schema = Schema::parse("type Query { id: String }", "schema.graphql")
+                .unwrap()
+                .validate()
+                .unwrap();
+
+            let running = test_running(Arc::new(RwLock::new(schema)));
+
+            let info = running.get_info();
+
+            assert_eq!(info.server_info.icons, None);
+        }
+
+        #[test]
+        fn get_info_forwards_configured_icons_with_optional_fields() {
+            use crate::server_info::{IconConfig, IconThemeConfig};
+            use rmcp::model::IconTheme;
+
+            let schema = Schema::parse("type Query { id: String }", "schema.graphql")
+                .unwrap()
+                .validate()
+                .unwrap();
+
+            let server_info = ServerInfoConfig {
+                icons: vec![
+                    IconConfig {
+                        src: "https://example.com/icon.svg".to_string(),
+                        mime_type: Some("image/svg+xml".to_string()),
+                        sizes: Some(vec!["any".to_string()]),
+                        theme: Some(IconThemeConfig::Dark),
+                    },
+                    IconConfig {
+                        src: "https://example.com/icon-48.png".to_string(),
+                        mime_type: None,
+                        sizes: None,
+                        theme: None,
+                    },
+                ],
+                ..Default::default()
+            };
+
+            let running = Running {
+                server_info,
+                ..test_running(Arc::new(RwLock::new(schema)))
+            };
+
+            let icons = running
+                .get_info()
+                .server_info
+                .icons
+                .expect("icons should be advertised when configured");
+
+            assert_eq!(icons.len(), 2);
+            assert_eq!(icons[0].src, "https://example.com/icon.svg");
+            assert_eq!(icons[0].mime_type.as_deref(), Some("image/svg+xml"));
+            assert_eq!(icons[0].sizes.as_deref(), Some(&["any".to_string()][..]));
+            assert_eq!(icons[0].theme, Some(IconTheme::Dark));
+            assert_eq!(icons[1].src, "https://example.com/icon-48.png");
+            assert!(icons[1].mime_type.is_none());
+            assert!(icons[1].sizes.is_none());
+            assert!(icons[1].theme.is_none());
         }
     }
 

--- a/crates/apollo-mcp-server/src/server_info.rs
+++ b/crates/apollo-mcp-server/src/server_info.rs
@@ -1,5 +1,6 @@
+use rmcp::model::{Icon, IconTheme};
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 
 /// Server metadata configuration returned in the MCP initialize response.
 /// All fields are optional and fall back to defaults if not provided.
@@ -20,6 +21,147 @@ pub struct ServerInfoConfig {
 
     /// A brief description of the server
     pub description: Option<String>,
+
+    /// Icons representing the server, for clients that display one
+    pub icons: Vec<IconConfig>,
+}
+
+/// A single icon representing the server. Clients pick whichever entry best
+/// fits the surface they are rendering, so several may be supplied.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct IconConfig {
+    /// URI of the icon: an `https://` URL or a base64-encoded `data:` URI
+    #[serde(deserialize_with = "deserialize_icon_src")]
+    pub src: String,
+
+    /// MIME type of the icon, such as `image/png`. Set this when the source
+    /// serves no MIME type of its own or serves a generic one
+    #[serde(default)]
+    pub mime_type: Option<String>,
+
+    /// Sizes the icon is available in, each `WxH` (e.g. `48x48`) or `any` for
+    /// scalable formats
+    #[serde(default, deserialize_with = "deserialize_icon_sizes")]
+    pub sizes: Option<Vec<String>>,
+
+    /// Background theme this icon is designed for. Omit to let the client use
+    /// it with any theme
+    #[serde(default)]
+    pub theme: Option<IconThemeConfig>,
+}
+
+/// Reject `src` values whose scheme the MCP spec instructs clients to refuse
+/// (`javascript:`, `file:`, `ftp:`, `ws:`, and anything else that isn't
+/// `https://` or `data:`), and reject well-schemed but empty inputs like a
+/// bare `https://` or a `data:` URI without an `image/*` payload.
+fn deserialize_icon_src<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = String::deserialize(deserializer)?;
+    let ok = if let Some(rest) = raw.strip_prefix("https://") {
+        has_host(rest)
+    } else if let Some(rest) = raw.strip_prefix("data:") {
+        is_image_data_uri(rest)
+    } else {
+        false
+    };
+    if ok {
+        Ok(raw)
+    } else {
+        Err(serde::de::Error::custom(format!(
+            "server_info.icons[].src must be an `https://` URL with a host or an \
+             `image/*` `data:` URI (got {raw:?})"
+        )))
+    }
+}
+
+fn has_host(after_scheme: &str) -> bool {
+    let host_end = after_scheme
+        .find(['/', '?', '#'])
+        .unwrap_or(after_scheme.len());
+    !after_scheme[..host_end].is_empty()
+}
+
+/// A `data:` URI is `mediatype[;base64],data`. Accept it only when the media
+/// type is `image/<subtype>` and the payload is non-empty; the RFC allows
+/// omitting either but neither shape makes sense for an icon source.
+fn is_image_data_uri(after_scheme: &str) -> bool {
+    let (metadata, data) = match after_scheme.split_once(',') {
+        Some(pair) => pair,
+        None => return false,
+    };
+    if data.is_empty() {
+        return false;
+    }
+    let mime = metadata.split(';').next().unwrap_or("");
+    match mime.strip_prefix("image/") {
+        Some(subtype) => !subtype.is_empty(),
+        None => false,
+    }
+}
+
+fn deserialize_icon_sizes<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = Option::<Vec<String>>::deserialize(deserializer)?;
+    if let Some(entries) = &raw {
+        for entry in entries {
+            if entry != "any" && !is_wxh_size(entry) {
+                return Err(serde::de::Error::custom(format!(
+                    "server_info.icons[].sizes entries must be `WxH` (e.g. `48x48`) or `any` (got {entry:?})"
+                )));
+            }
+        }
+    }
+    Ok(raw)
+}
+
+fn is_wxh_size(entry: &str) -> bool {
+    match entry.split_once('x') {
+        Some((width, height)) => {
+            !width.is_empty()
+                && !height.is_empty()
+                && width.bytes().all(|b| b.is_ascii_digit())
+                && height.bytes().all(|b| b.is_ascii_digit())
+        }
+        None => false,
+    }
+}
+
+/// Background theme an icon is designed for.
+#[derive(Debug, Clone, Copy, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum IconThemeConfig {
+    Light,
+    Dark,
+}
+
+impl From<IconThemeConfig> for IconTheme {
+    fn from(theme: IconThemeConfig) -> Self {
+        match theme {
+            IconThemeConfig::Light => IconTheme::Light,
+            IconThemeConfig::Dark => IconTheme::Dark,
+        }
+    }
+}
+
+impl From<&IconConfig> for Icon {
+    fn from(config: &IconConfig) -> Self {
+        let mut icon = Icon::new(config.src.clone());
+        if let Some(mime_type) = config.mime_type.as_deref() {
+            icon = icon.with_mime_type(mime_type);
+        }
+        if let Some(sizes) = config.sizes.clone() {
+            icon = icon.with_sizes(sizes);
+        }
+        if let Some(theme) = config.theme {
+            icon = icon.with_theme(theme.into());
+        }
+        icon
+    }
 }
 
 impl ServerInfoConfig {
@@ -45,5 +187,155 @@ impl ServerInfoConfig {
         self.description.as_deref().or(Some(
             "A Model Context Protocol (MCP) server for exposing GraphQL APIs as tools.",
         ))
+    }
+
+    /// No icon is advertised unless one is configured; there is no sensible
+    /// default to brand an embedding server with.
+    pub fn icons(&self) -> Option<Vec<Icon>> {
+        (!self.icons.is_empty()).then(|| self.icons.iter().map(Icon::from).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn icons_is_none_when_no_entries_configured() {
+        assert!(ServerInfoConfig::default().icons().is_none());
+    }
+
+    #[test]
+    fn icons_forwards_optional_fields() {
+        let config = ServerInfoConfig {
+            icons: vec![IconConfig {
+                src: "https://example.com/icon.png".to_string(),
+                mime_type: Some("image/png".to_string()),
+                sizes: Some(vec!["48x48".to_string(), "96x96".to_string()]),
+                theme: Some(IconThemeConfig::Light),
+            }],
+            ..Default::default()
+        };
+
+        let icons = config.icons().expect("configured icons should surface");
+        assert_eq!(icons.len(), 1);
+        assert_eq!(icons[0].src, "https://example.com/icon.png");
+        assert_eq!(icons[0].mime_type.as_deref(), Some("image/png"));
+        assert_eq!(
+            icons[0].sizes.as_deref(),
+            Some(&["48x48".to_string(), "96x96".to_string()][..]),
+        );
+        assert_eq!(icons[0].theme, Some(IconTheme::Light));
+    }
+
+    #[test]
+    fn icons_can_be_deserialized_from_yaml_with_minimal_fields() {
+        let yaml = r#"
+icons:
+  - src: "https://example.com/mark.svg"
+"#;
+        let config: ServerInfoConfig = serde_yaml::from_str(yaml).unwrap();
+
+        let icons = config.icons().expect("configured icons should surface");
+        assert_eq!(icons.len(), 1);
+        assert_eq!(icons[0].src, "https://example.com/mark.svg");
+        assert!(icons[0].mime_type.is_none());
+        assert!(icons[0].sizes.is_none());
+        assert!(icons[0].theme.is_none());
+    }
+
+    #[test]
+    fn icons_accept_https_and_data_sources() {
+        let yaml = r#"
+icons:
+  - src: "https://example.com/mark.svg"
+  - src: "data:image/png;base64,iVBORw0KGgo="
+  - src: "data:image/svg+xml,%3Csvg/%3E"
+"#;
+        let config: ServerInfoConfig = serde_yaml::from_str(yaml).unwrap();
+
+        assert_eq!(config.icons.len(), 3);
+    }
+
+    #[test]
+    fn icons_reject_unsafe_src_schemes() {
+        for src in [
+            "http://example.com/icon.png",
+            "javascript:alert(1)",
+            "file:///etc/passwd",
+            "ftp://example.com/icon.png",
+            "ws://example.com/icon",
+            "",
+            "example.com/icon.png",
+        ] {
+            let yaml = format!("icons:\n  - src: \"{src}\"\n");
+            let err = serde_yaml::from_str::<ServerInfoConfig>(&yaml)
+                .expect_err(&format!("scheme {src:?} should be rejected"));
+            assert!(
+                err.to_string()
+                    .contains("must be an `https://` URL with a host"),
+                "unexpected error for {src:?}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn icons_reject_malformed_https_and_data_sources() {
+        for src in [
+            "https://",
+            "https:///path",
+            "https://?query",
+            "data:",
+            "data:,",
+            "data:image/png,",
+            "data:text/plain;base64,Zm9v",
+            "data:image/;base64,AAAA",
+            "data:base64,AAAA",
+        ] {
+            let yaml = format!("icons:\n  - src: \"{src}\"\n");
+            let err = serde_yaml::from_str::<ServerInfoConfig>(&yaml)
+                .expect_err(&format!("malformed src {src:?} should be rejected"));
+            assert!(
+                err.to_string()
+                    .contains("must be an `https://` URL with a host"),
+                "unexpected error for {src:?}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn icons_accept_wxh_and_any_sizes() {
+        let yaml = r#"
+icons:
+  - src: "https://example.com/mark.svg"
+    sizes: ["48x48", "1024x1024", "any"]
+"#;
+        let config: ServerInfoConfig = serde_yaml::from_str(yaml).unwrap();
+
+        assert_eq!(
+            config.icons[0].sizes.as_deref(),
+            Some(
+                &[
+                    "48x48".to_string(),
+                    "1024x1024".to_string(),
+                    "any".to_string()
+                ][..]
+            ),
+        );
+    }
+
+    #[test]
+    fn icons_reject_malformed_size_entries() {
+        for size in ["48x", "x48", "fooxbar", "48X48", "48", "", "48x48x48"] {
+            let yaml = format!(
+                "icons:\n  - src: \"https://example.com/icon.svg\"\n    sizes: [\"{size}\"]\n"
+            );
+            let err = serde_yaml::from_str::<ServerInfoConfig>(&yaml)
+                .expect_err(&format!("size {size:?} should be rejected"));
+            assert!(
+                err.to_string().contains("must be `WxH`"),
+                "unexpected error for {size:?}: {err}"
+            );
+        }
     }
 }

--- a/crates/apollo-mcp-server/src/server_info.rs
+++ b/crates/apollo-mcp-server/src/server_info.rs
@@ -1,6 +1,7 @@
 use rmcp::model::{Icon, IconTheme};
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer};
+use url::Url;
 
 /// Server metadata configuration returned in the MCP initialize response.
 /// All fields are optional and fall back to defaults if not provided.
@@ -31,8 +32,11 @@ pub struct ServerInfoConfig {
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct IconConfig {
-    /// URI of the icon: an `https://` URL or a base64-encoded `data:` URI
+    /// URI of the icon, such as an `https://` URL or a base64-encoded `data:` URI.
+    /// Not `Url`: the value is advertised to clients verbatim, and `Url::parse`
+    /// normalizes its input
     #[serde(deserialize_with = "deserialize_icon_src")]
+    #[schemars(with = "Url")]
     pub src: String,
 
     /// MIME type of the icon, such as `image/png`. Set this when the source
@@ -42,7 +46,7 @@ pub struct IconConfig {
 
     /// Sizes the icon is available in, each `WxH` (e.g. `48x48`) or `any` for
     /// scalable formats
-    #[serde(default, deserialize_with = "deserialize_icon_sizes")]
+    #[serde(default)]
     pub sizes: Option<Vec<String>>,
 
     /// Background theme this icon is designed for. Omit to let the client use
@@ -51,84 +55,16 @@ pub struct IconConfig {
     pub theme: Option<IconThemeConfig>,
 }
 
-/// Reject `src` values whose scheme the MCP spec instructs clients to refuse
-/// (`javascript:`, `file:`, `ftp:`, `ws:`, and anything else that isn't
-/// `https://` or `data:`), and reject well-schemed but empty inputs like a
-/// bare `https://` or a `data:` URI without an `image/*` payload.
+/// `Icon.src` is `@format uri` in the MCP schema, so the one thing it has to do
+/// is parse as a URI.
 fn deserialize_icon_src<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let raw = String::deserialize(deserializer)?;
-    let ok = if let Some(rest) = raw.strip_prefix("https://") {
-        has_host(rest)
-    } else if let Some(rest) = raw.strip_prefix("data:") {
-        is_image_data_uri(rest)
-    } else {
-        false
-    };
-    if ok {
-        Ok(raw)
-    } else {
-        Err(serde::de::Error::custom(format!(
-            "server_info.icons[].src must be an `https://` URL with a host or an \
-             `image/*` `data:` URI (got {raw:?})"
-        )))
-    }
-}
-
-fn has_host(after_scheme: &str) -> bool {
-    let host_end = after_scheme
-        .find(['/', '?', '#'])
-        .unwrap_or(after_scheme.len());
-    !after_scheme[..host_end].is_empty()
-}
-
-/// A `data:` URI is `mediatype[;base64],data`. Accept it only when the media
-/// type is `image/<subtype>` and the payload is non-empty; the RFC allows
-/// omitting either but neither shape makes sense for an icon source.
-fn is_image_data_uri(after_scheme: &str) -> bool {
-    let (metadata, data) = match after_scheme.split_once(',') {
-        Some(pair) => pair,
-        None => return false,
-    };
-    if data.is_empty() {
-        return false;
-    }
-    let mime = metadata.split(';').next().unwrap_or("");
-    match mime.strip_prefix("image/") {
-        Some(subtype) => !subtype.is_empty(),
-        None => false,
-    }
-}
-
-fn deserialize_icon_sizes<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let raw = Option::<Vec<String>>::deserialize(deserializer)?;
-    if let Some(entries) = &raw {
-        for entry in entries {
-            if entry != "any" && !is_wxh_size(entry) {
-                return Err(serde::de::Error::custom(format!(
-                    "server_info.icons[].sizes entries must be `WxH` (e.g. `48x48`) or `any` (got {entry:?})"
-                )));
-            }
-        }
-    }
-    Ok(raw)
-}
-
-fn is_wxh_size(entry: &str) -> bool {
-    match entry.split_once('x') {
-        Some((width, height)) => {
-            !width.is_empty()
-                && !height.is_empty()
-                && width.bytes().all(|b| b.is_ascii_digit())
-                && height.bytes().all(|b| b.is_ascii_digit())
-        }
-        None => false,
-    }
+    use serde::de::Error;
+    let src = String::deserialize(deserializer)?;
+    Url::parse(&src).map_err(|e| D::Error::custom(format!("invalid icon src {src:?}: {e}")))?;
+    Ok(src)
 }
 
 /// Background theme an icon is designed for.
@@ -258,53 +194,31 @@ icons:
     }
 
     #[test]
-    fn icons_reject_unsafe_src_schemes() {
-        for src in [
-            "http://example.com/icon.png",
-            "javascript:alert(1)",
-            "file:///etc/passwd",
-            "ftp://example.com/icon.png",
-            "ws://example.com/icon",
-            "",
-            "example.com/icon.png",
-        ] {
+    fn icons_preserve_src_verbatim() {
+        let yaml = r#"
+icons:
+  - src: "https://example.com"
+"#;
+        let config: ServerInfoConfig = serde_yaml::from_str(yaml).unwrap();
+
+        assert_eq!(config.icons[0].src, "https://example.com");
+    }
+
+    #[test]
+    fn icons_reject_src_that_is_not_a_uri() {
+        for src in ["", "example.com/icon.png", "/icons/mark.svg", "https://"] {
             let yaml = format!("icons:\n  - src: \"{src}\"\n");
             let err = serde_yaml::from_str::<ServerInfoConfig>(&yaml)
-                .expect_err(&format!("scheme {src:?} should be rejected"));
+                .expect_err(&format!("src {src:?} should be rejected"));
             assert!(
-                err.to_string()
-                    .contains("must be an `https://` URL with a host"),
+                err.to_string().contains("invalid icon src"),
                 "unexpected error for {src:?}: {err}"
             );
         }
     }
 
     #[test]
-    fn icons_reject_malformed_https_and_data_sources() {
-        for src in [
-            "https://",
-            "https:///path",
-            "https://?query",
-            "data:",
-            "data:,",
-            "data:image/png,",
-            "data:text/plain;base64,Zm9v",
-            "data:image/;base64,AAAA",
-            "data:base64,AAAA",
-        ] {
-            let yaml = format!("icons:\n  - src: \"{src}\"\n");
-            let err = serde_yaml::from_str::<ServerInfoConfig>(&yaml)
-                .expect_err(&format!("malformed src {src:?} should be rejected"));
-            assert!(
-                err.to_string()
-                    .contains("must be an `https://` URL with a host"),
-                "unexpected error for {src:?}: {err}"
-            );
-        }
-    }
-
-    #[test]
-    fn icons_accept_wxh_and_any_sizes() {
+    fn icons_pass_sizes_through_unchanged() {
         let yaml = r#"
 icons:
   - src: "https://example.com/mark.svg"
@@ -325,17 +239,9 @@ icons:
     }
 
     #[test]
-    fn icons_reject_malformed_size_entries() {
-        for size in ["48x", "x48", "fooxbar", "48X48", "48", "", "48x48x48"] {
-            let yaml = format!(
-                "icons:\n  - src: \"https://example.com/icon.svg\"\n    sizes: [\"{size}\"]\n"
-            );
-            let err = serde_yaml::from_str::<ServerInfoConfig>(&yaml)
-                .expect_err(&format!("size {size:?} should be rejected"));
-            assert!(
-                err.to_string().contains("must be `WxH`"),
-                "unexpected error for {size:?}: {err}"
-            );
-        }
+    fn icons_reject_sizes_that_are_not_an_array_of_strings() {
+        let yaml = "icons:\n  - src: \"https://example.com/mark.svg\"\n    sizes: \"48x48\"\n";
+
+        assert!(serde_yaml::from_str::<ServerInfoConfig>(yaml).is_err());
     }
 }

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -570,12 +570,18 @@ Each icon entry supports the fields defined by the [MCP `Icon` object](https://m
 
 | Option      | Type       | Description                                                                                   |
 | :---------- | :--------- | :-------------------------------------------------------------------------------------------- |
-| `src`       | `string`   | URI of the icon: an `https://` URL or a base64-encoded `data:` URI. Required.                 |
+| `src`       | `string`   | URI of the icon, such as an `https://` URL or a base64-encoded `data:` URI. Required.       |
 | `mime_type` | `string`   | Explicit MIME type such as `image/png` or `image/svg+xml`. Optional.                          |
 | `sizes`     | `string[]` | Available sizes, each `WxH` (e.g. `48x48`) or `any` for scalable formats. Optional.           |
 | `theme`     | `string`   | Background theme the icon is designed for: `light` or `dark`. Omit this field to render with either theme. Optional. |
 
-No icon is advertised by default. Clients that support icon metadata should select the most appropriate entry for their UI. Clients that do not support icons may ignore this optional field.
+No icon is advertised by default. Clients that support icon metadata should select the most appropriate entry for their UI. Clients that do not support icons can ignore this optional field.
+
+<Note>
+
+The MCP specification makes the client responsible for refusing unsafe icon sources, such as `javascript:` URIs, and for sanitizing an icon before rendering it. The server advertises whatever you configure.
+
+</Note>
 
 ### Initialize instructions
 

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -579,7 +579,7 @@ No icon is advertised by default. Clients that support icon metadata should sele
 
 <Note>
 
-The MCP specification makes the client responsible for refusing unsafe icon sources, such as `javascript:` URIs, and for sanitizing an icon before rendering it. The server advertises whatever you configure.
+The MCP specification makes the client responsible for refusing unsafe icon sources, such as `javascript:` URIs, and for applying appropriate security precautions when rendering an icon. The server advertises whatever you configure.
 
 </Note>
 

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -549,6 +549,7 @@ These fields are under the top-level `server_info` key and configure the server 
 | `title`       | `string` | `"Apollo MCP Server"`                                                         | Human-readable title for the server (used for display in UIs)              |
 | `website_url` | `URL`    | `"https://www.apollographql.com/docs/apollo-mcp-server"`                      | URL to the server's website or documentation                               |
 | `description` | `string` | `"A Model Context Protocol (MCP) server for exposing GraphQL APIs as tools."` | A brief description of the server                                          |
+| `icons`       | `Icon[]` |                                                                               | Icons representing the server, for clients that display one                |
 
 All fields are optional. If not specified, sensible defaults are used. This is useful when wrapping Apollo MCP Server or branding it for specific use cases.
 
@@ -559,7 +560,22 @@ server_info:
   title: "Acme MCP Server"
   website_url: "https://acme.com/mcp-docs"
   description: "MCP server for Acme Corp's GraphQL API"
+  icons:
+    - src: "https://acme.com/mcp-icon.svg"
+      mime_type: "image/svg+xml"
+      sizes: ["any"]
 ```
+
+Each icon entry supports the fields defined by the [MCP `Icon` object](https://modelcontextprotocol.io/specification/2025-11-25/schema#icon):
+
+| Option      | Type       | Description                                                                                   |
+| :---------- | :--------- | :-------------------------------------------------------------------------------------------- |
+| `src`       | `string`   | URI of the icon: an `https://` URL or a base64-encoded `data:` URI. Required.                 |
+| `mime_type` | `string`   | Explicit MIME type such as `image/png` or `image/svg+xml`. Optional.                          |
+| `sizes`     | `string[]` | Available sizes, each `WxH` (e.g. `48x48`) or `any` for scalable formats. Optional.           |
+| `theme`     | `string`   | Background theme the icon is designed for: `light` or `dark`. Omit this field to render with either theme. Optional. |
+
+No icon is advertised by default. Clients that support icon metadata should select the most appropriate entry for their UI. Clients that do not support icons may ignore this optional field.
 
 ### Initialize instructions
 


### PR DESCRIPTION
Fixes #805.

> [!NOTE]
> Draft — opened alongside the linked enhancement issue so maintainers can
> see the shape of the proposal before signing off on the approach.
> CONTRIBUTING asks for agreement on features before code lands, so please
> read the issue first and I'll adjust or hold off based on your feedback.

## What

Adds an optional `server_info.icons` config option. Each entry maps to the
MCP [`Icon` object][mcp-icon] (`src` required, plus optional `mime_type`,
`sizes`, `theme`) and is forwarded verbatim on the `Implementation` returned
from `initialize`, via `rmcp`'s existing `Implementation::with_icons`
builder. No icon is advertised by default.

```yaml
server_info:
  name: "Acme MCP"
  icons:
    - src: "https://acme.com/mcp-icon.svg"
      mime_type: "image/svg+xml"
      sizes: ["any"]
```

## Why

MCP revision `2025-11-25` grew an `icons` field on `Implementation` so
hosts (Claude Desktop, Cursor, Zed, …) can render a per-server icon next
to the server's name. `apollo-mcp-server` already forwards every other
`Implementation` field (`name`, `version`, `title`, `description`,
`website_url`) but leaves `icons` unreachable, so downstream projects that
wrap this binary show up with the default host icon.

## How

- `ServerInfoConfig` grows an `icons: Vec<IconConfig>` field. `IconConfig`
  and `IconThemeConfig` mirror the SDK types 1:1, live in
  `crates/apollo-mcp-server/src/server_info.rs`, and use `#[serde(default,
  deny_unknown_fields)]` to match the surrounding config style.
- `From<&IconConfig> for rmcp::model::Icon` walks the optional fields via
  the SDK's builder methods.
- `Running::get_info` calls `impl_.with_icons(...)` when
  `ServerInfoConfig::icons()` returns `Some`.
- Docs updated in `docs/source/config-file.mdx` with the field table, YAML
  example, and per-field description.
- Changeset added at `.changeset/server_info_icons.md` (`minor`).

## Testing

New unit tests:

- `server_info::tests::icons_is_none_when_no_entries_configured`
- `server_info::tests::icons_forwards_optional_fields`
- `server_info::tests::icons_can_be_deserialized_from_yaml_with_minimal_fields`
- `server::states::running::tests::get_info::get_info_omits_icons_by_default`
- `server::states::running::tests::get_info::get_info_forwards_configured_icons_with_optional_fields`

Existing runtime snapshot (`it_merges_env_and_file_with_uplink_endpoints`)
updated for the new field. Full crate suite (`cargo test -p
apollo-mcp-server`) plus `cargo clippy --all-targets -- -D warnings` and
`cargo fmt --check` pass locally on the pinned `1.92.0` toolchain.

## Compatibility

Purely additive:

- Field is optional and defaults to an empty vec, so existing configs
  continue to serialize/deserialize unchanged.
- No new SDK surface — the `rmcp = 2.1` pin already exposes `Icon`,
  `IconTheme`, and `Implementation::with_icons`.
- Older clients (`2025-06-18` and earlier) ignore the field on the wire per
  the MCP spec, so operators can turn it on without waiting for host
  upgrades.

## Checklist

- [x] Tests added
- [x] Docs updated
- [x] Changeset added
- [ ] Approach agreed with maintainers (opened issue #805, waiting for
      sign-off before promoting from draft)

[mcp-icon]: https://modelcontextprotocol.io/specification/2025-11-25/schema#icon
