### PR TITLE
fix: annotate built-in introspection tools

### DIFF
--- a/.changeset/annotate_builtin_introspection_tools.md
+++ b/.changeset/annotate_builtin_introspection_tools.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Annotate built-in introspection tools
+
+The built-in `introspect`, `search`, `validate`, and `execute` tools now expose MCP `ToolAnnotations`. Schema-only tools are marked read-only, non-destructive, and idempotent. `execute` is read-only unless `mutation_mode` is `all`, and is always marked open-world because it calls the configured GraphQL endpoint.

--- a/crates/apollo-mcp-server/src/introspection/tools.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools.rs
@@ -5,3 +5,22 @@ pub(crate) mod execute;
 pub(crate) mod introspect;
 pub(crate) mod search;
 pub(crate) mod validate;
+
+use rmcp::model::{Tool, ToolAnnotations};
+
+/// Annotations for built-in tools that only read in-process schema state.
+///
+/// MCP: `readOnlyHint` means the tool does not modify its environment;
+/// `destructiveHint` is only meaningful when not read-only;
+/// `idempotentHint` means repeated calls with the same arguments have no
+/// additional effect; `openWorldHint` means the tool may interact with an
+/// open world of external entities.
+///
+/// introspect/search/validate operate against the locally held schema, so
+/// they are read-only, non-destructive, idempotent, and closed-world.
+fn annotate_schema_lookup_tool(tool: Tool) -> Tool {
+    let mut annotations = ToolAnnotations::new().read_only(true).destructive(false);
+    annotations.idempotent_hint = Some(true);
+    annotations.open_world_hint = Some(false);
+    tool.annotate(annotations)
+}

--- a/crates/apollo-mcp-server/src/introspection/tools.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools.rs
@@ -8,16 +8,7 @@ pub(crate) mod validate;
 
 use rmcp::model::{Tool, ToolAnnotations};
 
-/// Annotations for built-in tools that only read in-process schema state.
-///
-/// MCP: `readOnlyHint` means the tool does not modify its environment;
-/// `destructiveHint` is only meaningful when not read-only;
-/// `idempotentHint` means repeated calls with the same arguments have no
-/// additional effect; `openWorldHint` means the tool may interact with an
-/// open world of external entities.
-///
-/// introspect/search/validate operate against the locally held schema, so
-/// they are read-only, non-destructive, idempotent, and closed-world.
+/// Annotate built-in tools that only inspect local schema state.
 fn annotate_schema_lookup_tool(tool: Tool) -> Tool {
     let mut annotations = ToolAnnotations::new().read_only(true).destructive(false);
     annotations.idempotent_hint = Some(true);

--- a/crates/apollo-mcp-server/src/introspection/tools/execute.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/execute.rs
@@ -44,9 +44,7 @@ impl Execute {
             "Execute a GraphQL operation. Use the `introspect` tool to get information about the GraphQL schema. Always use the schema to create operations - do not try arbitrary operations. If available, first use the `validate` tool to validate operations. DO NOT try to execute introspection queries.",
             description_hint,
         );
-        // Execute talks to the configured GraphQL endpoint (`openWorldHint`).
-        // MutationMode::All is the only mode that lets this tool submit
-        // mutations; None and Explicit both reject ad hoc mutations here.
+        // Ad hoc mutations are only allowed in MutationMode::All.
         let permits_mutation = mutation_mode == MutationMode::All;
         let mut annotations = ToolAnnotations::new()
             .read_only(!permits_mutation)
@@ -278,38 +276,29 @@ mod tests {
         assert!(matches!(result, Err(ValidationError(msg)) if msg.contains("Invalid variables")));
     }
 
-    fn assert_annotations(execute: &Execute, read_only: bool, destructive: bool, idempotent: bool) {
-        let annotations = execute
-            .tool
-            .annotations
-            .as_ref()
-            .expect("execute tool must expose annotations");
-        assert_eq!(annotations.read_only_hint, Some(read_only));
-        assert_eq!(annotations.destructive_hint, Some(destructive));
-        assert_eq!(annotations.idempotent_hint, Some(idempotent));
-        assert_eq!(annotations.open_world_hint, Some(true));
-
-        let serialized = rmcp::serde_json::to_value(&execute.tool).expect("tool should serialize");
-        assert_eq!(serialized["annotations"]["readOnlyHint"], read_only);
-        assert_eq!(serialized["annotations"]["destructiveHint"], destructive);
-        assert_eq!(serialized["annotations"]["idempotentHint"], idempotent);
-        assert_eq!(serialized["annotations"]["openWorldHint"], true);
-    }
-
     #[test]
     fn execute_annotations_when_mutations_disabled() {
-        assert_annotations(&Execute::new(MutationMode::None, None), true, false, true);
-        // Explicit still rejects ad hoc mutations on this tool.
-        assert_annotations(
-            &Execute::new(MutationMode::Explicit, None),
-            true,
-            false,
-            true,
-        );
+        for mode in [MutationMode::None, MutationMode::Explicit] {
+            let annotations = Execute::new(mode, None)
+                .tool
+                .annotations
+                .expect("execute tool must expose annotations");
+            assert_eq!(annotations.read_only_hint, Some(true));
+            assert_eq!(annotations.destructive_hint, Some(false));
+            assert_eq!(annotations.idempotent_hint, Some(true));
+            assert_eq!(annotations.open_world_hint, Some(true));
+        }
     }
 
     #[test]
     fn execute_annotations_when_mutations_enabled() {
-        assert_annotations(&Execute::new(MutationMode::All, None), false, true, false);
+        let annotations = Execute::new(MutationMode::All, None)
+            .tool
+            .annotations
+            .expect("execute tool must expose annotations");
+        assert_eq!(annotations.read_only_hint, Some(false));
+        assert_eq!(annotations.destructive_hint, Some(true));
+        assert_eq!(annotations.idempotent_hint, Some(false));
+        assert_eq!(annotations.open_world_hint, Some(true));
     }
 }

