### PR TITLE
fix: use anyOf for output schema unions

### DIFF
--- a/.changeset/fix_output_schema_null_union_for_unmapped_scalars.md
+++ b/.changeset/fix_output_schema_null_union_for_unmapped_scalars.md
@@ -2,8 +2,10 @@
 default: patch
 ---
 
-# Fix output schema rejecting null for unmapped custom scalars and unknown types
+# Fix output schema rejecting valid responses for nullable and union fields
 
 With `overrides.enable_output_schema: true`, a nullable field's `outputSchema` wrapped its inner schema in `oneOf` with `{"type": "null"}`. For a custom scalar with no entry in `custom_scalars`, and for unknown types, the inner schema is `{}`, which already accepts `null`. A `null` response value therefore matched both `oneOf` branches, and MCP clients that validate `structuredContent` against `outputSchema` (such as the official MCP TypeScript SDK) rejected the tool result.
 
-The null union now uses `anyOf`, which is the correct keyword for a union and has no such overlap requirement.
+GraphQL union fields had the same problem. Each inline fragment became a `oneOf` branch, but the member schemas carry no discriminator and allow extra properties, so a response object that satisfies more than one fragment (for example when fragments select the same field names) also failed validation.
+
+Both places now use `anyOf`, which is the correct keyword for a union and has no exclusivity requirement.

--- a/.changeset/fix_output_schema_null_union_for_unmapped_scalars.md
+++ b/.changeset/fix_output_schema_null_union_for_unmapped_scalars.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+# Fix output schema rejecting null for unmapped custom scalars and unknown types
+
+With `overrides.enable_output_schema: true`, a nullable field's `outputSchema` wrapped its inner schema in `oneOf` with `{"type": "null"}`. For a custom scalar with no entry in `custom_scalars`, and for unknown types, the inner schema is `{}`, which already accepts `null`. A `null` response value therefore matched both `oneOf` branches, and MCP clients that validate `structuredContent` against `outputSchema` (such as the official MCP TypeScript SDK) rejected the tool result.
+
+The null union now uses `anyOf`, which is the correct keyword for a union and has no such overlap requirement.

