### PR TITLE
fix: don't gate the stateless streamable-HTTP GET with a 401

### DIFF
--- a/.changeset/dont_gate_stateless_get_with_401.md
+++ b/.changeset/dont_gate_stateless_get_with_401.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+# Don't reject an unauthenticated GET with 401 on a stateless streamable-HTTP transport
+
+With `transport.auth` configured and `stateful_mode: false`, an unauthenticated `GET` on the MCP endpoint now returns 405, matching what it already returned once a credential skipped validation, instead of 401. That route was never served in stateless mode regardless of a credential, so the 401 protected nothing on the wire. It did have a client-visible effect: at least one MCP client reads a 401 on that GET as "this server requires authentication" and hides every tool, including tools `transport.auth.skip_token_validation` was configured to expose without a token.
+
+A stateful transport's GET is unaffected: it still returns 401 when unauthenticated, because that GET carries the real server-to-client stream and must stay protected.

--- a/crates/apollo-mcp-server/src/auth.rs
+++ b/crates/apollo-mcp-server/src/auth.rs
@@ -473,6 +473,12 @@ struct AuthState {
     /// Skip lists resolved at startup, with the deprecated
     /// `allow_anonymous_mcp_discovery` flag already folded in.
     skip_token_validation: Arc<SkipTokenValidation>,
+    /// Whether the streamable-HTTP transport serves the `GET` server-to-client
+    /// stream (`true`) or not (`false`, `stateful_mode: false`). A stateless
+    /// transport answers that `GET` with 405 regardless of a credential, so
+    /// gating it here would only add a 401 a client may read as "this server
+    /// requires authentication for everything".
+    stateful_mode: bool,
 }
 
 impl Config {
@@ -506,6 +512,7 @@ impl Config {
         &self,
         router: Router,
         required_scopes: HashMap<String, OperationRequiredScopes>,
+        stateful_mode: bool,
     ) -> Result<Router, TlsConfigError> {
         // Parse and validate server URLs once at startup (fail fast on config
         // errors). The parsed list is reused for every request via `AuthState`.
@@ -589,6 +596,7 @@ impl Config {
             skip_token_validation: Arc::new(skip_token_validation),
             inflight: Arc::new(Mutex::new(IssuerFetchState::default())),
             jwks_cache: Arc::new(RwLock::new(HashMap::new())),
+            stateful_mode,
         };
 
         // Set up auth routes. NOTE: CORs needs to allow for get requests to the
@@ -738,6 +746,15 @@ async fn oauth_validate(
             }),
         )
     };
+
+    // See AuthState::stateful_mode's doc for why a stateless GET is exempt
+    // here. Stateful mode's GET carries real traffic and stays gated below
+    // like any other request.
+    if !auth_state.stateful_mode && request.method() == Method::GET {
+        let response = next.run(request).await;
+        tracing::Span::current().record("status_code", response.status().as_u16());
+        return Ok(response);
+    }
 
     // Every skip list applies only to a request that presents no token. A caller
     // that sends one always gets it validated, so an expired token is rejected
