### PR TITLE
feat: support the server/discover RPC

### DIFF
--- a/.changeset/cap_protocol_version_negotiation_on_stateful_transports.md
+++ b/.changeset/cap_protocol_version_negotiation_on_stateful_transports.md
@@ -4,6 +4,6 @@ default: patch
 
 # Cap protocol version negotiation on stateful transports
 
-On stateful streamable HTTP sessions and stdio, rmcp's handshake re-negotiated the protocol version after this server's `initialize` handler ran, echoing back any version in rmcp's `KNOWN_VERSIONS` regardless of whether this server implements it. A stateful client requesting `2026-07-28`, a revision rmcp has a constant for but this server doesn't yet handle (SEP-2243 headers and discovery), was told the server supports it and could send follow-up requests the server couldn't serve.
+On stateful streamable HTTP sessions and stdio, rmcp's handshake re-negotiated the protocol version after this server's `initialize` handler ran, echoing back any version in rmcp's `KNOWN_VERSIONS` regardless of whether this server implements it. A stateful client requesting `2026-07-28`, a revision rmcp has a constant for but this server doesn't yet handle (SEP-2243 headers and `subscriptions/listen`), was told the server supports it and could send follow-up requests the server couldn't serve.
 
 The rmcp upgrade to 3.2.0 adds a `ServerHandler::supported_protocol_versions` hook that rmcp's re-negotiation now consults on every transport. This server overrides it to the versions it actually implements, so the cap at the newest supported protocol version now holds consistently across stateless and stateful streamable HTTP and stdio.

--- a/.changeset/support_the_server_discover_rpc.md
+++ b/.changeset/support_the_server_discover_rpc.md
@@ -1,0 +1,13 @@
+---
+default: minor
+---
+
+# Support the `server/discover` RPC
+
+The server now answers `server/discover`, the RPC MCP 2026-07-28 requires for up-front protocol version selection. Clients can call it before any other request — including as the opening message on stdio, where it doubles as a backward-compatibility probe — without first establishing a session.
+
+The response advertises the same capabilities the `initialize` response returns, lists the protocol versions the server implements, and carries the server's implementation metadata — name, version, title, website URL, and description — sourced from the `server_info` configuration key. Note that discovery carries this metadata in the result's `_meta` under `io.modelcontextprotocol/serverInfo` rather than a top-level field.
+
+`server/discover` can now be listed in `skip_token_validation.methods` to allow it without authentication, and the deprecated `allow_anonymous_mcp_discovery` flag now folds it in alongside `initialize`, `tools/list`, and `resources/list`, since `server/discover` may be a client's first MCP request.
+
+The newest protocol version the server negotiates remains `2025-11-25`. Answering `server/discover` does not by itself make the server conformant with `2026-07-28`: that revision also replaces the standalone notification stream with `subscriptions/listen`, which this server does not yet implement. Advertising `2026-07-28` while the server announces `tools.listChanged` would promise change notifications it has no way to deliver, so the supported-version list stays capped until that work lands.

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -1880,8 +1880,8 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
 
         #[tokio::test]
         async fn server_discover_without_token_allowed_when_enabled() {
-            // `server/discover` precedes `initialize` in the inline lifecycle,
-            // so a client has no way to authenticate before calling it.
+            // `server/discover` may be a client's first MCP request, so this
+            // option permits it anonymously when anonymous discovery is enabled.
             let app = discovery_router(true);
             let req = Request::builder()
                 .method("POST")

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -618,8 +618,12 @@ const JWKS_MIN_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
 
 /// The methods the deprecated `allow_anonymous_mcp_discovery` flag allows,
 /// which it now expresses as `skip_token_validation.methods`.
-const DEPRECATED_ANONYMOUS_DISCOVERY_METHODS: &[&str] =
-    &["initialize", "server/discover", "tools/list", "resources/list"];
+const DEPRECATED_ANONYMOUS_DISCOVERY_METHODS: &[&str] = &[
+    "initialize",
+    "server/discover",
+    "tools/list",
+    "resources/list",
+];
 
 /// Maximum body size to buffer when peeking at the JSON-RPC method or tool
 /// name. A discovery request such as `tools/list` is under 100 bytes, but a
@@ -2509,7 +2513,12 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
                 let resolved = config.resolve_skip_token_validation().unwrap();
                 assert_eq!(
                     resolved.methods,
-                    vec!["initialize", "tools/list", "resources/list"]
+                    vec![
+                        "initialize",
+                        "server/discover",
+                        "tools/list",
+                        "resources/list"
+                    ]
                 );
             }
 

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -619,7 +619,7 @@ const JWKS_MIN_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
 /// The methods the deprecated `allow_anonymous_mcp_discovery` flag allows,
 /// which it now expresses as `skip_token_validation.methods`.
 const DEPRECATED_ANONYMOUS_DISCOVERY_METHODS: &[&str] =