--- a/crates/apollo-mcp-server/src/introspection/tools/execute.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/execute.rs
@@ -5,7 +5,7 @@ use crate::{
     schema_from_type,
 };
 use reqwest::header::{HeaderMap, HeaderValue};
-use rmcp::model::Tool;
+use rmcp::model::{Tool, ToolAnnotations};
 use rmcp::schemars::JsonSchema;
 use rmcp::serde_json::Value;
 use rmcp::{schemars, serde_json};
@@ -44,9 +44,20 @@ impl Execute {
             "Execute a GraphQL operation. Use the `introspect` tool to get information about the GraphQL schema. Always use the schema to create operations - do not try arbitrary operations. If available, first use the `validate` tool to validate operations. DO NOT try to execute introspection queries.",
             description_hint,
         );
+        // Execute talks to the configured GraphQL endpoint (`openWorldHint`).
+        // MutationMode::All is the only mode that lets this tool submit
+        // mutations; None and Explicit both reject ad hoc mutations here.
+        let permits_mutation = mutation_mode == MutationMode::All;
+        let mut annotations = ToolAnnotations::new()
+            .read_only(!permits_mutation)
+            .destructive(permits_mutation);
+        annotations.idempotent_hint = Some(!permits_mutation);
+        annotations.open_world_hint = Some(true);
+
         Self {
             mutation_mode,
-            tool: Tool::new(EXECUTE_TOOL_NAME, description, schema_from_type!(Input)),
+            tool: Tool::new(EXECUTE_TOOL_NAME, description, schema_from_type!(Input))
+                .annotate(annotations),
         }
     }
 }