@@ -899,7 +916,7 @@ async fn oauth_validate(
 mod tests {
     use super::*;
     use axum::middleware::from_fn_with_state;
-    use axum::routing::get;
+    use axum::routing::{get, post};
     use axum::{
         Router,
         body::Body,
@@ -929,7 +946,14 @@ mod tests {
         }
     }
 
+    /// Builds `AuthState` in `stateful_mode: true`, the mode every existing
+    /// test assumes. Tests exercising the stateless GET bypass use
+    /// [`test_auth_state_with_mode`] instead.
     fn test_auth_state(config: Config) -> AuthState {
+        test_auth_state_with_mode(config, true)
+    }
+
+    fn test_auth_state_with_mode(config: Config, stateful_mode: bool) -> AuthState {
         let resource_metadata_url = build_resource_metadata_url(&config.resource);
         let auth_servers = config
             .servers
@@ -950,6 +974,7 @@ mod tests {
             skip_token_validation: Arc::new(skip_token_validation),
             inflight: Arc::new(Mutex::new(IssuerFetchState::default())),
             jwks_cache: Arc::new(RwLock::new(HashMap::new())),
+            stateful_mode,
         }
     }
 
@@ -957,6 +982,18 @@ mod tests {
         Router::new()
             .route("/test", get(|| async { "ok" }))
             .layer(from_fn_with_state(test_auth_state(config), oauth_validate))
+    }
+
+    /// Like [`test_router`], but the route only handles `POST`, so axum's own
+    /// 405 stands in for the real `GET` route (owned by rmcp's
+    /// `StreamableHttpService`) that a stateless transport doesn't serve.
+    fn test_router_get_unhandled(config: Config, stateful_mode: bool) -> Router {
+        Router::new()
+            .route("/test", post(|| async { "ok" }))
+            .layer(from_fn_with_state(
+                test_auth_state_with_mode(config, stateful_mode),
+                oauth_validate,
+            ))
     }
 
     fn test_router_with_required_scopes(
@@ -968,6 +1005,67 @@ mod tests {
         Router::new()
             .route("/test", get(|| async { "ok" }))
             .layer(from_fn_with_state(auth_state, oauth_validate))
+    }
+
+    // Covers the interaction between `stateful_mode` and the `GET` server-
+    // to-client stream: a stateless transport never serves that route
+    // (rmcp answers 405 regardless of a credential), so gating it with a 401
+    // only misleads a client into thinking the whole server needs auth.
+    mod stateless_get {
+        use super::*;
+
+        #[tokio::test]
+        async fn stateless_unauthenticated_get_bypasses_auth_and_gets_405() {
+            let config = test_config();
+            let app = test_router_get_unhandled(config, /* stateful_mode */ false);
+            let req = Request::builder()
+                .method("GET")
+                .uri("/test")
+                .body(Body::empty())
+                .unwrap();
+            let res = app.oneshot(req).await.unwrap();
+            assert_eq!(res.status(), StatusCode::METHOD_NOT_ALLOWED);
+        }
+
+        /// Regression guard: a stateful transport's `GET` carries real
+        /// server-to-client traffic and must stay gated. Named explicitly so
+        /// it fails loudly if the `stateful_mode` default ever changes.
+        #[tokio::test]
+        async fn stateful_unauthenticated_get_still_returns_401() {
+            let config = test_config();
+            let app = test_router_get_unhandled(config, /* stateful_mode */ true);
+            let req = Request::builder()
+                .method("GET")
+                .uri("/test")
+                .body(Body::empty())
+                .unwrap();
+            let res = app.oneshot(req).await.unwrap();
+            assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+        }
+
+        /// Confirms the bypass added in `oauth_validate` is scoped to `GET`:
+        /// an unauthenticated `POST` for a method absent from every skip list
+        /// is still rejected in stateless mode, not waved through because
+        /// `stateful_mode` is `false`.
+        #[tokio::test]
+        async fn stateless_mode_does_not_change_post_gating() {
+            let config = test_config();
+            let app = test_router_get_unhandled(config, /* stateful_mode */ false);
+            let body = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/list",
+            })
+            .to_string();
+            let req = Request::builder()
+                .method("POST")
+                .uri("/test")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap();
+            let res = app.oneshot(req).await.unwrap();
+            assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+        }
     }
 
     mod oauth_validate {
@@ -1400,7 +1498,7 @@ mod tests {
 
             let router = Router::new();
             let err = config
-                .enable_middleware(router, HashMap::new())
+                .enable_middleware(router, HashMap::new(), true)
                 .unwrap_err();
 
             assert!(matches!(
@@ -1768,7 +1866,7 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
             config.resource = Url::parse("file:///some/path").unwrap();
 
             let err = config
-                .enable_middleware(Router::new(), HashMap::new())
+                .enable_middleware(Router::new(), HashMap::new(), true)
                 .unwrap_err();
 
             assert!(matches!(
@@ -1783,7 +1881,7 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
             config.resource = Url::parse("ftp://example.com/mcp").unwrap();
 
             let err = config
-                .enable_middleware(Router::new(), HashMap::new())
+                .enable_middleware(Router::new(), HashMap::new(), true)
                 .unwrap_err();
 
             assert!(matches!(
@@ -1797,7 +1895,7 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
             let mut config = test_config();
             config.resource = Url::parse("http://localhost:4000/mcp").unwrap();
 
-            let result = config.enable_middleware(Router::new(), HashMap::new());
+            let result = config.enable_middleware(Router::new(), HashMap::new(), true);
 
             assert!(result.is_ok());
         }
@@ -1807,7 +1905,7 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
             let mut config = test_config();
             config.resource = Url::parse("https://mcp.example.com/mcp").unwrap();
 
-            let result = config.enable_middleware(Router::new(), HashMap::new());
+            let result = config.enable_middleware(Router::new(), HashMap::new(), true);
 
             assert!(result.is_ok());
         }
@@ -1823,7 +1921,7 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
 
             let base_router = Router::new().route("/my-service/mcp", get(|| async { "ok" }));
             let app = config
-                .enable_middleware(base_router, HashMap::new())
+                .enable_middleware(base_router, HashMap::new(), true)
                 .unwrap();
 
             let req = Request::builder()
@@ -1851,7 +1949,7 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
 
             let base_router = Router::new().route("/my-service/mcp", get(|| async { "ok" }));
             let app = config
-                .enable_middleware(base_router, HashMap::new())
+                .enable_middleware(base_router, HashMap::new(), true)
                 .unwrap();
 
             let req = Request::builder()
@@ -1869,7 +1967,7 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
 
             let base_router = Router::new().route("/mcp", get(|| async { "ok" }));
             let app = config
-                .enable_middleware(base_router, HashMap::new())
+                .enable_middleware(base_router, HashMap::new(), true)
                 .unwrap();
 
             let req = Request::builder()
@@ -2593,7 +2691,7 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
                 config.allow_anonymous_mcp_discovery = true;
                 config.skip_token_validation = skip(&["server/discover"], &[], &[]);
 
-                let result = config.enable_middleware(Router::new(), HashMap::new());
+                let result = config.enable_middleware(Router::new(), HashMap::new(), true);
 
                 assert!(
                     matches!(result, Err(TlsConfigError::AnonymousDiscoveryConflict)),
@@ -2647,7 +2745,7 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
                 config.skip_token_validation = skip(&[], &["RestrictedOp"], &[]);
 
                 let _app = config
-                    .enable_middleware(Router::new(), required_read_scope())
+                    .enable_middleware(Router::new(), required_read_scope(), true)
                     .unwrap();
 
                 assert!(logs_contain("RestrictedOp"));
@@ -2661,7 +2759,7 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
                 config.skip_token_validation = skip(&[], &["PublicOp"], &[]);
 
                 let _app = config
-                    .enable_middleware(Router::new(), required_read_scope())
+                    .enable_middleware(Router::new(), required_read_scope(), true)
                     .unwrap();
 
                 assert!(!logs_contain("skip_token_validation.tools"));
@@ -2674,7 +2772,7 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
                 config.skip_token_validation = skip(&[], &[], &["x-api-key"]);
 
                 let _app = config
-                    .enable_middleware(Router::new(), required_read_scope())
+                    .enable_middleware(Router::new(), required_read_scope(), true)
                     .unwrap();
 
                 assert!(logs_contain("x-api-key"));
@@ -2690,7 +2788,7 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
                 config.skip_token_validation = skip(&[], &[], &["x-api-key"]);
 
                 let _app = config
-                    .enable_middleware(Router::new(), HashMap::new())
+                    .enable_middleware(Router::new(), HashMap::new(), true)
                     .unwrap();
 
                 assert!(logs_contain("skips token validation for every tool"));
@@ -2707,7 +2805,7 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
                 config.scope_mode = ScopeMode::Disabled;
 
                 let _app = config
-                    .enable_middleware(Router::new(), HashMap::new())
+                    .enable_middleware(Router::new(), HashMap::new(), true)
                     .unwrap();
 
                 assert!(!logs_contain("skips token validation for every tool"));
@@ -2721,7 +2819,7 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
                 config.scopes = vec![];
 
                 let _app = config
-                    .enable_middleware(Router::new(), HashMap::new())
+                    .enable_middleware(Router::new(), HashMap::new(), true)
                     .unwrap();
 
                 assert!(!logs_contain("skips token validation for every tool"));

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -215,7 +215,11 @@ impl Starting {
                 let mut router = axum::Router::new().nest_service("/mcp", service);
                 if let Some(auth) = auth {
                     router = auth
-                        .enable_middleware(router, self.config.required_scopes.clone())
+                        .enable_middleware(
+                            router,
+                            self.config.required_scopes.clone(),
+                            stateful_mode,
+                        )
                         .inspect_err(|e| {
                             error!("Failed to enable auth middleware: {}", e);
                         })?;

--- a/docs/source/auth.mdx
+++ b/docs/source/auth.mdx
@@ -369,7 +369,14 @@ transport:
 
 An empty list is off, so there is no separate switch to turn the lists on.
 
-A stateful session needs both `initialize` and the `notifications/initialized` notification that follows it on its own POST; missing either one from `methods` still ends the handshake in a 401, one step after `initialize` succeeded. A stateful session also opens a GET request for the server-to-client stream, which carries no JSON-RPC body: only `headers` can match a GET, since `methods` and `tools` need a body to inspect. A session with no token and no listed header does not get that stream.
+A stateful session needs both `initialize` and the `notifications/initialized` notification that follows it on its own POST. Missing either one from `methods` still ends the handshake in a 401, one step after `initialize` succeeded.
+
+`transport.stateful_mode` changes how a `GET` on the MCP endpoint is treated, and this is not stateful-only:
+
+- **`stateful_mode: true`** opens a real GET for the server-to-client stream, which carries no JSON-RPC body. Only `headers` can match a GET, since `methods` and `tools` need a body to inspect. A session with no token and no listed header does not get that stream, and gets a 401.
+- **`stateful_mode: false`** never serves that stream at all. The endpoint answers a GET with 405, whether or not a credential is present. This GET is not gated by `skip_token_validation` (there is nothing to protect), so a stateless deployment needs no `headers` entry to reach it.
+
+The distinction matters beyond the wire, because some MCP clients treat any 401 from the server as "this server requires authentication," and hide every tool in response, including ones `skip_token_validation` was configured to expose without a token. Getting the stateless GET's status code right (405, not 401) keeps that from happening to an otherwise-public deployment.
 
 <Caution>
 


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-615 -->

With `transport.auth` configured and `stateful_mode: false`, the streamable HTTP `GET /mcp` request was rejected with a 401. However, when auth is skipped, the same route returns a 405, which shows that the route is not served in stateless mode, even when credentials are provided.

MCP clients like Claude Code interpret the 401 as meaning that the server requires authentication, so they hide all the tools. That includes tools exposed without credentials through `skip_token_validation`. This defeats the purpose of that feature for anonymous deployments like GraphOS MCP Server.

This change passes `stateful_mode` into the auth middleware's `AuthState` and completely skips auth for `GET` requests when the transport is stateless. That lets rmcp return its own 405 response unchanged. Stateful mode is unaffected because its `GET` request carries real server-to-client traffic and still needs to be protected.

# Testing

Manually verified against locally built binaries in both modes:
- stateless, no credential, `GET /mcp` → 405 (was 401)
- stateful, no credential, `GET /mcp` → still 401
- stateless, `tools/list` (skip-listed), no credential → 200
- stateless, unlisted method, no credential → 401
- stateless, bad bearer token → 401
- stateless, `GET /mcp` with a skip-listed header → still 405