-    &["initialize", "tools/list", "resources/list"];
+    &["initialize", "server/discover", "tools/list", "resources/list"];
 
 /// Maximum body size to buffer when peeking at the JSON-RPC method or tool
 /// name. A discovery request such as `tools/list` is under 100 bytes, but a
@@ -1872,6 +1872,36 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
 
         fn resources_list_body() -> Body {
             Body::from(r#"{"jsonrpc":"2.0","id":1,"method":"resources/list"}"#)
+        }
+
+        fn server_discover_body() -> Body {
+            Body::from(r#"{"jsonrpc":"2.0","id":1,"method":"server/discover"}"#)
+        }
+
+        #[tokio::test]
+        async fn server_discover_without_token_allowed_when_enabled() {
+            // `server/discover` precedes `initialize` in the inline lifecycle,
+            // so a client has no way to authenticate before calling it.
+            let app = discovery_router(true);
+            let req = Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .body(server_discover_body())
+                .unwrap();
+            let res = app.oneshot(req).await.unwrap();
+            assert_eq!(res.status(), StatusCode::OK);
+        }
+
+        #[tokio::test]
+        async fn server_discover_without_token_rejected_when_disabled() {
+            let app = discovery_router(false);
+            let req = Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .body(server_discover_body())
+                .unwrap();
+            let res = app.oneshot(req).await.unwrap();
+            assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
         }
 
         #[tokio::test]

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -679,7 +679,8 @@ impl ServerHandler for Running {
     /// Narrows rmcp's re-negotiation (run on every transport after
     /// `initialize`) to [`SUPPORTED_PROTOCOL_VERSIONS`], so it can't advertise
     /// a newer version from rmcp's `KNOWN_VERSIONS` (e.g. `2026-07-28`'s
-    /// SEP-2243 headers and discovery, which this server doesn't yet handle).
+    /// SEP-2243 headers and `subscriptions/listen`, which this server doesn't
+    /// yet handle).
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
         Cow::Borrowed(&SUPPORTED_PROTOCOL_VERSIONS)
     }
@@ -3010,8 +3011,8 @@ mod integration_tests {
         #[tokio::test]
         async fn stateless_caps_at_max_supported_when_client_requests_newer_known_version() {
             // rmcp has a constant for 2026-07-28, but this server doesn't
-            // implement that revision (SEP-2243 headers, discovery). The
-            // stateless path must cap at the max supported version rather
+            // implement that revision (SEP-2243 headers, subscriptions/listen).
+            // The stateless path must cap at the max supported version rather
             // than advertise a version whose follow-up requests we can't
             // handle.
             let running = create_running_with_output_schema();
@@ -3988,6 +3989,231 @@ mod integration_tests {
                 "set_level should not return an error: {body}"
             );
             assert_eq!(body["result"], json!({}));
+        }
+    }
+
+    /// `server/discover`: called before any other request, without a session.
+    mod discover {
+        use std::sync::Arc;
+
+        use axum::body::Body;
+        use http::{Request, StatusCode};
+        use http_body_util::BodyExt;
+        use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+        use rmcp::transport::{StreamableHttpServerConfig, StreamableHttpService};
+        use serde_json::json;
+        use tokio::sync::RwLock;
+        use tower::ServiceExt;
+
+        use super::*;
+        use crate::server_info::ServerInfoConfig;
+
+        /// Discovery has no top-level `serverInfo`; it lives in `_meta`.
+        const SERVER_INFO_META_KEY: &str = "io.modelcontextprotocol/serverInfo";
+
+        fn create_test_running(server_info: ServerInfoConfig) -> Running {
+            let schema =
+                apollo_compiler::Schema::parse_and_validate("type Query { hello: String }", "test")
+                    .unwrap();
+            Running {
+                schema: Arc::new(RwLock::new(schema)),
+                operations: Arc::new(RwLock::new(vec![])),
+                apps: vec![],
+                prompts: vec![],
+                headers: http::HeaderMap::new(),
+                forward_headers: vec![],
+                endpoint: url::Url::parse("http://localhost:4000").unwrap(),
+                execute_tool: None,
+                introspect_tool: None,
+                search_tool: None,
+                explorer_tool: None,
+                validate_tool: None,
+                custom_scalar_map: None,
+                peers: Arc::new(RwLock::new(vec![])),
+                cancellation_token: CancellationToken::new(),
+                mutation_mode: MutationMode::None,
+                disable_type_description: false,
+                disable_schema_description: false,
+                enable_output_schema: false,
+                disable_auth_token_passthrough: false,
+                descriptions: HashMap::new(),
+                annotations: HashMap::new(),
+                health_check: None,
+                server_info,
+                instructions: None,
+                rhai_engine: Arc::new(parking_lot::Mutex::new(RhaiEngine::new("rhai"))),
+            }
+        }
+
+        fn create_service(
+            running: Running,
+            session_manager: Arc<LocalSessionManager>,
+        ) -> StreamableHttpService<Running, LocalSessionManager> {
+            StreamableHttpService::new(
+                move || Ok(running.clone()),
+                session_manager,
+                StreamableHttpServerConfig::default().with_legacy_session_mode(true),
+            )
+        }
+
+        /// Carries no session id, so `_meta` and the `MCP-Protocol-Version`
+        /// header have to be self-contained.
+        fn build_discover_request(protocol_version: &str) -> Request<Body> {
+            let body = json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "server/discover",
+                "params": {
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion": protocol_version,
+                        "io.modelcontextprotocol/clientCapabilities": {},
+                        "io.modelcontextprotocol/clientInfo": {
+                            "name": "test-client",
+                            "version": "1.0.0"
+                        }
+                    }
+                }
+            });
+            Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("Host", "localhost:8000")
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json, text/event-stream")
+                .header("MCP-Protocol-Version", protocol_version)
+                // SEP-2243 standard header.
+                .header("Mcp-Method", "server/discover")
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        }
+
+        async fn discover(running: Running) -> serde_json::Value {
+            let service = create_service(running, LocalSessionManager::default().into());
+            let response = service
+                .oneshot(build_discover_request(
+                    MAX_SUPPORTED_PROTOCOL_VERSION.as_str(),
+                ))
+                .await
+                .unwrap();
+            let status = response.status();
+            let bytes = response.into_body().collect().await.unwrap().to_bytes();
+            let body_str = String::from_utf8_lossy(&bytes);
+            let body: serde_json::Value = body_str
+                .lines()
+                .find_map(|line| serde_json::from_str(line.strip_prefix("data: ")?).ok())
+                .or_else(|| serde_json::from_str(&body_str).ok())
+                .unwrap_or_else(|| panic!("no JSON data found in response: {body_str}"));
+            assert_eq!(status, StatusCode::OK, "discover failed: {body}");
+            body["result"].clone()
+        }
+
+        #[tokio::test]
+        async fn returns_expected_result_shape() {
+            let running = create_test_running(ServerInfoConfig {
+                description: Some("Custom fleet description".to_string()),
+                ..Default::default()
+            });
+            let expected_capabilities = serde_json::to_value(running.get_info().capabilities)
+                .expect("capabilities serialize");
+
+            let result = discover(running).await;
+
+            assert_eq!(result["resultType"], "complete");
+            // `initialize` returns `get_info()` untouched but for the
+            // negotiated version, so this is the capability set both report.
+            assert_eq!(result["capabilities"], expected_capabilities);
+            assert!(result["ttlMs"].is_u64(), "ttlMs must be a number: {result}");
+            assert!(
+                result["cacheScope"].is_string(),
+                "cacheScope must be a string: {result}"
+            );
+
+            let server_info = &result["_meta"][SERVER_INFO_META_KEY];
+            assert_eq!(server_info["description"], "Custom fleet description");
+            assert_eq!(server_info["name"], "Apollo MCP Server");
+            assert!(
+                server_info["version"].is_string(),
+                "serverInfo must carry a version: {server_info}"
+            );
+        }
+
+        #[tokio::test]
+        async fn advertises_backward_compatible_protocol_versions() {
+            let result = discover(create_test_running(ServerInfoConfig::default())).await;
+
+            let versions: Vec<&str> = result["supportedVersions"]
+                .as_array()
+                .expect("supportedVersions must be an array")
+                .iter()
+                .map(|version| version.as_str().expect("versions are strings"))
+                .collect();
+
+            assert!(
+                versions.contains(&"2025-11-25"),
+                "must advertise 2025-11-25 for backward compat: {versions:?}"
+            );
+            // rmcp reuses this list as the ceiling on `initialize`
+            // negotiation, so advertising a version promises we can serve it.
+            assert!(
+                !versions
+                    .iter()
+                    .any(|version| *version > MAX_SUPPORTED_PROTOCOL_VERSION.as_str()),
+                "must not advertise past our cap: {versions:?}"
+            );
+        }
+
+        /// stdio has no headers to negotiate with, so discovery as the opening
+        /// message is the only compatibility probe available there.
+        #[tokio::test]
+        async fn works_as_opener_over_stdio() {
+            use rmcp::ServiceExt as _;
+            use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
+
+            let (server_io, client_io) = tokio::io::duplex(4096);
+            let (server_r, server_w) = tokio::io::split(server_io);
+            let (client_r, mut client_w) = tokio::io::split(client_io);
+
+            let server = tokio::spawn(async move {
+                let service = create_test_running(ServerInfoConfig::default())
+                    .serve((server_r, server_w))
+                    .await
+                    .expect("stdio serve should accept a discover opener");
+                let _ = service.waiting().await;
+            });
+
+            let mut request = json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "server/discover",
+                "params": {
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion":
+                            MAX_SUPPORTED_PROTOCOL_VERSION.as_str(),
+                        "io.modelcontextprotocol/clientCapabilities": {},
+                    }
+                }
+            })
+            .to_string();
+            request.push('\n');
+            client_w.write_all(request.as_bytes()).await.unwrap();
+
+            let mut reader = BufReader::new(client_r);
+            let mut response_line = String::new();
+            reader.read_line(&mut response_line).await.unwrap();
+            let body: serde_json::Value = serde_json::from_str(&response_line).unwrap();
+
+            assert!(
+                body.get("error").is_none(),
+                "discover over stdio returned an error: {body}"
+            );
+            let versions = body["result"]["supportedVersions"]
+                .as_array()
+                .expect("supportedVersions must be an array");
+            assert!(versions.iter().any(|version| version == "2025-11-25"));
+
+            drop(reader);
+            drop(client_w);
+            let _ = server.await;
         }
     }
 }