@@ -265,5 +276,40 @@ mod tests {
 
         let result = Executable::variables(&execute, input);
         assert!(matches!(result, Err(ValidationError(msg)) if msg.contains("Invalid variables")));
+    }
+
+    fn assert_annotations(execute: &Execute, read_only: bool, destructive: bool, idempotent: bool) {
+        let annotations = execute
+            .tool
+            .annotations
+            .as_ref()
+            .expect("execute tool must expose annotations");
+        assert_eq!(annotations.read_only_hint, Some(read_only));
+        assert_eq!(annotations.destructive_hint, Some(destructive));
+        assert_eq!(annotations.idempotent_hint, Some(idempotent));
+        assert_eq!(annotations.open_world_hint, Some(true));
+
+        let serialized = rmcp::serde_json::to_value(&execute.tool).expect("tool should serialize");
+        assert_eq!(serialized["annotations"]["readOnlyHint"], read_only);
+        assert_eq!(serialized["annotations"]["destructiveHint"], destructive);
+        assert_eq!(serialized["annotations"]["idempotentHint"], idempotent);
+        assert_eq!(serialized["annotations"]["openWorldHint"], true);
+    }
+
+    #[test]
+    fn execute_annotations_when_mutations_disabled() {
+        assert_annotations(&Execute::new(MutationMode::None, None), true, false, true);
+        // Explicit still rejects ad hoc mutations on this tool.
+        assert_annotations(
+            &Execute::new(MutationMode::Explicit, None),
+            true,
+            false,
+            true,
+        );
+    }
+
+    #[test]
+    fn execute_annotations_when_mutations_enabled() {
+        assert_annotations(&Execute::new(MutationMode::All, None), false, true, false);
     }
 }

--- a/crates/apollo-mcp-server/src/introspection/tools/introspect.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/introspect.rs
@@ -57,7 +57,11 @@ impl Introspect {
             schema,
             allow_mutations: root_mutation_type.is_some(),
             minify,
-            tool: Tool::new(INTROSPECT_TOOL_NAME, description, schema_from_type!(Input)),
+            tool: super::annotate_schema_lookup_tool(Tool::new(
+                INTROSPECT_TOOL_NAME,
+                description,
+                schema_from_type!(Input),
+            )),
         }
     }
 
@@ -308,5 +312,20 @@ mod tests {
             content.contains("type Mutation"),
             "Should contain Mutation type definition"
         );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn introspect_tool_annotations_are_schema_lookup(schema: Arc<RwLock<Valid<Schema>>>) {
+        let introspect = Introspect::new(schema, None, None, false, None);
+        let annotations = introspect
+            .tool
+            .annotations
+            .as_ref()
+            .expect("introspect tool must expose annotations");
+        assert_eq!(annotations.read_only_hint, Some(true));
+        assert_eq!(annotations.destructive_hint, Some(false));
+        assert_eq!(annotations.idempotent_hint, Some(true));
+        assert_eq!(annotations.open_world_hint, Some(false));
     }
 }

--- a/crates/apollo-mcp-server/src/introspection/tools/introspect.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/introspect.rs
@@ -313,19 +313,4 @@ mod tests {
             "Should contain Mutation type definition"
         );
     }
-
-    #[rstest]
-    #[tokio::test]
-    async fn introspect_tool_annotations_are_schema_lookup(schema: Arc<RwLock<Valid<Schema>>>) {
-        let introspect = Introspect::new(schema, None, None, false, None);
-        let annotations = introspect
-            .tool
-            .annotations
-            .as_ref()
-            .expect("introspect tool must expose annotations");
-        assert_eq!(annotations.read_only_hint, Some(true));
-        assert_eq!(annotations.destructive_hint, Some(false));
-        assert_eq!(annotations.idempotent_hint, Some(true));
-        assert_eq!(annotations.open_world_hint, Some(false));
-    }
 }

--- a/crates/apollo-mcp-server/src/introspection/tools/search.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/search.rs
@@ -277,21 +277,4 @@ mod tests {
         assert!(description.contains("T=type,I=input,E=enum,U=union,F=interface"));
         assert!(description.contains("s=String,i=Int,f=Float,b=Boolean,d=ID"));
     }
-
-    #[rstest]
-    #[tokio::test]
-    async fn search_tool_annotations_are_schema_lookup(schema: Valid<Schema>) {
-        let schema = Arc::new(RwLock::new(schema));
-        let search = Search::new(schema, false, 1, 15_000_000, false, None)
-            .expect("Failed to create search tool");
-        let annotations = search
-            .tool
-            .annotations
-            .as_ref()
-            .expect("search tool must expose annotations");
-        assert_eq!(annotations.read_only_hint, Some(true));
-        assert_eq!(annotations.destructive_hint, Some(false));
-        assert_eq!(annotations.idempotent_hint, Some(true));
-        assert_eq!(annotations.open_world_hint, Some(false));
-    }
 }

