### PR TITLE
fix: disable ANSI styling for non-terminal logs

### DIFF
--- a/.changeset/disable_ansi_for_non_terminal_log_output.md
+++ b/.changeset/disable_ansi_for_non_terminal_log_output.md
@@ -4,4 +4,4 @@ default: patch
 
 # Disable ANSI styling for non-terminal log output
 
-Apollo MCP Server now emits ANSI-styled logs only when the output stream is connected to a terminal. Redirected stdout, stderr fallback, and configured log files use plain text, and a non-empty `NO_COLOR` environment variable disables ANSI styling for terminal output.
+Apollo MCP Server now emits ANSI-styled logs only when the output stream is connected to a terminal. Redirected output and configured log files use plain text, and a non-empty `NO_COLOR` environment variable disables ANSI styling for terminal output.

--- a/.changeset/disable_ansi_for_non_terminal_log_output.md
+++ b/.changeset/disable_ansi_for_non_terminal_log_output.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Disable ANSI styling for non-terminal log output
+
+Apollo MCP Server now emits ANSI-styled logs only when the output stream is connected to a terminal. Redirected stdout, stderr fallback, and configured log files use plain text, and a non-empty `NO_COLOR` environment variable disables ANSI styling for terminal output.

--- a/crates/apollo-mcp-server/src/runtime/logging.rs
+++ b/crates/apollo-mcp-server/src/runtime/logging.rs
@@ -11,6 +11,8 @@ mod trace_id_format;
 use log_rotation_kind::LogRotationKind;
 use schemars::JsonSchema;
 use serde::Deserialize;
+use std::ffi::OsStr;
+use std::io::IsTerminal;
 use std::path::PathBuf;
 use tracing::Level;
 use tracing_appender::rolling::RollingFileAppender;
@@ -73,6 +75,7 @@ impl Logging {
     }
 
     pub fn logging_layer(logging: &Logging) -> Result<LoggingLayerResult, anyhow::Error> {
+        let no_color = std::env::var_os("NO_COLOR");
         let (writer, guard, with_ansi) = match logging.path.clone() {
             Some(path) => std::fs::create_dir_all(&path)
                 .map(|_| path)
@@ -97,9 +100,17 @@ impl Logging {
                 })
                 .unwrap_or_else(|| {
                     eprintln!("Log file setup failed - falling back to stderr");
-                    (BoxMakeWriter::new(std::io::stderr), None, true)
+                    (
+                        BoxMakeWriter::new(std::io::stderr),
+                        None,
+                        should_use_ansi(std::io::stderr().is_terminal(), no_color.as_deref()),
+                    )
                 }),
-            None => (BoxMakeWriter::new(std::io::stdout), None, true),
+            None => (
+                BoxMakeWriter::new(std::io::stdout),
+                None,
+                should_use_ansi(std::io::stdout().is_terminal(), no_color.as_deref()),
+            ),
         };
 
         let inner_format = tracing_subscriber::fmt::format::Format::default()
@@ -114,6 +125,10 @@ impl Logging {
             guard,
         ))
     }
+}
+
+fn should_use_ansi(is_terminal: bool, no_color: Option<&OsStr>) -> bool {
+    is_terminal && no_color.is_none_or(OsStr::is_empty)
 }
 
 fn level(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
@@ -132,4 +147,30 @@ fn level(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
     }
 
     Level::json_schema(generator)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn ansi_is_enabled_for_terminal_output() {
+        assert!(should_use_ansi(true, None));
+    }
+
+    #[test]
+    fn ansi_is_disabled_for_non_terminal_output() {
+        assert!(!should_use_ansi(false, None));
+    }
+
+    #[test]
+    fn ansi_is_disabled_when_no_color_is_set() {
+        assert!(!should_use_ansi(true, Some(OsStr::new("1"))));
+    }
+
+    #[test]
+    fn ansi_is_enabled_when_no_color_is_empty() {
+        assert!(should_use_ansi(true, Some(OsStr::new(""))));
+    }
 }

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -207,6 +207,8 @@ These fields are under the top-level `logging` key.
 | `path`     | `FilePath`                                          |            | Directory for rolling log files. If not provided, logging outputs to `stdout`.      |
 | `rotation` | `oneOf ["minutely", "hourly", "daily", "never"]`    | `"hourly"` | The log file rotation interval (if file logging is used)                          |
 
+Logs written to a terminal use ANSI styling. Redirected output and configured log files use plain text. To disable ANSI styling in a terminal, set the [`NO_COLOR`](https://no-color.org/) environment variable to a non-empty value.
+
 <Caution>
 
 At the `debug` level, Apollo MCP Server logs the parsed configuration. Ordinary static header values, including values you populate through `${env.VAR}`, can appear in this output. The GraphOS key is redacted. Do not enable debug logging in production without protecting and restricting access to the resulting logs.

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -207,7 +207,7 @@ These fields are under the top-level `logging` key.
 | `path`     | `FilePath`                                          |            | Directory for rolling log files. If not provided, logging outputs to `stdout`.      |
 | `rotation` | `oneOf ["minutely", "hourly", "daily", "never"]`    | `"hourly"` | The log file rotation interval (if file logging is used)                          |
 
-Logs written to a terminal use ANSI styling. Redirected output and configured log files use plain text. To disable ANSI styling in a terminal, set the [`NO_COLOR`](https://no-color.org/) environment variable to a non-empty value.
+Logs written to a terminal use ANSI styling. Redirected output and configured log files use plain text. To disable ANSI styling in a terminal, set the `NO_COLOR` environment variable to a non-empty value. For details, see the [NO_COLOR website](https://no-color.org/).
 
 <Caution>
 


### PR DESCRIPTION
## Summary

- enable ANSI log styling only when stdout or stderr is attached to a terminal
- honor a non-empty `NO_COLOR` environment variable
- document the behavior and include the required patch changeset

Fixes #813

## Byte-level verification

Tested against current `main` at `5b5a079cabc266ca9be9818c94ad09cb45742061` (package version `1.17.0`).

Before this change:

```text
non-TTY stdout:                48 occurrences of b'\x1b['
non-TTY stdout + NO_COLOR=1:   48 occurrences of b'\x1b['
```

With this change:

```text
non-TTY stdout:                 0 occurrences of b'\x1b['
TTY stdout:                    48 occurrences of b'\x1b['
TTY stdout + NO_COLOR=1:        0 occurrences of b'\x1b['
```

The counts were obtained from captured output using:

```shell
python3 -c "print(open('out.bin','rb').read().count(b'\x1b['))"
```

This preserves styled output for interactive terminals while making redirected output suitable for container log collection pipelines.

## Testing

- `cargo test`
- `cargo clippy --all-targets -- --deny warnings`
- `cargo fmt`
- four focused ANSI decision tests
- runtime byte capture with non-TTY, TTY, and TTY plus `NO_COLOR=1`
