### PR TITLE
feat: add scope-based tool discovery

### DIFF
--- a/.changeset/scope_aware_tool_discovery.md
+++ b/.changeset/scope_aware_tool_discovery.md
@@ -1,0 +1,9 @@
+---
+default: minor
+---
+
+# Filter tool discovery by caller OAuth scopes
+
+Add the opt-in `transport.auth.filter_tools_by_scope` setting to filter
+`tools/list` using the per-tool requirements configured under
+`overrides.required_scopes`. Call-time scope enforcement remains unchanged.

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -220,6 +220,14 @@ pub struct Config {
     #[serde(default)]
     pub allow_anonymous_mcp_discovery: bool,
 
+    /// Filter `tools/list` results using `overrides.required_scopes`.
+    ///
+    /// Tools without an entry in `required_scopes` remain visible. Authenticated
+    /// clients only see protected tools when their token satisfies the configured
+    /// scope requirement; anonymous discovery clients only see unprotected tools.
+    #[serde(default)]
+    pub filter_tools_by_scope: bool,
+
     /// TLS configuration for connecting to OAuth servers
     #[serde(default)]
     pub tls: TlsConfig,
@@ -298,6 +306,43 @@ fn build_resource_metadata_url(resource: &Url) -> Url {
     url
 }
 
+/// Shared per-operation scope policy used by request authorization and tool discovery.
+#[derive(Clone, Debug)]
+pub(crate) struct OperationScopePolicy {
+    required_scopes: Arc<HashMap<String, OperationRequiredScopes>>,
+    filter_tools_list: bool,
+}
+
+impl OperationScopePolicy {
+    pub(crate) fn new(
+        required_scopes: HashMap<String, OperationRequiredScopes>,
+        filter_tools_list: bool,
+    ) -> Self {
+        Self {
+            required_scopes: Arc::new(required_scopes),
+            filter_tools_list,
+        }
+    }
+
+    pub(crate) fn filters_tools_list(&self) -> bool {
+        self.filter_tools_list
+    }
+
+    pub(crate) fn allows_tool(&self, op_name: &str, token_scopes: &[String]) -> bool {
+        self.required_scopes
+            .get(op_name)
+            .is_none_or(|required| required.is_satisfied_by(token_scopes))
+    }
+
+    fn is_empty(&self) -> bool {
+        self.required_scopes.is_empty()
+    }
+
+    fn required_for(&self, op_name: &str) -> Option<&OperationRequiredScopes> {
+        self.required_scopes.get(op_name)
+    }
+}
+
 /// Internal state for the auth middleware, containing both config and pre-built HTTP client
 #[derive(Clone)]
 struct AuthState {
@@ -309,10 +354,8 @@ struct AuthState {
     /// Upstream OAuth server URLs, parsed once at startup so the per-request
     /// path neither re-parses nor allocates them.
     auth_servers: Arc<[Url]>,
-    /// Per-operation required scopes, keyed by the exact MCP tool name used in
-    /// `tools/call`.
-    /// Missing keys impose no additional restriction beyond the global requirement.
-    required_scopes: Arc<HashMap<String, OperationRequiredScopes>>,
+    /// Per-operation scope requirements and discovery filtering behavior.
+    operation_scope_policy: OperationScopePolicy,
 }
 
 impl Config {
@@ -379,7 +422,10 @@ impl Config {
             client,
             resource_metadata_url,
             auth_servers: Arc::from(auth_servers),
-            required_scopes: Arc::new(required_scopes),
+            operation_scope_policy: OperationScopePolicy::new(
+                required_scopes,
+                self.filter_tools_by_scope,
+            ),
             inflight: Arc::new(Mutex::new(IssuerFetchState::default())),
             jwks_cache: Arc::new(RwLock::new(HashMap::new())),
         };
@@ -457,21 +503,19 @@ async fn extract_body(request: &mut Request) -> Result<JsonRpcBodyPeek, StatusCo
 
 /// Checks if a `tools/call` request is missing required scopes for the named operation.
 ///
-/// Returns `Some(required_scopes)` when the token lacks one or more of the operation's
-/// required scopes, and `None` when the check passes or does not apply. It does not apply
-/// to non-`tools/call` methods, requests without a tool name, or tools with no entry in
-/// `required_scopes` — those are governed only by the global scope requirement.
+/// Returns `Some(required_scopes)` if the token is missing scopes, `None` if the request
+/// is allowed to proceed (wrong method, unknown operation, or scopes satisfied).
 fn missing_scopes_for_operation<'a>(
     peek: &JsonRpcBodyPeek,
-    required_scopes: &'a HashMap<String, OperationRequiredScopes>,
+    policy: &'a OperationScopePolicy,
     token_scopes: &[String],
 ) -> Option<&'a OperationRequiredScopes> {
     if peek.method != "tools/call" {
         return None;
     }
     let op_name = peek.params.as_ref()?.name.as_deref()?;
-    let required = required_scopes.get(op_name)?;
-    if required.is_satisfied_by(token_scopes) {
+    let required = policy.required_for(op_name)?;
+    if policy.allows_tool(op_name, token_scopes) {
         return None;
     }
     Some(required)
@@ -526,7 +570,7 @@ async fn oauth_validate(
     // anonymous discovery or per-operation scope checks.
     let body_peek = if request.method() == http::Method::POST
         && ((auth_config.allow_anonymous_mcp_discovery && token.is_none())
-            || !auth_state.required_scopes.is_empty())
+            || !auth_state.operation_scope_policy.is_empty())
     {
         match extract_body(&mut request).await {
             Ok(peek) => Some(peek),
@@ -538,6 +582,13 @@ async fn oauth_validate(
     } else {
         None
     };
+
+    // Make the scope policy available to the MCP handler. For anonymous
+    // discovery there is intentionally no ValidToken extension, so tools/list
+    // evaluates the policy with an empty scope set.
+    request
+        .extensions_mut()
+        .insert(auth_state.operation_scope_policy.clone());
 
     // Anonymous discovery bypass: when enabled, unauthenticated POST requests
     // whose body contains a discovery method (e.g. tools/list) skip auth entirely.
@@ -616,10 +667,14 @@ async fn oauth_validate(
         }
     }
 
-    // Per-operation requirements add to the global check and always require
-    // every listed scope, independently of the global `scope_mode`.
+    // Per-operation requirements add to the global check and use their configured
+    // all-of or alternative-group semantics independently of global `scope_mode`.
     if let Some(required) = body_peek.as_ref().and_then(|peek| {
-        missing_scopes_for_operation(peek, &auth_state.required_scopes, &valid_token.scopes)
+        missing_scopes_for_operation(
+            peek,
+            &auth_state.operation_scope_policy,
+            &valid_token.scopes,
+        )
     }) {
         let challenge_scopes = required.challenge_scopes();
         tracing::warn!(
@@ -674,6 +729,7 @@ mod tests {
             scope_mode: ScopeMode::default(),
             disable_auth_token_passthrough: false,
             allow_anonymous_mcp_discovery: false,
+            filter_tools_by_scope: false,
             tls: TlsConfig::default(),
             discovery_timeout: None,
             discovery_headers: HeaderMap::new(),
@@ -692,7 +748,7 @@ mod tests {
             client: reqwest::Client::new(),
             resource_metadata_url,
             auth_servers: Arc::from(auth_servers),
-            required_scopes: Arc::new(HashMap::new()),
+            operation_scope_policy: OperationScopePolicy::new(HashMap::new(), false),
             inflight: Arc::new(Mutex::new(IssuerFetchState::default())),
             jwks_cache: Arc::new(RwLock::new(HashMap::new())),
         }
@@ -709,7 +765,7 @@ mod tests {
         required_scopes: HashMap<String, OperationRequiredScopes>,
     ) -> Router {
         let mut auth_state = test_auth_state(config);
-        auth_state.required_scopes = Arc::new(required_scopes);
+        auth_state.operation_scope_policy = OperationScopePolicy::new(required_scopes, false);
         Router::new()
             .route("/test", get(|| async { "ok" }))
             .layer(from_fn_with_state(auth_state, oauth_validate))
@@ -1778,6 +1834,37 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
             let config: Config = serde_yaml::from_str(yaml).unwrap();
             assert!(!config.allow_anonymous_mcp_discovery);
         }
+
+        #[test]
+        fn yaml_with_filter_tools_by_scope() {
+            let yaml = r#"
+                servers:
+                  - http://localhost:1234
+                audiences:
+                  - test-audience
+                resource: http://localhost:4000
+                scopes:
+                  - read
+                filter_tools_by_scope: true
+            "#;
+            let config: Config = serde_yaml::from_str(yaml).unwrap();
+            assert!(config.filter_tools_by_scope);
+        }
+
+        #[test]
+        fn yaml_defaults_filter_tools_by_scope_to_false() {
+            let yaml = r#"
+                servers:
+                  - http://localhost:1234
+                audiences:
+                  - test-audience
+                resource: http://localhost:4000
+                scopes:
+                  - read
+            "#;
+            let config: Config = serde_yaml::from_str(yaml).unwrap();
+            assert!(!config.filter_tools_by_scope);
+        }
     }
 
     mod per_operation_scope_enforcement {
@@ -1818,6 +1905,10 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
             )])
         }
 
+        fn policy() -> OperationScopePolicy {
+            OperationScopePolicy::new(required(), true)
+        }
+
         fn tools_call_peek(op: &str) -> JsonRpcBodyPeek {
             JsonRpcBodyPeek {
                 method: "tools/call".to_string(),
@@ -1831,8 +1922,8 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
         fn returns_required_scopes_when_token_missing_scope() {
             let peek = tools_call_peek("RestrictedOp");
             let scopes = vec!["other:scope".to_string()];
-            let required = required();
-            let result = missing_scopes_for_operation(&peek, &required, &scopes);
+            let policy = policy();
+            let result = missing_scopes_for_operation(&peek, &policy, &scopes);
             assert_eq!(
                 result,
                 Some(
@@ -1846,8 +1937,8 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
         fn returns_none_when_token_has_required_scope() {
             let peek = tools_call_peek("RestrictedOp");
             let scopes = vec!["sensitive:read".to_string(), "other:scope".to_string()];
-            let required = required();
-            let result = missing_scopes_for_operation(&peek, &required, &scopes);
+            let policy = policy();
+            let result = missing_scopes_for_operation(&peek, &policy, &scopes);
             assert!(result.is_none());
         }
 
@@ -1855,8 +1946,8 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
         fn returns_none_when_token_satisfies_one_scope_alternative() {
             let peek = tools_call_peek("RestrictedOp");
             let scopes = vec!["admin".to_string(), "other:scope".to_string()];
-            let required = alternative_required();
-            let result = missing_scopes_for_operation(&peek, &required, &scopes);
+            let policy = OperationScopePolicy::new(alternative_required(), true);
+            let result = missing_scopes_for_operation(&peek, &policy, &scopes);
             assert!(result.is_none());
         }
 
@@ -1868,8 +1959,8 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
                 "tenant:admin".to_string(),
                 "other:scope".to_string(),
             ];
-            let required = alternative_required();
-            let result = missing_scopes_for_operation(&peek, &required, &scopes);
+            let policy = OperationScopePolicy::new(alternative_required(), true);
+            let result = missing_scopes_for_operation(&peek, &policy, &scopes);
             assert!(result.is_none());
         }
 
@@ -1877,8 +1968,8 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
         fn returns_required_scopes_when_token_satisfies_no_complete_alternative() {
             let peek = tools_call_peek("RestrictedOp");
             let scopes = vec!["sensitive:read".to_string()];
-            let required = alternative_required();
-            let result = missing_scopes_for_operation(&peek, &required, &scopes);
+            let policy = OperationScopePolicy::new(alternative_required(), true);
+            let result = missing_scopes_for_operation(&peek, &policy, &scopes);
             assert_eq!(
                 result,
                 Some(
@@ -1897,8 +1988,8 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
             // the second) without ever completing either.
             let peek = tools_call_peek("RestrictedOp");
             let scopes = vec!["scope:a".to_string(), "scope:c".to_string()];
-            let required = overlapping_multi_scope_alternatives();
-            let result = missing_scopes_for_operation(&peek, &required, &scopes);
+            let policy = OperationScopePolicy::new(overlapping_multi_scope_alternatives(), true);
+            let result = missing_scopes_for_operation(&peek, &policy, &scopes);
             assert!(result.is_some());
         }
 
@@ -1911,16 +2002,16 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
                 "scope:c".to_string(),
                 "scope:d".to_string(),
             ];
-            let required = overlapping_multi_scope_alternatives();
-            let result = missing_scopes_for_operation(&peek, &required, &scopes);
+            let policy = OperationScopePolicy::new(overlapping_multi_scope_alternatives(), true);
+            let result = missing_scopes_for_operation(&peek, &policy, &scopes);
             assert!(result.is_none());
         }
 
         #[test]
-        fn returns_none_for_unrestricted_operation() {
+        fn returns_none_for_unrestricted_tool() {
             let peek = tools_call_peek("PublicOp");
-            let required = required();
-            let result = missing_scopes_for_operation(&peek, &required, &[]);
+            let policy = policy();
+            let result = missing_scopes_for_operation(&peek, &policy, &[]);
             assert!(result.is_none());
         }
 
@@ -1930,17 +2021,36 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
                 method: "tools/list".to_string(),
                 params: None,
             };
-            let required = required();
-            let result = missing_scopes_for_operation(&peek, &required, &[]);
+            let policy = policy();
+            let result = missing_scopes_for_operation(&peek, &policy, &[]);
             assert!(result.is_none());
         }
 
         #[test]
         fn returns_none_when_required_scopes_map_is_empty() {
             let peek = tools_call_peek("RestrictedOp");
-            let empty = HashMap::new();
-            let result = missing_scopes_for_operation(&peek, &empty, &[]);
+            let policy = OperationScopePolicy::new(HashMap::new(), true);
+            let result = missing_scopes_for_operation(&peek, &policy, &[]);
             assert!(result.is_none());
+        }
+
+        #[test]
+        fn policy_requires_all_configured_scopes() {
+            let policy = OperationScopePolicy::new(
+                HashMap::from([(
+                    "RestrictedOp".to_string(),
+                    OperationRequiredScopes::new(vec![vec![
+                        "read".to_string(),
+                        "admin".to_string(),
+                    ]])
+                    .unwrap(),
+                )]),
+                true,
+            );
+
+            assert!(!policy.allows_tool("RestrictedOp", &["read".to_string()]));
+            assert!(policy.allows_tool("RestrictedOp", &["read".to_string(), "admin".to_string()]));
+            assert!(policy.allows_tool("PublicOp", &[]));
         }
     }
 }

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -31,6 +31,7 @@ use url::Url;
 use crate::apps::app::AppTarget;
 use crate::apps::resource::{attach_resource_mime_type, get_app_resource};
 use crate::apps::tool::{attach_tool_metadata, find_and_execute_app_tool, make_tool_private};
+use crate::auth::{OperationScopePolicy, ValidToken};
 use crate::generated::telemetry::{TelemetryAttribute, TelemetryMetric};
 use crate::meter;
 use crate::operations::{execute_operation, find_and_execute_operation};
@@ -283,6 +284,20 @@ impl Running {
             .build()
             .add(1, &[]);
 
+        let operation_scope_context =
+            extensions
+                .get::<axum::http::request::Parts>()
+                .and_then(|parts| {
+                    let policy = parts.extensions.get::<OperationScopePolicy>()?;
+                    policy.filters_tools_list().then(|| {
+                        let token_scopes = parts
+                            .extensions
+                            .get::<ValidToken>()
+                            .map(|token| token.scopes.clone())
+                            .unwrap_or_default();
+                        (policy.clone(), token_scopes)
+                    })
+                });
         let app_param = extract_app_param(&extensions);
         let app_target = AppTarget::try_from((extensions, client_capabilities))?;
 
@@ -335,6 +350,12 @@ impl Running {
                     .collect(),
             )
         };
+
+        if let Some((policy, token_scopes)) = operation_scope_context {
+            result
+                .tools
+                .retain(|tool| policy.allows_tool(tool.name.as_ref(), &token_scopes));
+        }
 
         if !self.client_supports_output_schema(protocol_version) {
             for tool in &mut result.tools {
@@ -1791,8 +1812,48 @@ mod tests {
 
     mod list_tools {
         use crate::apps::app::{AppResource, AppResourceSource};
+        use crate::scope_requirements::OperationRequiredScopes;
+        use axum_extra::headers::{Authorization, authorization::Bearer};
 
         use super::*;
+
+        fn scope_extensions(
+            required_scopes: HashMap<String, OperationRequiredScopes>,
+            filter_tools_list: bool,
+            token_scopes: Option<Vec<String>>,
+        ) -> Extensions {
+            let mut extensions = Extensions::new();
+            let request = axum::http::Request::builder()
+                .uri("http://localhost?app=MyApp")
+                .body(())
+                .unwrap();
+            let (mut parts, _) = request.into_parts();
+            parts.extensions.insert(OperationScopePolicy::new(
+                required_scopes,
+                filter_tools_list,
+            ));
+            if let Some(scopes) = token_scopes {
+                parts.extensions.insert(ValidToken {
+                    token: Authorization::<Bearer>::bearer("test-token").unwrap(),
+                    scopes,
+                });
+            }
+            extensions.insert(parts);
+            extensions
+        }
+
+        fn required_scopes(
+            tool_name: &str,
+            scopes: &[&str],
+        ) -> HashMap<String, OperationRequiredScopes> {
+            HashMap::from([(
+                tool_name.to_string(),
+                OperationRequiredScopes::new(vec![
+                    scopes.iter().map(|scope| (*scope).to_string()).collect(),
+                ])
+                .expect("test scope requirement must be non-empty"),
+            )])
+        }
 
         #[tokio::test]
         async fn list_tools_without_app_parameter() {
@@ -1809,6 +1870,72 @@ mod tests {
 
             assert_eq!(result.tools.len(), 0);
             assert_eq!(result.next_cursor, None);
+        }
+
+        #[tokio::test]
+        async fn filters_tools_using_authenticated_token_scopes() {
+            let running = running_with_apps(
+                AppResource::Single(AppResourceSource::Local("test".to_string())),
+                None,
+                None,
+            );
+            let required = required_scopes("GetId", &["app:read"]);
+
+            let hidden = running
+                .list_tools_impl(
+                    scope_extensions(required.clone(), true, Some(vec![])),
+                    None,
+                    None,
+                )
+                .await
+                .unwrap();
+            let visible = running
+                .list_tools_impl(
+                    scope_extensions(required, true, Some(vec!["app:read".to_string()])),
+                    None,
+                    None,
+                )
+                .await
+                .unwrap();
+
+            assert!(hidden.tools.is_empty());
+            assert_eq!(visible.tools.len(), 1);
+            assert_eq!(visible.tools[0].name, "GetId");
+        }
+
+        #[tokio::test]
+        async fn anonymous_discovery_hides_tools_with_required_scopes() {
+            let running = running_with_apps(
+                AppResource::Single(AppResourceSource::Local("test".to_string())),
+                None,
+                None,
+            );
+            let required = required_scopes("GetId", &["app:read"]);
+
+            let result = running
+                .list_tools_impl(scope_extensions(required, true, None), None, None)
+                .await
+                .unwrap();
+
+            assert!(result.tools.is_empty());
+        }
+
+        #[tokio::test]
+        async fn disabled_scope_filter_preserves_existing_tool_list() {
+            let running = running_with_apps(
+                AppResource::Single(AppResourceSource::Local("test".to_string())),
+                None,
+                None,
+            );
+            let required = required_scopes("GetId", &["app:read"]);
+
+            let result = running
+                .list_tools_impl(scope_extensions(required, false, Some(vec![])), None, None)
+                .await
+                .unwrap();
+
+            assert_eq!(result.tools.len(), 1);
+            assert_eq!(result.tools[0].name, "GetId");
         }
 
         #[tokio::test]

--- a/docs/source/auth.mdx
+++ b/docs/source/auth.mdx
@@ -172,6 +172,7 @@ transport:
   auth:
     servers:
       - https://auth.example.com
+    filter_tools_by_scope: true
 overrides:
   required_scopes:
     GetUser:
@@ -217,6 +218,8 @@ The server doesn't validate `required_scopes` keys against the current tool list
 Treat `required_scopes` as a manually maintained security policy. Compare its keys with the live `tools/list` response during deployment and whenever you add, remove, rename, or hot-reload operations.
 
 </Caution>
+
+By default, `tools/list` continues to return all tools after global authorization succeeds. Set `transport.auth.filter_tools_by_scope: true` to apply `required_scopes` during discovery as well. Authenticated clients then see a protected tool only when their token satisfies its flat requirement or at least one configured alternative group. Tools without an entry remain visible. If `allow_anonymous_mcp_discovery` is also enabled, anonymous clients see only tools without a `required_scopes` entry. This filtering changes discovery only; `tools/call` remains the authorization boundary and still returns HTTP 403 for insufficient scopes.
 
 ## HTTP error responses
 

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -421,6 +421,7 @@ Authentication is available only for `streamable_http`. Because the default tran
 | `scope_mode`                      | `string`              | `require_all` | Global scope enforcement mode: `disabled`, `require_all`, or `require_any`. Per-operation requirements always use all-of semantics.                                                                              |
 | `disable_auth_token_passthrough`  | `bool`                | `false`       | Disable automatic propagation of the validated Authorization header to the downstream API. When passthrough is disabled, headers forwarded via `forward_headers` are left untouched; when passthrough is active, the validated token replaces a forwarded `Authorization` header. |
 | `allow_anonymous_mcp_discovery`   | `bool`                | `false`       | Allow unauthenticated access to MCP discovery methods (`initialize`, `tools/list`, `resources/list`). See [anonymous MCP discovery](/apollo-mcp-server/auth#anonymous-mcp-discovery).                            |
+| `filter_tools_by_scope`           | `bool`                | `false`       | Filter `tools/list` using `overrides.required_scopes`. Authenticated clients see tools their token can call; anonymous discovery clients see only tools without required scopes.                           |
 | `discovery_timeout`               | `Duration`            | `5s`          | Timeout for authorization server metadata discovery requests. Supports human-readable durations (e.g., "5s", "10s", "30s").                                                                                      |
 | `discovery_headers`               | `Map<string, string>` | `{}`          | Custom headers to include in OIDC discovery and JWKS requests. Useful when upstream OAuth servers or WAFs require headers like `User-Agent`. See [discovery headers](/apollo-mcp-server/auth#discovery-headers). |
 | `tls.ca_cert`                     | `string`              |               | Path to a CA certificate to trust (PEM format).                                                                                                                                                                  |
@@ -480,6 +481,9 @@ transport:
     # Allow unauthenticated clients to call MCP discovery methods
     # (initialize, tools/list, resources/list). All other methods still require auth.
     # allow_anonymous_mcp_discovery: false
+
+    # Filter tools/list using overrides.required_scopes. Disabled by default.
+    # filter_tools_by_scope: false
 
     # Optional TLS configuration for connecting to OAuth servers
     tls:

--- a/docs/source/define-tools.mdx
+++ b/docs/source/define-tools.mdx
@@ -249,7 +249,7 @@ Config-level descriptions take priority over comment-based and schema-generated 
 
 ### Config-level scope requirements
 
-To restrict which OAuth scopes are required to call a specific tool, add a `required_scopes` map under the `overrides` config key. When a token lacks the required scopes, Apollo MCP Server returns `403 Forbidden`, and the client can re-authorize with a compatible scope set. See [per-operation scope requirements](/apollo-mcp-server/auth#per-operation-scope-requirements) for details.
+To restrict which OAuth scopes are required to call a specific tool, add a `required_scopes` map under the `overrides` config key. When a token lacks the required scopes, Apollo MCP Server returns `403 Forbidden`, and the client can re-authorize with a compatible scope set. Set `transport.auth.filter_tools_by_scope: true` to also hide unavailable tools from `tools/list`. See [per-operation scope requirements](/apollo-mcp-server/auth#per-operation-scope-requirements) for details.
 
 ```yaml title="Config with per-operation scope requirements" {4-12}
 operations:


### PR DESCRIPTION
## Summary

- Add the opt-in `transport.auth.filter_tools_by_scope` setting to filter GraphQL operation tools returned by `tools/list` using `overrides.required_scopes`.
- Preserve backward compatibility: filtering defaults to `false`, so existing discovery behavior remains unchanged unless explicitly enabled.
- Filter anonymous discovery to unrestricted tools when anonymous MCP discovery and scope filtering are both enabled.
- Support existing flat all-of requirements and alternative scope groups.
- Keep `tools/call` as the authorization boundary; discovery filtering does not replace call-time enforcement.

## Implementation details

- Add `filter_tools_by_scope` to the transport authentication configuration with a Serde default of `false`.
- Introduce a shared `OperationScopePolicy` containing the configured per-operation requirements and the discovery-filtering flag.
- Reuse `OperationRequiredScopes::is_satisfied_by` for discovery and call-time checks so both paths retain identical all-of and alternative-group semantics.
- Attach the scope policy to authenticated HTTP requests through request extensions.
- Read validated token scopes from `ValidToken` during `tools/list`; when anonymous discovery bypasses token validation, evaluate the policy with an empty scope set.
- Filter the completed tool list only when the opt-in flag is enabled. Tools without a `required_scopes` entry remain visible.
- Leave the existing `tools/call` HTTP 403 enforcement in place as the security boundary.
- Add configuration, authenticated discovery, anonymous discovery, disabled-filter, all-of, and alternative-scope coverage, plus documentation and a minor changeset.

## Validation

Built the repository Docker image successfully, confirming that the `apollo-mcp-server` release binary and its dependencies compile with these changes.

End-to-end testing used:

- A self-contained local OAuth server providing discovery metadata, an HS512 JWKS, and signed JWTs with configurable scopes.
- The bundled TheSpaceDevs schema and operations.
- Three scope-protected tools and one unrestricted tool.
- `filter_tools_by_scope: true`.

| Token scopes | Tools returned by `tools/list` |
| --- | --- |
| None | `ExploreCelestialBodies` |
| `astronauts.read` | Public tool plus `GetAstronautDetails` and `GetAstronautsCurrentlyInSpace` |
| `launches.read` | Public tool plus `ListUpcomingLaunches` |
| Both scopes | All four tools |
| Unrelated scope | `ExploreCelestialBodies` |

Additional validation results:

- Image smoke test: `docker run --rm apollo-mcp-server:scope-aware --version` returned `apollo-mcp-server 1.17.0`.
- Full workspace test suite: 910 passed, 0 failed.
- `cargo fmt --check`: passed.
- `cargo clippy --all-targets -- --deny warnings`: passed.
- `cargo clippy -p apollo-mcp-server --lib -- --deny warnings`: passed.
- `cargo doc --no-deps`: passed, with one pre-existing warning in unchanged `host_validation.rs` documentation.
- `git diff --check`: passed.
- A direct `tools/call` to a hidden, unauthorized tool still returned HTTP 403.
- With `filter_tools_by_scope: false`, its default value, a token without scopes still discovered all four tools.
- Anonymous discovery returned only unrestricted tools.
- Flat requirements required every configured scope.
- Alternative requirements exposed a tool when any complete alternative group was satisfied; scopes from incomplete alternatives could not be mixed.
- The standalone repository image was tested rather than the separate internal image that depends on unavailable Okta and Router infrastructure.
- Test containers and the mock OAuth server were removed afterward.

## Prior discussion

The implementation proposal received the required sign-off from Ganesh

Closes #474