--- a/crates/apollo-mcp-server/src/introspection/tools/search.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/search.rs
@@ -85,7 +85,11 @@ impl Search {
             allow_mutations,
             leaf_depth,
             minify,
-            tool: Tool::new(SEARCH_TOOL_NAME, description, schema_from_type!(Input)),
+            tool: super::annotate_schema_lookup_tool(Tool::new(
+                SEARCH_TOOL_NAME,
+                description,
+                schema_from_type!(Input),
+            )),
         })
     }
 
@@ -272,5 +276,22 @@ mod tests {
         // Should contain minification legend
         assert!(description.contains("T=type,I=input,E=enum,U=union,F=interface"));
         assert!(description.contains("s=String,i=Int,f=Float,b=Boolean,d=ID"));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn search_tool_annotations_are_schema_lookup(schema: Valid<Schema>) {
+        let schema = Arc::new(RwLock::new(schema));
+        let search = Search::new(schema, false, 1, 15_000_000, false, None)
+            .expect("Failed to create search tool");
+        let annotations = search
+            .tool
+            .annotations
+            .as_ref()
+            .expect("search tool must expose annotations");
+        assert_eq!(annotations.read_only_hint, Some(true));
+        assert_eq!(annotations.destructive_hint, Some(false));
+        assert_eq!(annotations.idempotent_hint, Some(true));
+        assert_eq!(annotations.open_world_hint, Some(false));
     }
 }

--- a/crates/apollo-mcp-server/src/introspection/tools/validate.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/validate.rs
@@ -137,18 +137,4 @@ mod tests {
         let result = validate.execute(input).await;
         assert!(result.is_error == Some(true));
     }
-
-    #[tokio::test]
-    async fn validate_tool_annotations_are_schema_lookup() {
-        let validate = Validate::new(SCHEMA.clone(), None);
-        let annotations = validate
-            .tool
-            .annotations
-            .as_ref()
-            .expect("validate tool must expose annotations");
-        assert_eq!(annotations.read_only_hint, Some(true));
-        assert_eq!(annotations.destructive_hint, Some(false));
-        assert_eq!(annotations.idempotent_hint, Some(true));
-        assert_eq!(annotations.open_world_hint, Some(false));
-    }
 }

--- a/crates/apollo-mcp-server/src/introspection/tools/validate.rs
+++ b/crates/apollo-mcp-server/src/introspection/tools/validate.rs
@@ -39,7 +39,11 @@ impl Validate {
         let description = append_description_hint(default_description, description_hint);
         Self {
             schema,
-            tool: Tool::new(VALIDATE_TOOL_NAME, description, schema_from_type!(Input)),
+            tool: super::annotate_schema_lookup_tool(Tool::new(
+                VALIDATE_TOOL_NAME,
+                description,
+                schema_from_type!(Input),
+            )),
         }
     }
 
@@ -132,5 +136,19 @@ mod tests {
         });
         let result = validate.execute(input).await;
         assert!(result.is_error == Some(true));