--- a/crates/apollo-mcp-server/src/operations/operation.rs
+++ b/crates/apollo-mcp-server/src/operations/operation.rs
@@ -817,7 +817,7 @@ mod tests {
                             "type": String("object"),
                             "properties": Object {
                                 "id": Object {
-                                    "oneOf": Array [
+                                    "anyOf": Array [
                                         Object {
                                             "type": String("string"),
                                         },
@@ -961,7 +961,7 @@ mod tests {
                             "type": String("object"),
                             "properties": Object {
                                 "id": Object {
-                                    "oneOf": Array [
+                                    "anyOf": Array [
                                         Object {
                                             "type": String("string"),
                                         },
@@ -1116,7 +1116,7 @@ mod tests {
                             "type": String("object"),
                             "properties": Object {
                                 "id": Object {
-                                    "oneOf": Array [
+                                    "anyOf": Array [
                                         Object {
                                             "type": String("string"),
                                         },
@@ -1274,7 +1274,7 @@ mod tests {
                             "type": String("object"),
                             "properties": Object {
                                 "id": Object {
-                                    "oneOf": Array [
+                                    "anyOf": Array [
                                         Object {
                                             "type": String("string"),
                                         },
@@ -1429,7 +1429,7 @@ mod tests {
                             "type": String("object"),
                             "properties": Object {
                                 "id": Object {
-                                    "oneOf": Array [
+                                    "anyOf": Array [
                                         Object {
                                             "type": String("string"),
                                         },
@@ -1581,7 +1581,7 @@ mod tests {
                             "type": String("object"),
                             "properties": Object {
                                 "id": Object {
-                                    "oneOf": Array [
+                                    "anyOf": Array [
                                         Object {
                                             "type": String("string"),
                                         },
@@ -1743,7 +1743,7 @@ mod tests {
                             "type": String("object"),
                             "properties": Object {
                                 "id": Object {
-                                    "oneOf": Array [
+                                    "anyOf": Array [
                                         Object {
                                             "type": String("string"),
                                         },
@@ -1920,7 +1920,7 @@ mod tests {
                             "type": String("object"),
                             "properties": Object {
                                 "id": Object {
-                                    "oneOf": Array [
+                                    "anyOf": Array [
                                         Object {
                                             "type": String("string"),
                                         },
@@ -2062,7 +2062,7 @@ mod tests {
                             "type": String("object"),
                             "properties": Object {
                                 "id": Object {
-                                    "oneOf": Array [
+                                    "anyOf": Array [
                                         Object {
                                             "type": String("string"),
                                         },
@@ -2319,7 +2319,7 @@ mod tests {
                             "type": String("object"),
                             "properties": Object {
                                 "id": Object {
-                                    "oneOf": Array [
+                                    "anyOf": Array [
                                         Object {
                                             "type": String("string"),
                                         },
@@ -2464,7 +2464,7 @@ mod tests {
                             "type": String("object"),
                             "properties": Object {
                                 "id": Object {
-                                    "oneOf": Array [
+                                    "anyOf": Array [
                                         Object {
                                             "type": String("string"),
                                         },
@@ -2613,7 +2613,7 @@ mod tests {
                             "type": String("object"),
                             "properties": Object {
                                 "id": Object {
-                                    "oneOf": Array [
+                                    "anyOf": Array [
                                         Object {
                                             "type": String("string"),
                                         },
@@ -2751,7 +2751,7 @@ mod tests {
                             "type": String("object"),
                             "properties": Object {
                                 "id": Object {
-                                    "oneOf": Array [
+                                    "anyOf": Array [
                                         Object {
                                             "type": String("string"),
                                         },
@@ -3293,7 +3293,7 @@ mod tests {
                             "properties": Object {
                                 "field": Object {
                                     "description": String("the Query.field field"),
-                                    "oneOf": Array [
+                                    "anyOf": Array [
                                         Object {
                                             "type": String("string"),
                                         },
@@ -3425,7 +3425,7 @@ mod tests {
                             "type": String("object"),
                             "properties": Object {
                                 "id": Object {
-                                    "oneOf": Array [
+                                    "anyOf": Array [
                                         Object {
                                             "type": String("string"),
                                         },
@@ -4003,7 +4003,7 @@ mod tests {
                             "type": String("object"),
                             "properties": Object {
                                 "id": Object {
-                                    "oneOf": Array [
+                                    "anyOf": Array [
                                         Object {
                                             "type": String("string"),
                                         },
@@ -4196,7 +4196,7 @@ mod tests {
                             "type": String("object"),
                             "properties": Object {
                                 "id": Object {
-                                    "oneOf": Array [
+                                    "anyOf": Array [
                                         Object {
                                             "type": String("string"),
                                         },
@@ -4406,7 +4406,7 @@ mod tests {
                                 "type": String("object"),
                                 "properties": Object {
                                     "id": Object {
-                                        "oneOf": Array [
+                                        "anyOf": Array [
                                             Object {
                                                 "type": String("string"),
                                             },
@@ -4539,7 +4539,7 @@ mod tests {
                                 "type": String("object"),
                                 "properties": Object {
                                     "id": Object {
-                                        "oneOf": Array [
+                                        "anyOf": Array [
                                             Object {
                                                 "type": String("string"),
                                             },
@@ -4672,7 +4672,7 @@ mod tests {
                             "type": String("object"),
                             "properties": Object {
                                 "id": Object {
-                                    "oneOf": Array [
+                                    "anyOf": Array [
                                         Object {
                                             "type": String("string"),
                                         },

--- a/crates/apollo-mcp-server/src/operations/schema_walker/output.rs
+++ b/crates/apollo-mcp-server/src/operations/schema_walker/output.rs
@@ -316,7 +316,8 @@ fn type_to_output_schema(
             })
         }
 
-        // Nullable types - allow null
+        // Nullable types - allow null. `anyOf` rather than `oneOf`: the inner schema may
+        // itself accept `null`, and `oneOf` would then reject it for matching both branches.
         GraphQLType::Named(name) => {
             let inner = named_type_to_output_schema(
                 name,
@@ -328,7 +329,7 @@ fn type_to_output_schema(
                 private_tree,
             );
             json_schema!({
-                "oneOf": [inner, {"type": "null"}]
+                "anyOf": [inner, {"type": "null"}]
             })
         }
         GraphQLType::List(inner) => {
@@ -342,7 +343,7 @@ fn type_to_output_schema(
                 private_tree,
             );
             json_schema!({
-                "oneOf": [
+                "anyOf": [
                     {"type": "array", "items": items},
                     {"type": "null"}
                 ]
@@ -540,6 +541,7 @@ fn with_description(mut schema: JSONSchema, description: Option<String>) -> JSON
 mod tests {
     use super::*;
     use apollo_compiler::parser::Parser;
+    use rstest::rstest;
 
     use crate::operations::private_fields::{collect_named_fragments, collect_private_fields};
 
@@ -655,6 +657,63 @@ mod tests {
         );
 
         insta::assert_snapshot!(serde_json::to_string_pretty(&output_schema).unwrap());
+    }
+
+    #[rstest]
+    #[case::null_scalar(serde_json::json!({"id": "1", "meta": null, "tags": []}))]
+    #[case::null_list(serde_json::json!({"id": "1", "meta": {"k": "v"}, "tags": null}))]
+    #[case::null_list_item(serde_json::json!({"id": "1", "meta": {"k": "v"}, "tags": [null, 1]}))]
+    fn output_schema_accepts_null_for_unmapped_custom_scalar(#[case] thing: Value) {
+        let schema = parse_schema(
+            r#"
+            scalar JSON
+
+            type Thing {
+                id: ID!
+                meta: JSON
+                tags: [JSON]
+            }
+
+            type Query {
+                thing: Thing
+            }
+            "#,
+        );
+
+        let (_, selection_set) = parse_operation(
+            r#"
+            query GetThing {
+                thing {
+                    id
+                    meta
+                    tags
+                }
+            }
+            "#,
+        );
+
+        let query_type = schema.types.get("Query").unwrap();
+        let output_schema = selection_set_to_schema(
+            &selection_set,
+            query_type,
+            &schema,
+            None,
+            &HashMap::new(),
+            None,
+        );
+
+        let validator = jsonschema::validator_for(&serde_json::to_value(&output_schema).unwrap())
+            .expect("emitted output schema should itself be a valid JSON Schema");
+        let response = serde_json::json!({"data": {"thing": thing}});
+
+        let errors: Vec<String> = validator
+            .iter_errors(&response)
+            .map(|e| format!("{}: {e}", e.instance_path()))
+            .collect();
+        assert!(
+            errors.is_empty(),
+            "response must validate against the emitted output schema, got: {errors:#?}"
+        );
     }
 
     #[test]

--- a/crates/apollo-mcp-server/src/operations/schema_walker/output.rs
+++ b/crates/apollo-mcp-server/src/operations/schema_walker/output.rs
@@ -417,7 +417,9 @@ fn named_type_to_output_schema(
                 }
             }
 
-            // Union types - oneOf the possible types based on inline fragments
+            // Union types - anyOf the possible types based on inline fragments. Member
+            // schemas carry no discriminator and allow extra properties, so one response
+            // object can match several members and `oneOf` would reject it.
             Some(ExtendedType::Union(_union_def)) => {
                 if selection_set.is_empty() {
                     json_schema!({})
@@ -450,7 +452,7 @@ fn named_type_to_output_schema(
                     } else if type_schemas.len() == 1 {
                         type_schemas.remove(0)
                     } else {
-                        json_schema!({"oneOf": type_schemas})
+                        json_schema!({"anyOf": type_schemas})
                     }
                 }
             }
@@ -713,6 +715,63 @@ mod tests {
         assert!(
             errors.is_empty(),
             "response must validate against the emitted output schema, got: {errors:#?}"
+        );
+    }
+
+    #[test]
+    fn output_schema_accepts_union_member_matching_several_fragments() {
+        let schema = parse_schema(
+            r#"
+            type Book {
+                id: ID!
+                name: String
+            }
+
+            type Author {
+                id: ID!
+                name: String
+            }
+
+            union SearchResult = Book | Author
+
+            type Query {
+                search: SearchResult!
+            }
+            "#,
+        );
+
+        let (_, selection_set) = parse_operation(
+            r#"
+            query Search {
+                search {
+                    ... on Book { id name }
+                    ... on Author { id name }
+                }
+            }
+            "#,
+        );
+
+        let query_type = schema.types.get("Query").unwrap();
+        let output_schema = selection_set_to_schema(
+            &selection_set,
+            query_type,
+            &schema,
+            None,
+            &HashMap::new(),
+            None,
+        );
+
+        let validator = jsonschema::validator_for(&serde_json::to_value(&output_schema).unwrap())
+            .expect("emitted output schema should itself be a valid JSON Schema");
+        let response = serde_json::json!({"data": {"search": {"id": "1", "name": "Dune"}}});
+
+        let errors: Vec<String> = validator
+            .iter_errors(&response)
+            .map(|e| format!("{}: {e}", e.instance_path()))
+            .collect();
+        assert!(
+            errors.is_empty(),
+            "a member object that matches more than one fragment must validate, got: {errors:#?}"
         );
     }
 

--- a/crates/apollo-mcp-server/src/operations/schema_walker/snapshots/apollo_mcp_server__operations__schema_walker__output__tests__nested_object_output_schema.snap
+++ b/crates/apollo-mcp-server/src/operations/schema_walker/snapshots/apollo_mcp_server__operations__schema_walker__output__tests__nested_object_output_schema.snap
@@ -9,7 +9,7 @@ expression: "serde_json::to_string_pretty(&output_schema).unwrap()"
       "type": "object",
       "properties": {
         "user": {
-          "oneOf": [
+          "anyOf": [
             {
               "type": "object",
               "properties": {
@@ -27,7 +27,7 @@ expression: "serde_json::to_string_pretty(&output_schema).unwrap()"
                   "type": "object",
                   "properties": {
                     "bio": {
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string"
                         },

--- a/crates/apollo-mcp-server/src/operations/schema_walker/snapshots/apollo_mcp_server__operations__schema_walker__output__tests__private_fields_excluded_from_output_schema.snap
+++ b/crates/apollo-mcp-server/src/operations/schema_walker/snapshots/apollo_mcp_server__operations__schema_walker__output__tests__private_fields_excluded_from_output_schema.snap
@@ -9,7 +9,7 @@ expression: "serde_json::to_string_pretty(&output_schema).unwrap()"
       "type": "object",
       "properties": {
         "user": {
-          "oneOf": [
+          "anyOf": [
             {
               "type": "object",
               "properties": {

--- a/crates/apollo-mcp-server/src/operations/schema_walker/snapshots/apollo_mcp_server__operations__schema_walker__output__tests__simple_query_output_schema.snap
+++ b/crates/apollo-mcp-server/src/operations/schema_walker/snapshots/apollo_mcp_server__operations__schema_walker__output__tests__simple_query_output_schema.snap
@@ -10,7 +10,7 @@ expression: "serde_json::to_string_pretty(&output_schema).unwrap()"
       "properties": {
         "user": {
           "description": "Get a user by ID",
-          "oneOf": [
+          "anyOf": [
             {
               "type": "object",
               "properties": {
@@ -31,7 +31,7 @@ expression: "serde_json::to_string_pretty(&output_schema).unwrap()"
                 },
                 "email": {
                   "description": "The user's email address",
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-606 -->

With `overrides.enable_output_schema: true`, nullable fields were emitted as `{"oneOf": [<inner>, {"type": "null"}]}`. For custom scalars without a `custom_scalars` entry, and for unknown types, `<inner>` was the empty schema `{}`. Since that schema already accepts `null`, a `null` value matched both branches. As a result, clients that validate `structuredContent` against `outputSchema`, including the official TypeScript SDK in `callTool`, rejected the entire tool result.

GraphQL union fields had the same issue. Each inline fragment became a `oneOf` branch, but the member schemas had no `__typename` discriminator and allowed extra properties. So a response that matched more than one fragment, such as `... on Book { id name }` and `... on Author { id name }`, was rejected as well.

As a follow-up to PR #822, which makes the same change on the input side, this updates both the nullable unions and the union-type branches to use `anyOf`. That is the correct keyword for a union because it does not require the branches to be exclusive. The `oneOf` schemas for `ID` and error `path` remain unchanged because `string` and `integer` cannot overlap.