--- a/docs/source/auth.mdx
+++ b/docs/source/auth.mdx
@@ -451,6 +451,6 @@ The server logs a deprecation warning at startup. Setting both `allow_anonymous_
 
 <Note>
 
-`server/discover` may be the client's first MCP request, so this deprecated flag maps onto it too. The same applies if you list `server/discover` directly in `skip_token_validation.methods`.
+`server/discover` might be the client's first MCP request, so this deprecated flag maps onto it too. The same applies if you list `server/discover` directly in your `skip_token_validation.methods` configuration.
 
 </Note>

--- a/docs/source/auth.mdx
+++ b/docs/source/auth.mdx
@@ -442,8 +442,15 @@ transport:
     skip_token_validation:
       methods:
         - initialize
+        - server/discover
         - tools/list
         - resources/list
 ```
 
 The server logs a deprecation warning at startup. Setting both `allow_anonymous_mcp_discovery` and `skip_token_validation.methods` is an error, because the two would describe the same list twice. Remove the flag and list the methods you want.
+
+<Note>
+
+`server/discover` may be the client's first MCP request, so this deprecated flag maps onto it too. The same applies if you list `server/discover` directly in `skip_token_validation.methods`.
+
+</Note>

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -423,7 +423,7 @@ Authentication is available only for `streamable_http`. Because the default tran
 | `skip_token_validation.methods`   | `List<string>`        | `[]`          | JSON-RPC method names that skip token validation when the request carries no `Authorization` header. Methods that name one of many items, such as `tools/call` and `resources/read`, are rejected. See [skipping token validation](/apollo-mcp-server/auth#skipping-token-validation). |
 | `skip_token_validation.tools`     | `List<string>`        | `[]`          | Tool names that skip token validation when the request carries no `Authorization` header. See [skipping token validation](/apollo-mcp-server/auth#skipping-token-validation).                                    |
 | `skip_token_validation.headers`   | `List<string>`        | `[]`          | HTTP header names that skip token validation when the request carries no `Authorization` header. A later layer authenticates the request. See [skipping token validation](/apollo-mcp-server/auth#skipping-token-validation). |
-| `allow_anonymous_mcp_discovery`   | `bool`                | `false`       | **Deprecated.** Use `skip_token_validation.methods` instead. Enabling this is the same as listing `initialize`, `tools/list`, and `resources/list` there. Setting both is an error.                              |
+| `allow_anonymous_mcp_discovery`   | `bool`                | `false`       | **Deprecated.** Use `skip_token_validation.methods` instead. Enabling this is the same as listing `initialize`, `server/discover`, `tools/list`, and `resources/list` there. Setting both is an error.           |
 | `discovery_timeout`               | `Duration`            | `5s`          | Timeout for authorization server metadata discovery requests. Supports human-readable durations (e.g., "5s", "10s", "30s").                                                                                      |
 | `discovery_headers`               | `Map<string, string>` | `{}`          | Custom headers to include in OIDC discovery and JWKS requests. Useful when upstream OAuth servers or WAFs require headers like `User-Agent`. See [discovery headers](/apollo-mcp-server/auth#discovery-headers). |
 | `tls.ca_cert`                     | `string`              |               | Path to a CA certificate to trust (PEM format).                                                                                                                                                                  |
@@ -485,6 +485,7 @@ transport:
     # skip_token_validation:
     #   methods:
     #     - tools/list
+    #     - server/discover
     #   tools:
     #     - PublicTool
     #   headers:


### PR DESCRIPTION
Clients can call `server/discover` before any other request to select a compatible protocol version, including as the opening message on stdio where it acts as a backward-compatibility probe.

rmcp 3.1.4 routes the request and builds the response from the same `get_info()` that backs `initialize`, so the discovery response carries matching capabilities and the `server_info` metadata by construction. Adds tests pinning that, and allows `server/discover` without authentication when `allow_anonymous_mcp_discovery` is enabled, since it precedes `initialize` and clients cannot authenticate before calling it.

The supported-version list stays capped at 2025-11-25. Advertising 2026-07-28 would also commit `initialize` to negotiating it, and that revision replaces the standalone notification stream with `subscriptions/listen`, which is not implemented here — a client would read the advertised `tools.listChanged` capability and never receive those notifications.

<!-- https://apollographql.atlassian.net/browse/AMS-510 -->