+    }
+
+    #[tokio::test]
+    async fn validate_tool_annotations_are_schema_lookup() {
+        let validate = Validate::new(SCHEMA.clone(), None);
+        let annotations = validate
+            .tool
+            .annotations
+            .as_ref()
+            .expect("validate tool must expose annotations");
+        assert_eq!(annotations.read_only_hint, Some(true));
+        assert_eq!(annotations.destructive_hint, Some(false));
+        assert_eq!(annotations.idempotent_hint, Some(true));
+        assert_eq!(annotations.open_world_hint, Some(false));
     }
 }

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -1843,19 +1843,25 @@ mod tests {
             let introspect = annotation_of(INTROSPECT_TOOL_NAME);
             assert_eq!(introspect.read_only_hint, Some(true));
             assert_eq!(introspect.destructive_hint, Some(false));
+            assert_eq!(introspect.idempotent_hint, Some(true));
             assert_eq!(introspect.open_world_hint, Some(false));
 
             let search = annotation_of(SEARCH_TOOL_NAME);
             assert_eq!(search.read_only_hint, Some(true));
             assert_eq!(search.destructive_hint, Some(false));
+            assert_eq!(search.idempotent_hint, Some(true));
+            assert_eq!(search.open_world_hint, Some(false));
 
             let validate = annotation_of(VALIDATE_TOOL_NAME);
             assert_eq!(validate.read_only_hint, Some(true));
             assert_eq!(validate.destructive_hint, Some(false));
+            assert_eq!(validate.idempotent_hint, Some(true));
+            assert_eq!(validate.open_world_hint, Some(false));
 
             let execute = annotation_of(EXECUTE_TOOL_NAME);
             assert_eq!(execute.read_only_hint, Some(true));
             assert_eq!(execute.destructive_hint, Some(false));
+            assert_eq!(execute.idempotent_hint, Some(true));
             assert_eq!(execute.open_world_hint, Some(true));
         }
 

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -1803,6 +1803,63 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn builtin_tools_expose_annotations_in_tools_list() {
+            let schema = Schema::parse("type Query { id: String }", "schema.graphql")
+                .unwrap()
+                .validate()
+                .unwrap();
+            let schema = Arc::new(RwLock::new(schema));
+            let mut running = test_running(schema.clone());
+            running.execute_tool = Some(Execute::new(MutationMode::None, None));
+            running.introspect_tool = Some(Introspect::new(
+                schema.clone(),
+                Some("Query".to_string()),
+                None,
+                false,
+                None,
+            ));
+            running.validate_tool = Some(Validate::new(schema.clone(), None));
+            running.search_tool = Some(
+                Search::new(schema, false, 1, 15_000_000, false, None)
+                    .expect("search tool should index"),
+            );
+
+            let result = running
+                .list_tools_impl(Extensions::new(), None, None)
+                .await
+                .unwrap();
+
+            let annotation_of = |name: &str| {
+                result
+                    .tools
+                    .iter()
+                    .find(|tool| tool.name == name)
+                    .and_then(|tool| tool.annotations.clone())
+                    .unwrap_or_else(|| {
+                        panic!("{name} should appear in tools/list with annotations")
+                    })
+            };
+
+            let introspect = annotation_of(INTROSPECT_TOOL_NAME);
+            assert_eq!(introspect.read_only_hint, Some(true));
+            assert_eq!(introspect.destructive_hint, Some(false));
+            assert_eq!(introspect.open_world_hint, Some(false));
+
+            let search = annotation_of(SEARCH_TOOL_NAME);
+            assert_eq!(search.read_only_hint, Some(true));
+            assert_eq!(search.destructive_hint, Some(false));
+
+            let validate = annotation_of(VALIDATE_TOOL_NAME);
+            assert_eq!(validate.read_only_hint, Some(true));
+            assert_eq!(validate.destructive_hint, Some(false));
+
+            let execute = annotation_of(EXECUTE_TOOL_NAME);
+            assert_eq!(execute.read_only_hint, Some(true));
+            assert_eq!(execute.destructive_hint, Some(false));
+            assert_eq!(execute.open_world_hint, Some(true));
+        }
+
+        #[tokio::test]
         async fn list_tools_with_valid_app_parameter() {
             let running = running_with_apps(
                 AppResource::Single(AppResourceSource::Local("test".to_string())),


### PR DESCRIPTION
Fixes #793.

The built-in execute, introspect, search, and validate tools currently omit MCP tool annotations, so clients that use readOnlyHint for approval decisions cannot distinguish the read-only tools.

This adds annotations to the built-ins:

- introspect, search, and validate are read-only, non-destructive, idempotent, and closed-world.
- execute is read-only unless mutation_mode: all allows ad hoc mutations, and remains open-world because it calls the configured GraphQL endpoint.

Also adds coverage at the tools/list boundary.

### Testing

- cargo test -p apollo-mcp-server
- cargo clippy --all-targets -- --deny warnings
- cargo fmt --check