### PR TITLE
Refactor/service owned tool notifications

### DIFF
--- a/.changeset/service-owned-tool-notifications.md
+++ b/.changeset/service-owned-tool-notifications.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Replace shared MCP peer tracking with service-owned tool-change notification tasks. Slow clients no longer delay catalog updates or other clients, and legacy session teardown releases notification resources. Existing sessionless HTTP behavior and supported protocol versions are preserved.

--- a/.changeset/service-owned-tool-notifications.md
+++ b/.changeset/service-owned-tool-notifications.md
@@ -2,4 +2,4 @@
 default: patch
 ---
 
-Replace shared MCP peer tracking with service-owned tool-change notification tasks. Slow clients no longer delay catalog updates or other clients, and legacy session teardown releases notification resources. Existing sessionless HTTP behavior and supported protocol versions are preserved. Catalog invalidations registered during initialization are retained until the initialized notification starts delivery, preventing missed updates while callbacks are scheduled.
+Replace shared MCP peer tracking with service-owned tool-change notification tasks. Slow clients no longer delay catalog updates or other clients, and a slow send no longer permanently disables notifications after five seconds. Legacy session teardown releases notification resources. Existing sessionless HTTP behavior and supported protocol versions are preserved. Catalog invalidations registered during initialization are retained until the initialized notification starts delivery, preventing missed updates while callbacks are scheduled.

--- a/.changeset/service-owned-tool-notifications.md
+++ b/.changeset/service-owned-tool-notifications.md
@@ -2,4 +2,4 @@
 default: patch
 ---
 
-Replace shared MCP peer tracking with service-owned tool-change notification tasks. Slow clients no longer delay catalog updates or other clients, and legacy session teardown releases notification resources. Existing sessionless HTTP behavior and supported protocol versions are preserved.
+Replace shared MCP peer tracking with service-owned tool-change notification tasks. Slow clients no longer delay catalog updates or other clients, and legacy session teardown releases notification resources. Existing sessionless HTTP behavior and supported protocol versions are preserved. Catalog invalidations registered during initialization are retained until the initialized notification starts delivery, preventing missed updates while callbacks are scheduled.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,7 @@ dependencies = [
  "opentelemetry_sdk 0.32.1",
  "parking_lot",
  "prettyplease",
+ "proptest",
  "quote",
  "regex",
  "reqwest",
@@ -3477,6 +3478,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.10.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3507,6 +3527,12 @@ checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -3663,6 +3689,15 @@ checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4138,6 +4173,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -5037,6 +5084,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -5391,6 +5439,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5517,6 +5571,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "shellexpand",
+ "sse-stream",
  "syn 2.0.114",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -77,8 +77,8 @@ chrono = { version = "0.4.41", default-features = false, features = ["now"] }
 figment = { version = "0.10.19", features = ["test"] }
 insta.workspace = true
 mockito = "1.7.0"
-proptest = "1"
 opentelemetry_sdk = { version = "0.32.1", features = ["testing"] }
+proptest = "1"
 rstest.workspace = true
 secrecy.workspace = true
 serde_yaml = "0.9.34"

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -58,7 +58,7 @@ serde_yaml = "0.9.34"
 shellexpand = { version = "3.1", default-features = false, features = ["base-0"] }
 thiserror.workspace = true
 tokio.workspace = true
-tokio-util = "0.7.15"
+tokio-util = { version = "0.7.15", features = ["rt"] }
 tonic = "0.14"
 tower-http = { version = "0.6.6", features = ["cors", "trace"] }
 tracing-appender = "0.2.3"
@@ -77,11 +77,12 @@ chrono = { version = "0.4.41", default-features = false, features = ["now"] }
 figment = { version = "0.10.19", features = ["test"] }
 insta.workspace = true
 mockito = "1.7.0"
+proptest = "1"
 opentelemetry_sdk = { version = "0.32.1", features = ["testing"] }
 rstest.workspace = true
 secrecy.workspace = true
 serde_yaml = "0.9.34"
-tokio.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 tower = "0.5.2"
 tracing-test = "0.2.5"
 

--- a/crates/apollo-mcp-server/Cargo.toml
+++ b/crates/apollo-mcp-server/Cargo.toml
@@ -82,6 +82,7 @@ proptest = "1"
 rstest.workspace = true
 secrecy.workspace = true
 serde_yaml = "0.9.34"
+sse-stream = "0.2.5"
 tokio = { workspace = true, features = ["test-util"] }
 tower = "0.5.2"
 tracing-test = "0.2.5"

--- a/crates/apollo-mcp-server/src/server.rs
+++ b/crates/apollo-mcp-server/src/server.rs
@@ -106,7 +106,7 @@ pub enum Transport {
         #[serde(default = "Transport::default_port")]
         port: u16,
 
-        /// Enable stateful mode for session management
+        /// Enable legacy HTTP sessions. Sessionless requests do not receive unsolicited notifications.
         #[serde(default = "Transport::default_stateful_mode")]
         stateful_mode: bool,
 

--- a/crates/apollo-mcp-server/src/server/states.rs
+++ b/crates/apollo-mcp-server/src/server/states.rs
@@ -483,7 +483,6 @@ mod tests {
             validate_tool: None,
             custom_scalar_map: None,
             tool_list_changes: Default::default(),
-            legacy_tool_notifications: Default::default(),
             cancellation_token: CancellationToken::new(),
             mutation_mode: MutationMode::None,
             disable_type_description: false,

--- a/crates/apollo-mcp-server/src/server/states.rs
+++ b/crates/apollo-mcp-server/src/server/states.rs
@@ -30,6 +30,7 @@ mod running;
 mod schema_configured;
 mod starting;
 pub(crate) mod telemetry;
+mod tool_list_changes;
 
 use configuring::Configuring;
 use operations_configured::OperationsConfigured;
@@ -481,7 +482,8 @@ mod tests {
             explorer_tool: None,
             validate_tool: None,
             custom_scalar_map: None,
-            peers: Arc::new(RwLock::new(vec![])),
+            tool_list_changes: Default::default(),
+            legacy_tool_notifications: Default::default(),
             cancellation_token: CancellationToken::new(),
             mutation_mode: MutationMode::None,
             disable_type_description: false,

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -4027,16 +4027,6 @@ mod integration_tests {
                 .unwrap()
         }
 
-        async fn wait_for_receivers(running: &Running, expected: usize) {
-            tokio::time::timeout(std::time::Duration::from_secs(2), async {
-                while running.tool_list_changes.receiver_count() != expected {
-                    tokio::task::yield_now().await;
-                }
-            })
-            .await
-            .expect("initialization must register a change receiver");
-        }
-
         async fn initialize_legacy_session(
             service: &StreamableHttpService<McpService, LocalSessionManager>,
             running: &Running,
@@ -4064,7 +4054,6 @@ mod integration_tests {
                 .await
                 .unwrap();
             assert_eq!(response.status(), StatusCode::ACCEPTED);
-            wait_for_receivers(running, previous + 1).await;
             session
         }
 
@@ -4128,6 +4117,108 @@ mod integration_tests {
             })
             .await
             .expect("expected MCP message")
+        }
+
+        // Keep unread bytes across events so a frame containing multiple SSE
+        // events cannot discard the event following the one a test observes.
+        struct NotificationStream {
+            body: Body,
+            buffer: Vec<u8>,
+        }
+
+        impl NotificationStream {
+            fn new(body: Body) -> Self {
+                Self {
+                    body,
+                    buffer: Vec::new(),
+                }
+            }
+
+            async fn next_notification(&mut self) -> String {
+                use http_body_util::BodyExt as _;
+
+                tokio::time::timeout(std::time::Duration::from_secs(2), async {
+                    loop {
+                        let boundary = self
+                            .buffer
+                            .windows(2)
+                            .position(|bytes| bytes == b"\n\n")
+                            .map(|position| (position, 2))
+                            .into_iter()
+                            .chain(
+                                self.buffer
+                                    .windows(4)
+                                    .position(|bytes| bytes == b"\r\n\r\n")
+                                    .map(|position| (position, 4)),
+                            )
+                            .min_by_key(|(position, _)| *position);
+                        if let Some((position, delimiter_len)) = boundary {
+                            let event: Vec<_> =
+                                self.buffer.drain(..position + delimiter_len).collect();
+                            let event = std::str::from_utf8(&event).unwrap();
+                            let mut id = None;
+                            let mut data = Vec::new();
+                            for line in event.lines() {
+                                if let Some(value) = line.strip_prefix("id:") {
+                                    id = Some(value.strip_prefix(' ').unwrap_or(value).to_owned());
+                                } else if let Some(value) = line.strip_prefix("data:") {
+                                    data.push(value.strip_prefix(' ').unwrap_or(value));
+                                }
+                            }
+                            let data = data.join("\n");
+                            if data.is_empty() {
+                                continue; // Ignore keep-alive and retry-only events.
+                            }
+                            let message: Value = serde_json::from_str(&data).unwrap();
+                            assert_eq!(message["method"], "notifications/tools/list_changed");
+                            return id.expect("legacy notifications must have an SSE event ID");
+                        }
+                        let frame = self
+                            .body
+                            .frame()
+                            .await
+                            .expect("notification stream closed")
+                            .unwrap();
+                        if let Some(data) = frame.data_ref() {
+                            self.buffer.extend_from_slice(data);
+                        }
+                    }
+                })
+                .await
+                .expect("expected a complete tool-list notification")
+            }
+        }
+
+        proptest::proptest! {
+            #[test]
+            fn notification_stream_preserves_events_across_frame_boundaries(
+                chunk_sizes in proptest::collection::vec(1usize..128, 1..16),
+                crlf in proptest::bool::ANY,
+            ) {
+                // Framing must not affect event identity, including when several
+                // events share a frame or an event is split between frames.
+                let newline = if crlf { "\r\n" } else { "\n" };
+                let payload = format!(
+                    ": keep-alive{newline}{newline}data:{newline}{newline}id: first{newline}data: {{\"method\":\"notifications/tools/list_changed\"}}{newline}{newline}id: second{newline}data: {{\"method\":\"notifications/tools/list_changed\"}}{newline}{newline}"
+                );
+                let mut remaining = payload.as_bytes();
+                let mut chunks = Vec::new();
+                for size in chunk_sizes.into_iter().cycle() {
+                    if remaining.is_empty() {
+                        break;
+                    }
+                    let (chunk, rest) = remaining.split_at(size.min(remaining.len()));
+                    chunks.push(Ok::<_, std::convert::Infallible>(chunk.to_vec()));
+                    remaining = rest;
+                }
+                let runtime = tokio::runtime::Builder::new_current_thread().enable_time().build().unwrap();
+                runtime.block_on(async {
+                    let body = Body::from_stream(futures::stream::iter(chunks));
+                    let mut stream = NotificationStream::new(body);
+                    assert_eq!(stream.next_notification().await, "first");
+                    assert_eq!(stream.next_notification().await, "second");
+                });
+            }
         }
 
         fn session_request(session: &str, method: http::Method, body: Value) -> Request<Body> {
@@ -4418,16 +4509,14 @@ mod integration_tests {
             for session in &sessions {
                 let response = service.clone().oneshot(session_get(session)).await.unwrap();
                 assert_eq!(response.status(), StatusCode::OK);
-                streams.push(response.into_body());
+                streams.push(NotificationStream::new(Body::new(response.into_body())));
             }
             running
                 .update_operations(vec![("query Hello { hello }".to_owned(), None).into()])
                 .await;
+            let mut last_event_ids = Vec::new();
             for stream in &mut streams {
-                assert_eq!(
-                    next_message(stream).await["method"],
-                    "notifications/tools/list_changed"
-                );
+                last_event_ids.push(stream.next_notification().await);
             }
             let list = json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"});
             let mut response = service
@@ -4441,11 +4530,6 @@ mod integration_tests {
 
             // Closing a GET stream must not tear down a reconnectable legacy session.
             streams.clear();
-            for session in &sessions {
-                let response = service.clone().oneshot(session_get(session)).await.unwrap();
-                assert_eq!(response.status(), StatusCode::OK);
-                streams.push(response.into_body());
-            }
             running
                 .update_schema(
                     apollo_compiler::Schema::parse_and_validate(
@@ -4455,12 +4539,27 @@ mod integration_tests {
                     .unwrap(),
                 )
                 .await;
-            for stream in &mut streams {
-                assert_eq!(
-                    next_message(stream).await["method"],
-                    "notifications/tools/list_changed"
-                );
+            // Resume from the last observed event, rather than replaying all history.
+            for (session, last_event_id) in sessions.iter().zip(&last_event_ids) {
+                let mut request = session_get(session);
+                request
+                    .headers_mut()
+                    .insert("Last-Event-ID", last_event_id.parse().unwrap());
+                let response = service.clone().oneshot(request).await.unwrap();
+                assert_eq!(response.status(), StatusCode::OK);
+                streams.push(NotificationStream::new(Body::new(response.into_body())));
             }
+            for (stream, last_event_id) in streams.iter_mut().zip(&mut last_event_ids) {
+                let mut next_event_id = stream.next_notification().await;
+                // rmcp 3.2's in-memory cache replays the cursor event inclusively.
+                // That duplicate cannot establish delivery of the gap update.
+                if next_event_id == *last_event_id {
+                    next_event_id = stream.next_notification().await;
+                }
+                assert_ne!(next_event_id, *last_event_id);
+                *last_event_id = next_event_id;
+            }
+
             let mut response = service
                 .clone()
                 .oneshot(session_post(&sessions[0], list))
@@ -4472,6 +4571,11 @@ mod integration_tests {
                 before["result"]["tools"][0]["outputSchema"],
                 after["result"]["tools"][0]["outputSchema"]
             );
+            // Delivery must also continue after the streams have reconnected.
+            running.update_operations(vec![]).await;
+            for (stream, last_event_id) in streams.iter_mut().zip(&last_event_ids) {
+                assert_ne!(stream.next_notification().await, *last_event_id);
+            }
             for session in &sessions {
                 service
                     .clone()
@@ -4530,7 +4634,6 @@ mod integration_tests {
                 .write_all(format!("{initialized}\n").as_bytes())
                 .await
                 .unwrap();
-            wait_for_receivers(&running, 1).await;
             drop(intermediate_clone);
             running.update_operations(vec![]).await;
             line.clear();

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -74,7 +74,6 @@ pub(super) struct Running {
     pub(super) validate_tool: Option<Validate>,
     pub(super) custom_scalar_map: Option<CustomScalarMap>,
     pub(super) tool_list_changes: ToolListChanges,
-    pub(super) legacy_tool_notifications: LegacyToolNotifications,
     pub(super) cancellation_token: CancellationToken,
     pub(super) mutation_mode: MutationMode,
     pub(super) disable_type_description: bool,
@@ -118,12 +117,11 @@ impl<'a> PeerContext<'a> {
 }
 
 impl Running {
-    /// Create a fresh notification owner for an rmcp service. Clones of the
-    /// returned handler share that owner; the application handler never retains it.
-    pub(super) fn for_service(&self) -> Self {
-        Self {
-            legacy_tool_notifications: LegacyToolNotifications::for_service(),
-            ..self.clone()
+    /// Construct an independent rmcp service sharing this application's catalog.
+    pub(super) fn for_service(&self) -> McpService {
+        McpService {
+            application: self.clone(),
+            notifications: Default::default(),
         }
     }
 
@@ -679,7 +677,15 @@ fn negotiate_protocol_version(client_requested: &ProtocolVersion) -> ProtocolVer
     }
 }
 
-impl ServerHandler for Running {
+/// Transport handler with its own legacy lifecycle. Application clones cannot
+/// accidentally be served without constructing this owner.
+#[derive(Clone)]
+pub(super) struct McpService {
+    application: Running,
+    notifications: LegacyToolNotifications,
+}
+
+impl ServerHandler for McpService {
     #[tracing::instrument(skip_all, parent = get_parent_span(&context), fields(apollo.mcp.client_name = request.client_info.name, apollo.mcp.client_version = request.client_info.version))]
     async fn initialize(
         &self,
@@ -708,15 +714,14 @@ impl ServerHandler for Running {
         // re-negotiation capped at the same version (closes #803).
         let mut info = self.get_info();
         info.protocol_version = negotiate_protocol_version(&request.protocol_version);
+        self.notifications
+            .initialize(&self.application.tool_list_changes);
         Ok(info)
     }
 
     async fn on_initialized(&self, context: NotificationContext<RoleServer>) {
-        self.legacy_tool_notifications.on_initialized(
-            context.peer,
-            &self.tool_list_changes,
-            self.cancellation_token.clone(),
-        );
+        self.notifications
+            .on_initialized(context.peer, self.application.cancellation_token.clone());
     }
 
     /// Narrows rmcp's re-negotiation (run on every transport after
@@ -744,6 +749,7 @@ impl ServerHandler for Running {
         let protocol_version = context.protocol_version();
 
         let result = self
+            .application
             .call_tool_impl(request, &context.extensions, protocol_version.as_ref())
             .await;
 
@@ -773,7 +779,9 @@ impl ServerHandler for Running {
             protocol_version: protocol_version.as_ref(),
         };
 
-        self.list_tools_impl(context.extensions, peer).await
+        self.application
+            .list_tools_impl(context.extensions, peer)
+            .await
     }
 
     #[tracing::instrument(skip_all)]
@@ -782,10 +790,10 @@ impl ServerHandler for Running {
         _request: Option<PaginatedRequestParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, ErrorData> {
-        let peer_info = context.peer.peer_info();
-        let protocol_version = peer_info.as_ref().map(|info| &info.protocol_version);
+        let protocol_version = context.protocol_version();
 
-        self.list_resources_impl(&context.extensions, protocol_version)
+        self.application
+            .list_resources_impl(&context.extensions, protocol_version.as_ref())
     }
 
     #[tracing::instrument(skip_all, fields(apollo.mcp.resource_uri = request.uri.as_str(), apollo.mcp.request_id = %context.id.clone()))]
@@ -801,7 +809,8 @@ impl ServerHandler for Running {
             protocol_version: protocol_version.as_ref(),
         };
 
-        self.read_resource_impl(request, context.extensions, peer)
+        self.application
+            .read_resource_impl(request, context.extensions, peer)
             .await
             .map(Into::into)
     }
@@ -812,10 +821,9 @@ impl ServerHandler for Running {
         _request: Option<PaginatedRequestParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<ListPromptsResult, McpError> {
-        let peer_info = context.peer.peer_info();
-        let protocol_version = peer_info.as_ref().map(|info| &info.protocol_version);
+        let protocol_version = context.protocol_version();
 
-        self.list_prompts_impl(protocol_version)
+        self.application.list_prompts_impl(protocol_version.as_ref())
     }
 
     #[tracing::instrument(skip_all, fields(apollo.mcp.prompt_name = request.name))]
@@ -824,7 +832,7 @@ impl ServerHandler for Running {
         request: GetPromptRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<GetPromptResponse, McpError> {
-        self.get_prompt_impl(request).map(Into::into)
+        self.application.get_prompt_impl(request).map(Into::into)
     }
 
     // `logging` is deprecated by SEP-2577, but we still override this handler so
@@ -856,8 +864,10 @@ impl ServerHandler for Running {
         let mut tools = ToolsCapability::default();
         tools.list_changed = Some(true);
         capabilities.tools = Some(tools);
-        capabilities.resources = (!self.apps.is_empty()).then(ResourcesCapability::default);
-        capabilities.prompts = (!self.prompts.is_empty()).then(PromptsCapability::default);
+        capabilities.resources =
+            (!self.application.apps.is_empty()).then(ResourcesCapability::default);
+        capabilities.prompts =
+            (!self.application.prompts.is_empty()).then(PromptsCapability::default);
 
         // Advertise the max supported version as the default. Our `initialize`
         // handler negotiates the per-client value, echoing the client's requested
@@ -865,22 +875,22 @@ impl ServerHandler for Running {
         let protocol_version = MAX_SUPPORTED_PROTOCOL_VERSION;
 
         let mut impl_ = Implementation::new(
-            self.server_info.name().to_string(),
-            self.server_info.version().to_string(),
+            self.application.server_info.name().to_string(),
+            self.application.server_info.version().to_string(),
         );
-        if let Some(t) = self.server_info.title() {
+        if let Some(t) = self.application.server_info.title() {
             impl_ = impl_.with_title(t);
         }
-        if let Some(d) = self.server_info.description() {
+        if let Some(d) = self.application.server_info.description() {
             impl_ = impl_.with_description(d);
         }
-        if let Some(u) = self.server_info.website_url() {
+        if let Some(u) = self.application.server_info.website_url() {
             impl_ = impl_.with_website_url(u);
         }
         let mut result = InitializeResult::new(capabilities)
             .with_protocol_version(protocol_version)
             .with_server_info(impl_);
-        if let Some(instructions) = self.instructions.as_deref() {
+        if let Some(instructions) = self.application.instructions.as_deref() {
             result = result.with_instructions(instructions);
         }
         result
@@ -931,7 +941,6 @@ mod tests {
             validate_tool: None,
             custom_scalar_map: None,
             tool_list_changes: Default::default(),
-            legacy_tool_notifications: Default::default(),
             cancellation_token: CancellationToken::new(),
             mutation_mode: MutationMode::None,
             disable_type_description: false,
@@ -1085,7 +1094,8 @@ mod tests {
         }))
         .unwrap();
         let (server_io, _client_io) = tokio::io::duplex(4096);
-        let service = rmcp::service::serve_directly(running.clone(), server_io, Some(legacy_info));
+        let service =
+            rmcp::service::serve_directly(running.for_service(), server_io, Some(legacy_info));
         let mcp_capabilities: ClientCapabilities = serde_json::from_value(serde_json::json!({
             "extensions": {"io.modelcontextprotocol/ui": {"mimeTypes": ["text/html;profile=mcp-app"]}}
         })).unwrap();
@@ -1105,7 +1115,11 @@ mod tests {
             if let Some(capabilities) = capabilities {
                 context.meta.set_client_capabilities(capabilities);
             }
-            let tools = running.list_tools(None, context.clone()).await.unwrap();
+            let tools = running
+                .for_service()
+                .list_tools(None, context.clone())
+                .await
+                .unwrap();
             assert_eq!(
                 tools.tools[0]
                     .meta
@@ -1115,6 +1129,7 @@ mod tests {
                 openai
             );
             let resource = running
+                .for_service()
                 .read_resource(ReadResourceRequestParams::new(RESOURCE_URI), context)
                 .await
                 .unwrap();
@@ -2418,7 +2433,7 @@ mod tests {
 
             let running = test_running(Arc::new(RwLock::new(schema)));
 
-            let info = running.get_info();
+            let info = running.for_service().get_info();
 
             assert_eq!(info.server_info.name, "Apollo MCP Server");
             assert_eq!(info.server_info.version, env!("CARGO_PKG_VERSION"));
@@ -2453,7 +2468,7 @@ mod tests {
                 ..test_running(Arc::new(RwLock::new(schema)))
             };
 
-            let info = running.get_info();
+            let info = running.for_service().get_info();
             assert_eq!(
                 info.instructions.as_deref(),
                 Some("Prefer search before list.")
@@ -2480,7 +2495,7 @@ mod tests {
                 ..test_running(Arc::new(RwLock::new(schema)))
             };
 
-            let info = running.get_info();
+            let info = running.for_service().get_info();
 
             assert_eq!(info.server_info.name, "My Custom Server");
             assert_eq!(info.server_info.version, "3.0.0-beta");
@@ -2518,7 +2533,7 @@ mod tests {
                 ..test_running(Arc::clone(&schema))
             };
 
-            let info = running.get_info();
+            let info = running.for_service().get_info();
 
             assert_eq!(info.protocol_version, MAX_SUPPORTED_PROTOCOL_VERSION);
         }
@@ -2636,14 +2651,14 @@ mod tests {
                 template: "test".to_string(),
             }];
             let running = running_with_prompts(prompts);
-            let info = running.get_info();
+            let info = running.for_service().get_info();
             assert!(info.capabilities.prompts.is_some());
         }
 
         #[test]
         fn get_info_no_prompts_capability_when_empty() {
             let running = running_with_prompts(vec![]);
-            let info = running.get_info();
+            let info = running.for_service().get_info();
             assert!(info.capabilities.prompts.is_none());
         }
     }
@@ -2968,7 +2983,6 @@ mod integration_tests {
                 validate_tool: None,
                 custom_scalar_map: None,
                 tool_list_changes: Default::default(),
-                legacy_tool_notifications: Default::default(),
                 cancellation_token: CancellationToken::new(),
                 mutation_mode: MutationMode::None,
                 disable_type_description: false,
@@ -2988,7 +3002,7 @@ mod integration_tests {
         fn create_service(
             running: Running,
             session_manager: Arc<LocalSessionManager>,
-        ) -> StreamableHttpService<Running, LocalSessionManager> {
+        ) -> StreamableHttpService<McpService, LocalSessionManager> {
             StreamableHttpService::new(
                 move || Ok(running.for_service()),
                 session_manager,
@@ -3050,7 +3064,7 @@ mod integration_tests {
                 "protocolVersion":"2025-03-26", "capabilities":{}, "clientInfo":{"name":"legacy", "version":"1"}
             })).unwrap();
             let service =
-                rmcp::service::serve_directly(running.clone(), server_io, Some(legacy_info));
+                rmcp::service::serve_directly(running.for_service(), server_io, Some(legacy_info));
             for (version, expected_output_schema) in [
                 (None, false),
                 (Some(ProtocolVersion::V_2025_06_18), true),
@@ -3061,7 +3075,11 @@ mod integration_tests {
                 if let Some(version) = version {
                     context.meta.set_protocol_version(version);
                 }
-                let tools = running.list_tools(None, context).await.unwrap();
+                let tools = running
+                    .for_service()
+                    .list_tools(None, context)
+                    .await
+                    .unwrap();
                 assert_eq!(
                     tools.tools[0].output_schema.is_some(),
                     expected_output_schema
@@ -3255,6 +3273,7 @@ mod integration_tests {
 
             let server = tokio::spawn(async move {
                 let service = running
+                    .for_service()
                     .serve((server_r, server_w))
                     .await
                     .expect("stdio serve should complete the initialize handshake");
@@ -3306,6 +3325,7 @@ mod integration_tests {
 
             let server = tokio::spawn(async move {
                 let service = running
+                    .for_service()
                     .serve((server_r, server_w))
                     .await
                     .expect("stdio serve should complete the initialize handshake");
@@ -3343,7 +3363,7 @@ mod integration_tests {
         fn create_stateless_service(
             running: Running,
             session_manager: Arc<LocalSessionManager>,
-        ) -> StreamableHttpService<Running, LocalSessionManager> {
+        ) -> StreamableHttpService<McpService, LocalSessionManager> {
             StreamableHttpService::new(
                 move || Ok(running.for_service()),
                 session_manager,
@@ -3507,7 +3527,6 @@ mod integration_tests {
                 validate_tool: None,
                 custom_scalar_map: None,
                 tool_list_changes: Default::default(),
-                legacy_tool_notifications: Default::default(),
                 cancellation_token: CancellationToken::new(),
                 mutation_mode: MutationMode::None,
                 disable_type_description: false,
@@ -3610,7 +3629,6 @@ mod integration_tests {
                 validate_tool: None,
                 custom_scalar_map: None,
                 tool_list_changes: Default::default(),
-                legacy_tool_notifications: Default::default(),
                 cancellation_token: CancellationToken::new(),
                 mutation_mode: MutationMode::All,
                 disable_type_description: false,
@@ -3629,7 +3647,7 @@ mod integration_tests {
 
         fn create_test_service(
             stateful_mode: bool,
-        ) -> StreamableHttpService<Running, LocalSessionManager> {
+        ) -> StreamableHttpService<McpService, LocalSessionManager> {
             let running = create_test_running();
             StreamableHttpService::new(
                 move || Ok(running.for_service()),
@@ -3641,7 +3659,7 @@ mod integration_tests {
         fn create_stateful_service(
             running: Running,
             session_manager: Arc<LocalSessionManager>,
-        ) -> StreamableHttpService<Running, LocalSessionManager> {
+        ) -> StreamableHttpService<McpService, LocalSessionManager> {
             StreamableHttpService::new(
                 move || Ok(running.for_service()),
                 session_manager,
@@ -3932,7 +3950,6 @@ mod integration_tests {
                 validate_tool: None,
                 custom_scalar_map: None,
                 tool_list_changes: Default::default(),
-                legacy_tool_notifications: Default::default(),
                 cancellation_token: CancellationToken::new(),
                 mutation_mode: MutationMode::All,
                 disable_type_description: false,
@@ -3952,7 +3969,7 @@ mod integration_tests {
         fn create_service(
             running: Running,
             session_manager: Arc<LocalSessionManager>,
-        ) -> StreamableHttpService<Running, LocalSessionManager> {
+        ) -> StreamableHttpService<McpService, LocalSessionManager> {
             StreamableHttpService::new(
                 move || Ok(running.for_service()),
                 session_manager,
@@ -3962,7 +3979,7 @@ mod integration_tests {
 
         struct LegacyHttp {
             running: Running,
-            service: StreamableHttpService<Running, LocalSessionManager>,
+            service: StreamableHttpService<McpService, LocalSessionManager>,
         }
 
         impl LegacyHttp {
@@ -4010,18 +4027,18 @@ mod integration_tests {
                 .unwrap()
         }
 
-        async fn wait_for_forwarders(running: &Running, expected: usize) {
+        async fn wait_for_receivers(running: &Running, expected: usize) {
             tokio::time::timeout(std::time::Duration::from_secs(2), async {
                 while running.tool_list_changes.receiver_count() != expected {
                     tokio::task::yield_now().await;
                 }
             })
             .await
-            .expect("initialized notification must start a forwarder");
+            .expect("initialization must register a change receiver");
         }
 
         async fn initialize_legacy_session(
-            service: &StreamableHttpService<Running, LocalSessionManager>,
+            service: &StreamableHttpService<McpService, LocalSessionManager>,
             running: &Running,
         ) -> String {
             let previous = running.tool_list_changes.receiver_count();
@@ -4035,7 +4052,7 @@ mod integration_tests {
                 .to_str()
                 .unwrap()
                 .to_owned();
-            assert_eq!(running.tool_list_changes.receiver_count(), previous);
+            assert_eq!(running.tool_list_changes.receiver_count(), previous + 1);
 
             let response = service
                 .clone()
@@ -4047,19 +4064,32 @@ mod integration_tests {
                 .await
                 .unwrap();
             assert_eq!(response.status(), StatusCode::ACCEPTED);
-            wait_for_forwarders(running, previous + 1).await;
+            wait_for_receivers(running, previous + 1).await;
             session
         }
 
+        #[rstest::rstest]
         #[tokio::test]
+        #[timeout(std::time::Duration::from_secs(10))]
         async fn deleted_session_releases_forwarder_without_a_catalog_update() {
             let running = create_test_running();
             let session_manager: Arc<LocalSessionManager> = LocalSessionManager::default().into();
 
             let service = create_service(running.clone(), Arc::clone(&session_manager));
             let session_id = initialize_legacy_session(&service, &running).await;
+            let mut stream = service
+                .clone()
+                .oneshot(session_get(&session_id))
+                .await
+                .unwrap()
+                .into_body();
+            running.update_operations(vec![]).await;
+            assert_eq!(
+                next_message(&mut stream).await["method"],
+                "notifications/tools/list_changed"
+            );
 
-            // Delete the session — closes the session transport
+            // Delete an actively forwarding session, not just a pending receiver.
             let service = create_service(running.clone(), Arc::clone(&session_manager));
             let response = service
                 .oneshot(build_delete_request(&session_id))
@@ -4124,31 +4154,29 @@ mod integration_tests {
             session_request(session, http::Method::POST, body)
         }
 
+        #[rstest::rstest]
+        #[case::application(false)]
+        #[case::signal(true)]
         #[tokio::test]
-        async fn http_shutdown_releases_an_open_notification_stream() {
+        #[timeout(std::time::Duration::from_secs(10))]
+        async fn http_shutdown_releases_an_open_notification_stream(#[case] signal_shutdown: bool) {
+            use crate::server::states::starting::{build_http_service, serve_http};
             let running = create_test_running();
             let shutdown = running.cancellation_token.clone();
-            let service = StreamableHttpService::new(
-                {
-                    let running = running.clone();
-                    move || Ok(running.for_service())
-                },
-                Arc::new(LocalSessionManager::default()),
-                StreamableHttpServerConfig::default()
-                    .with_legacy_session_mode(true)
-                    .with_cancellation_token(shutdown.child_token()),
-            );
+            let service = build_http_service(running.clone(), true, &Default::default());
             let session = initialize_legacy_session(&service, &running).await;
             let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
             let address = listener.local_addr().unwrap();
-            let token = shutdown.clone();
-            let server = tokio::spawn(async move {
-                axum::serve(listener, axum::Router::new().nest_service("/mcp", service))
-                    .with_graceful_shutdown(token.cancelled_owned())
-                    .await
-                    .unwrap();
-            });
-            let response = reqwest::Client::new()
+            let (signal, received) = tokio::sync::oneshot::channel();
+            let server = tokio::spawn(serve_http(
+                listener,
+                axum::Router::new().nest_service("/mcp", service),
+                shutdown.clone(),
+                async move {
+                    received.await.unwrap();
+                },
+            ));
+            let mut response = reqwest::Client::new()
                 .get(format!("http://{address}/mcp"))
                 .header("Accept", "text/event-stream")
                 .header("Mcp-Session-Id", session)
@@ -4156,32 +4184,163 @@ mod integration_tests {
                 .await
                 .unwrap();
             assert_eq!(response.status(), StatusCode::OK);
+            running.update_operations(vec![]).await;
+            let mut received = String::new();
+            while !received.contains("notifications/tools/list_changed") {
+                let chunk = response
+                    .chunk()
+                    .await
+                    .unwrap()
+                    .expect("open notification stream");
+                received.push_str(&String::from_utf8_lossy(&chunk));
+            }
             assert_eq!(running.tool_list_changes.receiver_count(), 1);
-            shutdown.cancel();
-            tokio::time::timeout(std::time::Duration::from_secs(2), server)
-                .await
-                .unwrap()
-                .unwrap();
-            tokio::time::timeout(
-                std::time::Duration::from_secs(2),
-                running.tool_list_changes.closed(),
-            )
-            .await
-            .unwrap();
+            if signal_shutdown {
+                signal.send(()).unwrap();
+            } else {
+                shutdown.cancel();
+            }
+            server.await.unwrap().unwrap();
+            running.tool_list_changes.closed().await;
+            assert!(shutdown.is_cancelled());
             drop(response);
         }
 
+        #[rstest::rstest]
         #[tokio::test]
+        #[timeout(std::time::Duration::from_secs(10))]
+        async fn updates_while_initialized_callback_is_delayed_are_delivered() {
+            struct DelayedService {
+                service: McpService,
+                release: Arc<tokio::sync::Semaphore>,
+                entered: tokio::sync::mpsc::UnboundedSender<()>,
+            }
+            impl ServerHandler for DelayedService {
+                fn get_info(&self) -> ServerInfo {
+                    self.service.get_info()
+                }
+                async fn initialize(
+                    &self,
+                    request: InitializeRequestParams,
+                    context: RequestContext<RoleServer>,
+                ) -> Result<InitializeResult, McpError> {
+                    self.service.initialize(request, context).await
+                }
+                async fn on_initialized(&self, context: NotificationContext<RoleServer>) {
+                    self.entered.send(()).unwrap();
+                    self.release.acquire().await.unwrap().forget();
+                    self.service.on_initialized(context).await;
+                }
+                async fn list_tools(
+                    &self,
+                    request: Option<PaginatedRequestParams>,
+                    context: RequestContext<RoleServer>,
+                ) -> Result<ListToolsResult, McpError> {
+                    self.service.list_tools(request, context).await
+                }
+            }
+            let running = create_test_running();
+            let release = Arc::new(tokio::sync::Semaphore::new(0));
+            let (entered, mut callbacks) = tokio::sync::mpsc::unbounded_channel();
+            let service = StreamableHttpService::new(
+                {
+                    let running = running.clone();
+                    let release = release.clone();
+                    move || {
+                        Ok(DelayedService {
+                            service: running.for_service(),
+                            release: release.clone(),
+                            entered: entered.clone(),
+                        })
+                    }
+                },
+                Arc::new(LocalSessionManager::default()),
+                StreamableHttpServerConfig::default().with_legacy_session_mode(true),
+            );
+            let response = service
+                .clone()
+                .oneshot(build_initialize_request())
+                .await
+                .unwrap();
+            let session = response.headers()["Mcp-Session-Id"]
+                .to_str()
+                .unwrap()
+                .to_owned();
+            service
+                .clone()
+                .oneshot(session_post(
+                    &session,
+                    json!({"jsonrpc":"2.0","method":"notifications/initialized"}),
+                ))
+                .await
+                .unwrap();
+            callbacks.recv().await.unwrap();
+            let list = json!({"jsonrpc":"2.0","id":2,"method":"tools/list"});
+            let mut before = service
+                .clone()
+                .oneshot(session_post(&session, list.clone()))
+                .await
+                .unwrap()
+                .into_body();
+            assert!(
+                next_message(&mut before).await["result"]["tools"]
+                    .as_array()
+                    .unwrap()
+                    .is_empty()
+            );
+            let mut stream = service
+                .clone()
+                .oneshot(session_get(&session))
+                .await
+                .unwrap()
+                .into_body();
+            running
+                .update_operations(vec![("query Hello { hello }".to_owned(), None).into()])
+                .await;
+            // The update must be retained even though delivery has not started.
+            release.add_permits(1);
+            assert_eq!(
+                next_message(&mut stream).await["method"],
+                "notifications/tools/list_changed"
+            );
+            let mut after = service
+                .clone()
+                .oneshot(session_post(&session, list))
+                .await
+                .unwrap()
+                .into_body();
+            assert_eq!(
+                next_message(&mut after).await["result"]["tools"][0]["name"],
+                "Hello"
+            );
+            service
+                .oneshot(build_delete_request(&session))
+                .await
+                .unwrap();
+            running.tool_list_changes.closed().await;
+        }
+
+        #[rstest::rstest]
+        #[tokio::test]
+        #[timeout(std::time::Duration::from_secs(10))]
         async fn repeated_initialized_notifications_keep_one_forwarder() {
             // rmcp dispatches notifications concurrently. Observe completion of
             // each real callback rather than treating a later request as a barrier.
             struct ObservedService {
-                running: Running,
+                running: McpService,
                 completed: tokio::sync::mpsc::UnboundedSender<()>,
             }
             impl ServerHandler for ObservedService {
                 fn get_info(&self) -> ServerInfo {
                     self.running.get_info()
+                }
+
+                async fn initialize(
+                    &self,
+                    request: InitializeRequestParams,
+                    context: RequestContext<RoleServer>,
+                ) -> Result<InitializeResult, McpError> {
+                    self.running.initialize(request, context).await
                 }
 
                 async fn on_initialized(&self, context: NotificationContext<RoleServer>) {
@@ -4214,7 +4373,7 @@ mod integration_tests {
                 .to_str()
                 .unwrap()
                 .to_owned();
-            assert_eq!(running.tool_list_changes.receiver_count(), 0);
+            assert_eq!(running.tool_list_changes.receiver_count(), 1);
             for _ in 0..2 {
                 let response = service
                     .clone()
@@ -4243,7 +4402,9 @@ mod integration_tests {
             .unwrap();
         }
 
+        #[rstest::rstest]
         #[tokio::test]
+        #[timeout(std::time::Duration::from_secs(10))]
         async fn http_clients_receive_catalog_updates_across_sse_reconnects() {
             let mut running = create_test_running();
             running.enable_output_schema = true;
@@ -4327,7 +4488,9 @@ mod integration_tests {
             .unwrap();
         }
 
+        #[rstest::rstest]
         #[tokio::test]
+        #[timeout(std::time::Duration::from_secs(10))]
         async fn stdio_delivers_changes_and_releases_forwarder_on_disconnect() {
             use rmcp::ServiceExt as _;
             use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
@@ -4361,13 +4524,13 @@ mod integration_tests {
                     .get("result")
                     .is_some()
             );
-            assert_eq!(running.tool_list_changes.receiver_count(), 0);
+            assert_eq!(running.tool_list_changes.receiver_count(), 1);
             let initialized = json!({"jsonrpc": "2.0", "method": "notifications/initialized"});
             writer
                 .write_all(format!("{initialized}\n").as_bytes())
                 .await
                 .unwrap();
-            wait_for_forwarders(&running, 1).await;
+            wait_for_receivers(&running, 1).await;
             drop(intermediate_clone);
             running.update_operations(vec![]).await;
             line.clear();
@@ -4424,7 +4587,6 @@ mod integration_tests {
                 validate_tool: None,
                 custom_scalar_map: None,
                 tool_list_changes: Default::default(),
-                legacy_tool_notifications: Default::default(),
                 cancellation_token: CancellationToken::new(),
                 mutation_mode: MutationMode::None,
                 disable_type_description: false,
@@ -4497,7 +4659,6 @@ mod integration_tests {
                 validate_tool: None,
                 custom_scalar_map: None,
                 tool_list_changes: Default::default(),
-                legacy_tool_notifications: Default::default(),
                 cancellation_token: CancellationToken::new(),
                 mutation_mode: MutationMode::None,
                 disable_type_description: false,
@@ -4517,7 +4678,7 @@ mod integration_tests {
         fn create_service(
             running: Running,
             session_manager: Arc<LocalSessionManager>,
-        ) -> StreamableHttpService<Running, LocalSessionManager> {
+        ) -> StreamableHttpService<McpService, LocalSessionManager> {
             StreamableHttpService::new(
                 move || Ok(running.for_service()),
                 session_manager,
@@ -4582,8 +4743,9 @@ mod integration_tests {
                 description: Some("Custom fleet description".to_string()),
                 ..Default::default()
             });
-            let expected_capabilities = serde_json::to_value(running.get_info().capabilities)
-                .expect("capabilities serialize");
+            let expected_capabilities =
+                serde_json::to_value(running.for_service().get_info().capabilities)
+                    .expect("capabilities serialize");
 
             let result = discover(running).await;
 
@@ -4644,6 +4806,7 @@ mod integration_tests {
 
             let server = tokio::spawn(async move {
                 let service = create_test_running(ServerInfoConfig::default())
+                    .for_service()
                     .serve((server_r, server_w))
                     .await
                     .expect("stdio serve should accept a discover opener");

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -3598,45 +3598,10 @@ mod integration_tests {
         use rmcp::transport::{StreamableHttpServerConfig, StreamableHttpService};
         use serde_json::json;
         use std::sync::Arc;
-        use tokio::sync::RwLock;
         use tower::ServiceExt;
 
+        use super::super::test_support::create_test_running;
         use super::*;
-
-        fn create_test_running() -> Running {
-            let schema =
-                apollo_compiler::Schema::parse_and_validate("type Query { hello: String }", "test")
-                    .unwrap();
-            Running {
-                schema: Arc::new(RwLock::new(schema)),
-                operations: Arc::new(RwLock::new(vec![])),
-                apps: vec![],
-                prompts: vec![],
-                headers: http::HeaderMap::new(),
-                forward_headers: vec![],
-                endpoint: url::Url::parse("http://localhost:4000").unwrap(),
-                execute_tool: None,
-                introspect_tool: None,
-                search_tool: None,
-                explorer_tool: None,
-                validate_tool: None,
-                custom_scalar_map: None,
-                tool_list_changes: Default::default(),
-                cancellation_token: CancellationToken::new(),
-                mutation_mode: MutationMode::All,
-                disable_type_description: false,
-                disable_schema_description: false,
-                enable_output_schema: false,
-                disable_auth_token_passthrough: false,
-                descriptions: HashMap::new(),
-                annotations: HashMap::new(),
-                health_check: None,
-                server_info: Default::default(),
-                instructions: None,
-                rhai_engine: Arc::new(parking_lot::Mutex::new(RhaiEngine::new("rhai"))),
-                caching: Caching::default(),
-            }
-        }
 
         fn create_test_service(
             stateful_mode: bool,
@@ -3919,46 +3884,10 @@ mod integration_tests {
         use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
         use rmcp::transport::{StreamableHttpServerConfig, StreamableHttpService};
         use serde_json::json;
-        use tokio::sync::RwLock;
         use tower::ServiceExt;
 
-        use super::super::test_support::{SseReader, next_message};
+        use super::super::test_support::{SseReader, create_test_running, next_message};
         use super::*;
-
-        fn create_test_running() -> Running {
-            let schema =
-                apollo_compiler::Schema::parse_and_validate("type Query { hello: String }", "test")
-                    .unwrap();
-            Running {
-                schema: Arc::new(RwLock::new(schema)),
-                operations: Arc::new(RwLock::new(vec![])),
-                apps: vec![],
-                prompts: vec![],
-                headers: http::HeaderMap::new(),
-                forward_headers: vec![],
-                endpoint: url::Url::parse("http://localhost:4000").unwrap(),
-                execute_tool: None,
-                introspect_tool: None,
-                search_tool: None,
-                explorer_tool: None,
-                validate_tool: None,
-                custom_scalar_map: None,
-                tool_list_changes: Default::default(),
-                cancellation_token: CancellationToken::new(),
-                mutation_mode: MutationMode::All,
-                disable_type_description: false,
-                disable_schema_description: false,
-                enable_output_schema: false,
-                disable_auth_token_passthrough: false,
-                descriptions: HashMap::new(),
-                annotations: HashMap::new(),
-                health_check: None,
-                server_info: Default::default(),
-                instructions: None,
-                rhai_engine: Arc::new(parking_lot::Mutex::new(RhaiEngine::new("rhai"))),
-                caching: Caching::default(),
-            }
-        }
 
         fn create_service(
             running: Running,

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -823,7 +823,8 @@ impl ServerHandler for McpService {
     ) -> Result<ListPromptsResult, McpError> {
         let protocol_version = context.protocol_version();
 
-        self.application.list_prompts_impl(protocol_version.as_ref())
+        self.application
+            .list_prompts_impl(protocol_version.as_ref())
     }
 
     #[tracing::instrument(skip_all, fields(apollo.mcp.prompt_name = request.name))]
@@ -3088,19 +3089,11 @@ mod integration_tests {
             service.cancel().await.unwrap();
         }
         #[tokio::test]
-        async fn omits_cache_hints_after_initializing_supported_protocol() {
+        async fn omits_cache_hints_before_the_fields_were_supported() {
             let mut running = create_running_with_output_schema();
             running.caching.ttl_ms = 60_000;
-            let session_manager: Arc<LocalSessionManager> = LocalSessionManager::default().into();
-            let session_id = initialize_session(&running, &session_manager, "2025-11-25").await;
-
-            let service = create_service(running, session_manager);
-            let response = service
-                .oneshot(build_tools_list_request(&session_id))
-                .await
-                .unwrap();
-            assert_eq!(response.status(), StatusCode::OK);
-            let body = extract_json_body(response).await;
+            let body =
+                super::stateless_request(running, "2025-11-25", "tools/list", json!({})).await;
             let result = &body["result"];
             assert!(
                 !result["tools"]
@@ -3118,7 +3111,7 @@ mod integration_tests {
         ) -> serde_json::Value {
             let running = create_running_with_output_schema();
             let service = StreamableHttpService::new(
-                move || Ok(running.clone()),
+                move || Ok(running.for_service()),
                 Arc::new(LocalSessionManager::default()),
                 StreamableHttpServerConfig::default().with_legacy_session_mode(legacy_session_mode),
             );

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -16,13 +16,13 @@ use rmcp::model::{
     ToolsCapability,
 };
 use rmcp::{
-    Peer, RoleServer, ServerHandler, ServiceError,
+    RoleServer, ServerHandler,
     model::{
         CallToolRequestParams, CallToolResult, ContentBlock, ErrorCode, InitializeRequestParams,
         InitializeResult, ListToolsResult, PaginatedRequestParams, ProtocolVersion,
         ServerCapabilities, ServerInfo,
     },
-    service::RequestContext,
+    service::{NotificationContext, RequestContext},
 };
 use serde_json::Value;
 use tokio::sync::RwLock;
@@ -56,6 +56,8 @@ use crate::{
 };
 use apollo_mcp_rhai::RhaiEngine;
 
+use super::tool_list_changes::{LegacyToolNotifications, ToolListChanges};
+
 #[derive(Clone)]
 pub(super) struct Running {
     pub(super) schema: Arc<RwLock<Valid<Schema>>>,
@@ -71,7 +73,8 @@ pub(super) struct Running {
     pub(super) explorer_tool: Option<Explorer>,
     pub(super) validate_tool: Option<Validate>,
     pub(super) custom_scalar_map: Option<CustomScalarMap>,
-    pub(super) peers: Arc<RwLock<Vec<Peer<RoleServer>>>>,
+    pub(super) tool_list_changes: ToolListChanges,
+    pub(super) legacy_tool_notifications: LegacyToolNotifications,
     pub(super) cancellation_token: CancellationToken,
     pub(super) mutation_mode: MutationMode,
     pub(super) disable_type_description: bool,
@@ -115,6 +118,15 @@ impl<'a> PeerContext<'a> {
 }
 
 impl Running {
+    /// Create a fresh notification owner for an rmcp service. Clones of the
+    /// returned handler share that owner; the application handler never retains it.
+    pub(super) fn for_service(&self) -> Self {
+        Self {
+            legacy_tool_notifications: LegacyToolNotifications::for_service(),
+            ..self.clone()
+        }
+    }
+
     /// Returns true when `enable_output_schema` is active and the negotiated
     /// protocol version supports `outputSchema` / `structuredContent` (MCP 2025-06-18+).
     fn client_supports_output_schema(&self, protocol_version: Option<&ProtocolVersion>) -> bool {
@@ -166,15 +178,11 @@ impl Running {
 
         *operations_lock = operations;
 
-        // Drop the operations lock before notifying peers. The operations are
-        // already written, so clients will see the updated list when they
-        // re-fetch. Holding the lock during notification can starve all
-        // list_tools / call_tool / initialize requests if any peer notification
-        // is slow or hangs.
+        // Publish only after the updated catalog is visible to readers.
         drop(operations_lock);
 
         // Notify MCP clients that tools have changed
-        Self::notify_tool_list_changed(self.peers.clone()).await;
+        self.tool_list_changes.publish();
     }
 
     /// Replaces the current predefined operation catalog with the latest source update.
@@ -219,11 +227,11 @@ impl Running {
         );
         *operations_lock = updated_operations;
 
-        // Drop the operations lock before notifying peers (same rationale as update_schema).
+        // Publish only after the updated catalog is visible to readers.
         drop(operations_lock);
 
         // Notify MCP clients that tools have changed
-        Self::notify_tool_list_changed(self.peers.clone()).await;
+        self.tool_list_changes.publish();
     }
 
     /// Reload Rhai scripts from the configured Rhai directory.
@@ -238,68 +246,6 @@ impl Running {
                 error!("Failed to reload Rhai scripts, keeping previous version: {err}");
             }
         }
-    }
-
-    /// Notify any peers that tools have changed. Drops unreachable peers from the list.
-    ///
-    /// Locking strategy: snapshot the peer list under a **read** lock, notify
-    /// without holding any lock, then briefly take a **write** lock only to
-    /// swap in the retained list. This keeps the write-lock hold time
-    /// negligible regardless of how many peers need notifying.
-    #[tracing::instrument(skip_all)]
-    async fn notify_tool_list_changed(peers: Arc<RwLock<Vec<Peer<RoleServer>>>>) {
-        const PEER_NOTIFY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
-
-        // Snapshot under read lock, then release immediately so concurrent
-        // initialize requests can register new peers without blocking.
-        let snapshot: Vec<_> = {
-            let guard = peers.read().await;
-            if guard.is_empty() {
-                return;
-            }
-            debug!(
-                "Operations changed, notifying {} peers of tool change",
-                guard.len()
-            );
-            guard.clone()
-        };
-        let snapshot_len = snapshot.len();
-
-        // Notify without holding any lock.
-        let mut retained_peers = Vec::new();
-        for peer in &snapshot {
-            if !peer.is_transport_closed() {
-                match tokio::time::timeout(PEER_NOTIFY_TIMEOUT, peer.notify_tool_list_changed())
-                    .await
-                {
-                    Ok(Ok(_)) => retained_peers.push(peer.clone()),
-                    Ok(Err(ServiceError::TransportSend(_) | ServiceError::TransportClosed)) => {
-                        error!("Failed to notify peer of tool list change - dropping peer");
-                    }
-                    Ok(Err(e)) => {
-                        error!("Failed to notify peer of tool list change {:?}", e);
-                        retained_peers.push(peer.clone());
-                    }
-                    Err(_) => {
-                        error!(
-                            "Timed out notifying peer of tool list change after {}s - dropping peer",
-                            PEER_NOTIFY_TIMEOUT.as_secs()
-                        );
-                    }
-                }
-            }
-        }
-
-        // Brief write lock: replace the snapshot portion with retained peers,
-        // preserving any peers added by concurrent initialize calls.
-        let mut guard = peers.write().await;
-        let new_peers: Vec<_> = if guard.len() > snapshot_len {
-            guard.split_off(snapshot_len)
-        } else {
-            vec![]
-        };
-        *guard = retained_peers;
-        guard.extend(new_peers);
     }
 
     async fn list_tools_impl(
@@ -755,9 +701,6 @@ impl ServerHandler for Running {
             .u64_counter(TelemetryMetric::InitializeCount.as_str())
             .build()
             .add(1, &attributes);
-        // TODO: how to remove these?
-        let mut peers = self.peers.write().await;
-        peers.push(context.peer);
         // Echo the client's requested protocol version when supported,
         // falling back to our max supported version otherwise (#794). rmcp's
         // handshake re-negotiates this after `initialize` on every
@@ -766,6 +709,14 @@ impl ServerHandler for Running {
         let mut info = self.get_info();
         info.protocol_version = negotiate_protocol_version(&request.protocol_version);
         Ok(info)
+    }
+
+    async fn on_initialized(&self, context: NotificationContext<RoleServer>) {
+        self.legacy_tool_notifications.on_initialized(
+            context.peer,
+            &self.tool_list_changes,
+            self.cancellation_token.clone(),
+        );
     }
 
     /// Narrows rmcp's re-negotiation (run on every transport after
@@ -790,11 +741,10 @@ impl ServerHandler for Running {
             span.record("apollo.mcp.tool_arguments", json.as_str());
         }
 
-        let peer_info = context.peer.peer_info();
-        let protocol_version = peer_info.as_ref().map(|info| &info.protocol_version);
+        let protocol_version = context.protocol_version();
 
         let result = self
-            .call_tool_impl(request, &context.extensions, protocol_version)
+            .call_tool_impl(request, &context.extensions, protocol_version.as_ref())
             .await;
 
         // Strip meta before recording: _meta.structuredContent holds the unfiltered
@@ -816,10 +766,11 @@ impl ServerHandler for Running {
         _request: Option<PaginatedRequestParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
-        let peer_info = context.peer.peer_info();
+        let client_capabilities = context.client_capabilities();
+        let protocol_version = context.protocol_version();
         let peer = PeerContext {
-            client_capabilities: peer_info.as_ref().map(|info| &info.capabilities),
-            protocol_version: peer_info.as_ref().map(|info| &info.protocol_version),
+            client_capabilities: client_capabilities.as_ref(),
+            protocol_version: protocol_version.as_ref(),
         };
 
         self.list_tools_impl(context.extensions, peer).await
@@ -843,10 +794,11 @@ impl ServerHandler for Running {
         request: rmcp::model::ReadResourceRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResponse, ErrorData> {
-        let peer_info = context.peer.peer_info();
+        let client_capabilities = context.client_capabilities();
+        let protocol_version = context.protocol_version();
         let peer = PeerContext {
-            client_capabilities: peer_info.as_ref().map(|info| &info.capabilities),
-            protocol_version: peer_info.as_ref().map(|info| &info.protocol_version),
+            client_capabilities: client_capabilities.as_ref(),
+            protocol_version: protocol_version.as_ref(),
         };
 
         self.read_resource_impl(request, context.extensions, peer)
@@ -978,7 +930,8 @@ mod tests {
             explorer_tool: None,
             validate_tool: None,
             custom_scalar_map: None,
-            peers: Arc::new(RwLock::new(vec![])),
+            tool_list_changes: Default::default(),
+            legacy_tool_notifications: Default::default(),
             cancellation_token: CancellationToken::new(),
             mutation_mode: MutationMode::None,
             disable_type_description: false,
@@ -1112,6 +1065,69 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn request_capabilities_override_legacy_info_without_leaking_to_later_requests() {
+        use crate::apps::app::{AppResourceSource, TargetedAppResource};
+        use rmcp::model::{ReadResourceRequestParams, ResourceContents};
+
+        let mut running = running_with_apps(
+            AppResource::Targeted(TargetedAppResource {
+                openai: Some(AppResourceSource::Local("openai resource".into())),
+                mcp: Some(AppResourceSource::Local("mcp resource".into())),
+            }),
+            None,
+            None,
+        );
+        running.apps[0].tools[0].labels.tool_invocation_invoking = Some("Loading".into());
+        let legacy_info = serde_json::from_value(serde_json::json!({
+            "protocolVersion": "2025-11-25", "capabilities": {},
+            "clientInfo": {"name": "legacy", "version": "1"}
+        }))
+        .unwrap();
+        let (server_io, _client_io) = tokio::io::duplex(4096);
+        let service = rmcp::service::serve_directly(running.clone(), server_io, Some(legacy_info));
+        let mcp_capabilities: ClientCapabilities = serde_json::from_value(serde_json::json!({
+            "extensions": {"io.modelcontextprotocol/ui": {"mimeTypes": ["text/html;profile=mcp-app"]}}
+        })).unwrap();
+
+        for (capabilities, expected_resource, openai) in [
+            (Some(mcp_capabilities), "mcp resource", false),
+            (None, "openai resource", true),
+        ] {
+            let mut context =
+                RequestContext::new(rmcp::model::RequestId::Number(1), service.peer().clone());
+            let (parts, _) = http::Request::builder()
+                .uri("http://localhost?app=MyApp")
+                .body(())
+                .unwrap()
+                .into_parts();
+            context.extensions.insert(parts);
+            if let Some(capabilities) = capabilities {
+                context.meta.set_client_capabilities(capabilities);
+            }
+            let tools = running.list_tools(None, context.clone()).await.unwrap();
+            assert_eq!(
+                tools.tools[0]
+                    .meta
+                    .as_ref()
+                    .unwrap()
+                    .contains_key("openai/toolInvocation/invoking"),
+                openai
+            );
+            let resource = running
+                .read_resource(ReadResourceRequestParams::new(RESOURCE_URI), context)
+                .await
+                .unwrap();
+            let rmcp::model::ReadResourceResponse::Complete(resource) = resource else {
+                panic!("expected resource result");
+            };
+            let ResourceContents::TextResourceContents { text, .. } = &resource.contents[0] else {
+                panic!("expected text resource");
+            };
+            assert_eq!(text, expected_resource);
+        }
+        service.cancel().await.unwrap();
+    }
     mod protocol_version_negotiation {
         use rstest::rstest;
 
@@ -2857,6 +2873,51 @@ mod tests {
 mod integration_tests {
     use super::*;
 
+    /// Exercise the supported sessionless transport without an initialize handshake.
+    async fn stateless_request(
+        running: Running,
+        version: &str,
+        method: &str,
+        params: Value,
+    ) -> Value {
+        use axum::body::Body;
+        use http_body_util::BodyExt as _;
+        use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+        use rmcp::transport::{StreamableHttpServerConfig, StreamableHttpService};
+        use tower::ServiceExt as _;
+
+        let changes = running.tool_list_changes.clone();
+        let service = StreamableHttpService::new(
+            move || Ok(running.for_service()),
+            Arc::new(LocalSessionManager::default()),
+            StreamableHttpServerConfig::default()
+                .with_legacy_session_mode(false)
+                .with_json_response(true),
+        );
+        let request = http::Request::builder()
+            .method("POST")
+            .uri("/mcp")
+            .header("Host", "localhost")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .header("Mcp-Protocol-Version", version)
+            .body(Body::from(
+                serde_json::json!({"jsonrpc": "2.0", "id": 1, "method": method, "params": params})
+                    .to_string(),
+            ))
+            .unwrap();
+        let response = service.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), http::StatusCode::OK);
+        assert!(!response.headers().contains_key("Mcp-Session-Id"));
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(
+            changes.receiver_count(),
+            0,
+            "sessionless requests must not retain a forwarder"
+        );
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
     mod output_schema_gating {
         use std::sync::Arc;
 
@@ -2906,7 +2967,8 @@ mod integration_tests {
                 explorer_tool: None,
                 validate_tool: None,
                 custom_scalar_map: None,
-                peers: Arc::new(RwLock::new(vec![])),
+                tool_list_changes: Default::default(),
+                legacy_tool_notifications: Default::default(),
                 cancellation_token: CancellationToken::new(),
                 mutation_mode: MutationMode::None,
                 disable_type_description: false,
@@ -2928,7 +2990,7 @@ mod integration_tests {
             session_manager: Arc<LocalSessionManager>,
         ) -> StreamableHttpService<Running, LocalSessionManager> {
             StreamableHttpService::new(
-                move || Ok(running.clone()),
+                move || Ok(running.for_service()),
                 session_manager,
                 StreamableHttpServerConfig::default().with_legacy_session_mode(true),
             )
@@ -2958,49 +3020,6 @@ mod integration_tests {
                 .unwrap()
         }
 
-        fn build_notification_request(session_id: &str) -> Request<Body> {
-            let body = json!({
-                "jsonrpc": "2.0",
-                "method": "notifications/initialized"
-            });
-            Request::builder()
-                .method("POST")
-                .uri("/mcp")
-                .header("Host", "localhost:8000")
-                .header("Content-Type", "application/json")
-                .header("Accept", "application/json, text/event-stream")
-                .header("Mcp-Session-Id", session_id)
-                .body(Body::from(body.to_string()))
-                .unwrap()
-        }
-
-        fn build_tools_list_request(session_id: &str) -> Request<Body> {
-            let body = json!({
-                "jsonrpc": "2.0",
-                "id": 2,
-                "method": "tools/list"
-            });
-            Request::builder()
-                .method("POST")
-                .uri("/mcp")
-                .header("Host", "localhost:8000")
-                .header("Content-Type", "application/json")
-                .header("Accept", "application/json, text/event-stream")
-                .header("Mcp-Session-Id", session_id)
-                .body(Body::from(body.to_string()))
-                .unwrap()
-        }
-
-        fn extract_session_id<B>(response: &http::Response<B>) -> String {
-            response
-                .headers()
-                .get("mcp-session-id")
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .to_string()
-        }
-
         async fn extract_json_body<B>(response: http::Response<B>) -> serde_json::Value
         where
             B: BodyExt,
@@ -3023,46 +3042,33 @@ mod integration_tests {
             panic!("no JSON data found in SSE response");
         }
 
-        async fn initialize_session(
-            running: &Running,
-            session_manager: &Arc<LocalSessionManager>,
-            protocol_version: &str,
-        ) -> String {
-            let service = create_service(running.clone(), Arc::clone(session_manager));
-            let response = service
-                .oneshot(build_initialize_request(protocol_version))
-                .await
-                .unwrap();
-            assert_eq!(response.status(), StatusCode::OK);
-            let session_id = extract_session_id(&response);
-
-            let service = create_service(running.clone(), Arc::clone(session_manager));
-            let response = service
-                .oneshot(build_notification_request(&session_id))
-                .await
-                .unwrap();
-            assert_eq!(response.status(), StatusCode::ACCEPTED);
-
-            session_id
+        #[tokio::test]
+        async fn list_tools_uses_request_protocol_with_legacy_fallback() {
+            let running = create_running_with_output_schema();
+            let (server_io, _client_io) = tokio::io::duplex(4096);
+            let legacy_info = serde_json::from_value(json!({
+                "protocolVersion":"2025-03-26", "capabilities":{}, "clientInfo":{"name":"legacy", "version":"1"}
+            })).unwrap();
+            let service =
+                rmcp::service::serve_directly(running.clone(), server_io, Some(legacy_info));
+            for (version, expected_output_schema) in [
+                (None, false),
+                (Some(ProtocolVersion::V_2025_06_18), true),
+                (None, false),
+            ] {
+                let mut context =
+                    RequestContext::new(rmcp::model::RequestId::Number(1), service.peer().clone());
+                if let Some(version) = version {
+                    context.meta.set_protocol_version(version);
+                }
+                let tools = running.list_tools(None, context).await.unwrap();
+                assert_eq!(
+                    tools.tools[0].output_schema.is_some(),
+                    expected_output_schema
+                );
+            }
+            service.cancel().await.unwrap();
         }
-
-        async fn list_tools(
-            running: Running,
-            session_manager: Arc<LocalSessionManager>,
-            session_id: &str,
-        ) -> Vec<serde_json::Value> {
-            let service = create_service(running, session_manager);
-            let response = service
-                .oneshot(build_tools_list_request(session_id))
-                .await
-                .unwrap();
-            let body = extract_json_body(response).await;
-            body["result"]["tools"]
-                .as_array()
-                .expect("tools/list should return a tools array")
-                .clone()
-        }
-
         #[tokio::test]
         async fn omits_cache_hints_after_initializing_supported_protocol() {
             let mut running = create_running_with_output_schema();
@@ -3155,13 +3161,12 @@ mod integration_tests {
         #[tokio::test]
         async fn excludes_output_schema_when_protocol_predates_it() {
             let running = create_running_with_output_schema();
-            let session_manager: Arc<LocalSessionManager> = LocalSessionManager::default().into();
-            let session_id = initialize_session(&running, &session_manager, "2025-03-26").await;
-
-            let tools = list_tools(running, session_manager, &session_id).await;
+            let body =
+                super::stateless_request(running, "2025-03-26", "tools/list", json!({})).await;
+            let tools = body["result"]["tools"].as_array().unwrap();
 
             assert!(!tools.is_empty());
-            for tool in &tools {
+            for tool in tools {
                 assert!(
                     tool.get("outputSchema").is_none(),
                     "tool '{}' should not have outputSchema with protocol 2025-03-26",
@@ -3173,13 +3178,12 @@ mod integration_tests {
         #[tokio::test]
         async fn includes_output_schema_when_protocol_supports_it() {
             let running = create_running_with_output_schema();
-            let session_manager: Arc<LocalSessionManager> = LocalSessionManager::default().into();
-            let session_id = initialize_session(&running, &session_manager, "2025-06-18").await;
-
-            let tools = list_tools(running, session_manager, &session_id).await;
+            let body =
+                super::stateless_request(running, "2025-06-18", "tools/list", json!({})).await;
+            let tools = body["result"]["tools"].as_array().unwrap();
 
             assert!(!tools.is_empty());
-            for tool in &tools {
+            for tool in tools {
                 assert!(
                     tool.get("outputSchema").is_some(),
                     "tool '{}' should have outputSchema with protocol 2025-06-18",
@@ -3341,7 +3345,7 @@ mod integration_tests {
             session_manager: Arc<LocalSessionManager>,
         ) -> StreamableHttpService<Running, LocalSessionManager> {
             StreamableHttpService::new(
-                move || Ok(running.clone()),
+                move || Ok(running.for_service()),
                 session_manager,
                 StreamableHttpServerConfig::default().with_legacy_session_mode(false),
             )
@@ -3462,14 +3466,8 @@ mod integration_tests {
     mod structured_content_gating {
         use std::sync::Arc;
 
-        use axum::body::Body;
-        use http::{Request, StatusCode};
-        use http_body_util::BodyExt;
-        use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
-        use rmcp::transport::{StreamableHttpServerConfig, StreamableHttpService};
         use serde_json::json;
         use tokio::sync::RwLock;
-        use tower::ServiceExt;
 
         use super::*;
         use crate::operations::RawOperation;
@@ -3508,7 +3506,8 @@ mod integration_tests {
                 explorer_tool: None,
                 validate_tool: None,
                 custom_scalar_map: None,
-                peers: Arc::new(RwLock::new(vec![])),
+                tool_list_changes: Default::default(),
+                legacy_tool_notifications: Default::default(),
                 cancellation_token: CancellationToken::new(),
                 mutation_mode: MutationMode::None,
                 disable_type_description: false,
@@ -3525,143 +3524,6 @@ mod integration_tests {
             }
         }
 
-        fn create_service(
-            running: Running,
-            session_manager: Arc<LocalSessionManager>,
-        ) -> StreamableHttpService<Running, LocalSessionManager> {
-            StreamableHttpService::new(
-                move || Ok(running.clone()),
-                session_manager,
-                StreamableHttpServerConfig::default().with_legacy_session_mode(true),
-            )
-        }
-
-        fn build_initialize_request(protocol_version: &str) -> Request<Body> {
-            let body = json!({
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "initialize",
-                "params": {
-                    "protocolVersion": protocol_version,
-                    "capabilities": {},
-                    "clientInfo": {
-                        "name": "test-client",
-                        "version": "1.0.0"
-                    }
-                }
-            });
-            Request::builder()
-                .method("POST")
-                .uri("/mcp")
-                .header("Host", "localhost:8000")
-                .header("Content-Type", "application/json")
-                .header("Accept", "application/json, text/event-stream")
-                .body(Body::from(body.to_string()))
-                .unwrap()
-        }
-
-        fn build_notification_request(session_id: &str) -> Request<Body> {
-            let body = json!({
-                "jsonrpc": "2.0",
-                "method": "notifications/initialized"
-            });
-            Request::builder()
-                .method("POST")
-                .uri("/mcp")
-                .header("Host", "localhost:8000")
-                .header("Content-Type", "application/json")
-                .header("Accept", "application/json, text/event-stream")
-                .header("Mcp-Session-Id", session_id)
-                .body(Body::from(body.to_string()))
-                .unwrap()
-        }
-
-        fn build_call_tool_request(session_id: &str, tool_name: &str) -> Request<Body> {
-            let body = json!({
-                "jsonrpc": "2.0",
-                "id": 3,
-                "method": "tools/call",
-                "params": {
-                    "name": tool_name,
-                    "arguments": {}
-                }
-            });
-            Request::builder()
-                .method("POST")
-                .uri("/mcp")
-                .header("Host", "localhost:8000")
-                .header("Content-Type", "application/json")
-                .header("Accept", "application/json, text/event-stream")
-                .header("Mcp-Session-Id", session_id)
-                .body(Body::from(body.to_string()))
-                .unwrap()
-        }
-
-        fn extract_session_id<B>(response: &http::Response<B>) -> String {
-            response
-                .headers()
-                .get("mcp-session-id")
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .to_string()
-        }
-
-        async fn extract_json_body<B>(response: http::Response<B>) -> serde_json::Value
-        where
-            B: BodyExt,
-            B::Error: std::fmt::Debug,
-        {
-            let bytes = response.into_body().collect().await.unwrap().to_bytes();
-            let body_str = String::from_utf8_lossy(&bytes);
-
-            for line in body_str.lines() {
-                if let Some(data) = line.strip_prefix("data: ")
-                    && let Ok(val) = serde_json::from_str::<serde_json::Value>(data)
-                {
-                    return val;
-                }
-            }
-            panic!("no JSON data found in SSE response");
-        }
-
-        async fn initialize_session(
-            running: &Running,
-            session_manager: &Arc<LocalSessionManager>,
-            protocol_version: &str,
-        ) -> String {
-            let service = create_service(running.clone(), Arc::clone(session_manager));
-            let response = service
-                .oneshot(build_initialize_request(protocol_version))
-                .await
-                .unwrap();
-            assert_eq!(response.status(), StatusCode::OK);
-            let session_id = extract_session_id(&response);
-
-            let service = create_service(running.clone(), Arc::clone(session_manager));
-            let response = service
-                .oneshot(build_notification_request(&session_id))
-                .await
-                .unwrap();
-            assert_eq!(response.status(), StatusCode::ACCEPTED);
-
-            session_id
-        }
-
-        async fn call_tool(
-            running: Running,
-            session_manager: Arc<LocalSessionManager>,
-            session_id: &str,
-            tool_name: &str,
-        ) -> serde_json::Value {
-            let service = create_service(running, session_manager);
-            let response = service
-                .oneshot(build_call_tool_request(session_id, tool_name))
-                .await
-                .unwrap();
-            extract_json_body(response).await
-        }
-
         #[tokio::test]
         async fn strips_structured_content_when_protocol_predates_it() {
             let mut server = mockito::Server::new_async().await;
@@ -3672,10 +3534,13 @@ mod integration_tests {
                 .await;
 
             let running = create_running_with_mock_endpoint(server.url().parse().unwrap());
-            let session_manager: Arc<LocalSessionManager> = LocalSessionManager::default().into();
-            let session_id = initialize_session(&running, &session_manager, "2025-03-26").await;
-
-            let body = call_tool(running, session_manager, &session_id, "Hello").await;
+            let body = super::stateless_request(
+                running,
+                "2025-03-26",
+                "tools/call",
+                json!({"name": "Hello", "arguments": {}}),
+            )
+            .await;
 
             mock.assert();
             let result = &body["result"];
@@ -3695,10 +3560,13 @@ mod integration_tests {
                 .await;
 
             let running = create_running_with_mock_endpoint(server.url().parse().unwrap());
-            let session_manager: Arc<LocalSessionManager> = LocalSessionManager::default().into();
-            let session_id = initialize_session(&running, &session_manager, "2025-06-18").await;
-
-            let body = call_tool(running, session_manager, &session_id, "Hello").await;
+            let body = super::stateless_request(
+                running,
+                "2025-06-18",
+                "tools/call",
+                json!({"name": "Hello", "arguments": {}}),
+            )
+            .await;
 
             mock.assert();
             let result = &body["result"];
@@ -3741,7 +3609,8 @@ mod integration_tests {
                 explorer_tool: None,
                 validate_tool: None,
                 custom_scalar_map: None,
-                peers: Arc::new(RwLock::new(vec![])),
+                tool_list_changes: Default::default(),
+                legacy_tool_notifications: Default::default(),
                 cancellation_token: CancellationToken::new(),
                 mutation_mode: MutationMode::All,
                 disable_type_description: false,
@@ -3763,7 +3632,7 @@ mod integration_tests {
         ) -> StreamableHttpService<Running, LocalSessionManager> {
             let running = create_test_running();
             StreamableHttpService::new(
-                move || Ok(running.clone()),
+                move || Ok(running.for_service()),
                 LocalSessionManager::default().into(),
                 StreamableHttpServerConfig::default().with_legacy_session_mode(stateful_mode),
             )
@@ -3774,7 +3643,7 @@ mod integration_tests {
             session_manager: Arc<LocalSessionManager>,
         ) -> StreamableHttpService<Running, LocalSessionManager> {
             StreamableHttpService::new(
-                move || Ok(running.clone()),
+                move || Ok(running.for_service()),
                 session_manager,
                 StreamableHttpServerConfig::default().with_legacy_session_mode(true),
             )
@@ -4031,7 +3900,7 @@ mod integration_tests {
         }
     }
 
-    mod peer_cleanup {
+    mod legacy_notifications {
         use std::sync::Arc;
 
         use axum::body::Body;
@@ -4062,7 +3931,8 @@ mod integration_tests {
                 explorer_tool: None,
                 validate_tool: None,
                 custom_scalar_map: None,
-                peers: Arc::new(RwLock::new(vec![])),
+                tool_list_changes: Default::default(),
+                legacy_tool_notifications: Default::default(),
                 cancellation_token: CancellationToken::new(),
                 mutation_mode: MutationMode::All,
                 disable_type_description: false,
@@ -4084,10 +3954,26 @@ mod integration_tests {
             session_manager: Arc<LocalSessionManager>,
         ) -> StreamableHttpService<Running, LocalSessionManager> {
             StreamableHttpService::new(
-                move || Ok(running.clone()),
+                move || Ok(running.for_service()),
                 session_manager,
                 StreamableHttpServerConfig::default().with_legacy_session_mode(true),
             )
+        }
+
+        struct LegacyHttp {
+            running: Running,
+            service: StreamableHttpService<Running, LocalSessionManager>,
+        }
+
+        impl LegacyHttp {
+            fn new(running: Running) -> Self {
+                let service = create_service(running.clone(), Arc::default());
+                Self { running, service }
+            }
+
+            async fn connect(&self) -> String {
+                initialize_legacy_session(&self.service, &self.running).await
+            }
         }
 
         fn build_initialize_request() -> Request<Body> {
@@ -4096,7 +3982,7 @@ mod integration_tests {
                 "id": 1,
                 "method": "initialize",
                 "params": {
-                    "protocolVersion": "2024-11-05",
+                    "protocolVersion": "2025-11-25",
                     "capabilities": {},
                     "clientInfo": {
                         "name": "test-client",
@@ -4124,35 +4010,54 @@ mod integration_tests {
                 .unwrap()
         }
 
+        async fn wait_for_forwarders(running: &Running, expected: usize) {
+            tokio::time::timeout(std::time::Duration::from_secs(2), async {
+                while running.tool_list_changes.receiver_count() != expected {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("initialized notification must start a forwarder");
+        }
+
+        async fn initialize_legacy_session(
+            service: &StreamableHttpService<Running, LocalSessionManager>,
+            running: &Running,
+        ) -> String {
+            let previous = running.tool_list_changes.receiver_count();
+            let response = service
+                .clone()
+                .oneshot(build_initialize_request())
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let session = response.headers()["Mcp-Session-Id"]
+                .to_str()
+                .unwrap()
+                .to_owned();
+            assert_eq!(running.tool_list_changes.receiver_count(), previous);
+
+            let response = service
+                .clone()
+                .oneshot(session_request(
+                    &session,
+                    http::Method::POST,
+                    json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::ACCEPTED);
+            wait_for_forwarders(running, previous + 1).await;
+            session
+        }
+
         #[tokio::test]
-        async fn closed_peers_are_cleaned_up_on_operations_update() {
+        async fn deleted_session_releases_forwarder_without_a_catalog_update() {
             let running = create_test_running();
             let session_manager: Arc<LocalSessionManager> = LocalSessionManager::default().into();
 
-            // Initialize a session — this adds a peer to running.peers
             let service = create_service(running.clone(), Arc::clone(&session_manager));
-            let response = service.oneshot(build_initialize_request()).await.unwrap();
-            assert_eq!(response.status(), StatusCode::OK);
-            let session_id = response
-                .headers()
-                .get("mcp-session-id")
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .to_string();
-
-            // Poll until the peer is registered by the async initialize handler
-            let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
-            loop {
-                if running.peers.read().await.len() == 1 {
-                    break;
-                }
-                assert!(
-                    tokio::time::Instant::now() < deadline,
-                    "peer should be registered after initialize"
-                );
-                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-            }
+            let session_id = initialize_legacy_session(&service, &running).await;
 
             // Delete the session — closes the session transport
             let service = create_service(running.clone(), Arc::clone(&session_manager));
@@ -4162,44 +4067,341 @@ mod integration_tests {
                 .unwrap();
             assert_eq!(response.status(), StatusCode::ACCEPTED);
 
-            // Poll until the transport is fully closed
-            let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
-            loop {
-                let guard = running.peers.read().await;
-                if guard.first().is_some_and(|p| p.is_transport_closed()) {
-                    break;
+            tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                running.tool_list_changes.closed(),
+            )
+            .await
+            .expect("session teardown must release its change receiver without another update");
+        }
+        async fn next_message<B>(body: &mut B) -> Value
+        where
+            B: http_body_util::BodyExt + Unpin,
+            B::Data: AsRef<[u8]>,
+            B::Error: std::fmt::Debug,
+        {
+            tokio::time::timeout(std::time::Duration::from_secs(2), async {
+                let mut buffer = String::new();
+                loop {
+                    let frame = body.frame().await.expect("stream closed").unwrap();
+                    if let Some(data) = frame.data_ref() {
+                        buffer.push_str(&String::from_utf8_lossy(data.as_ref()));
+                        for line in buffer.lines() {
+                            if let Some(data) = line.strip_prefix("data: ")
+                                && let Ok(message) = serde_json::from_str(data)
+                            {
+                                return message;
+                            }
+                        }
+                    }
                 }
-                drop(guard);
-                assert!(
-                    tokio::time::Instant::now() < deadline,
-                    "peer transport should be closed after session delete"
-                );
-                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-            }
+            })
+            .await
+            .expect("expected MCP message")
+        }
 
-            // Trigger update_operations which calls notify_tool_list_changed,
-            // cleaning up the now-closed peer
-            running.update_operations(vec![]).await;
+        fn session_request(session: &str, method: http::Method, body: Value) -> Request<Body> {
+            Request::builder()
+                .method(method.clone())
+                .uri("/mcp")
+                .header("Host", "localhost")
+                .header("Accept", "application/json, text/event-stream")
+                .header("Content-Type", "application/json")
+                .header("Mcp-Session-Id", session)
+                .body(if method == http::Method::GET {
+                    Body::empty()
+                } else {
+                    Body::from(body.to_string())
+                })
+                .unwrap()
+        }
 
-            assert_eq!(
-                running.peers.read().await.len(),
-                0,
-                "closed peer should be removed after update_operations"
+        fn session_get(session: &str) -> Request<Body> {
+            session_request(session, http::Method::GET, Value::Null)
+        }
+
+        fn session_post(session: &str, body: Value) -> Request<Body> {
+            session_request(session, http::Method::POST, body)
+        }
+
+        #[tokio::test]
+        async fn http_shutdown_releases_an_open_notification_stream() {
+            let running = create_test_running();
+            let shutdown = running.cancellation_token.clone();
+            let service = StreamableHttpService::new(
+                {
+                    let running = running.clone();
+                    move || Ok(running.for_service())
+                },
+                Arc::new(LocalSessionManager::default()),
+                StreamableHttpServerConfig::default()
+                    .with_legacy_session_mode(true)
+                    .with_cancellation_token(shutdown.child_token()),
             );
+            let session = initialize_legacy_session(&service, &running).await;
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let address = listener.local_addr().unwrap();
+            let token = shutdown.clone();
+            let server = tokio::spawn(async move {
+                axum::serve(listener, axum::Router::new().nest_service("/mcp", service))
+                    .with_graceful_shutdown(token.cancelled_owned())
+                    .await
+                    .unwrap();
+            });
+            let response = reqwest::Client::new()
+                .get(format!("http://{address}/mcp"))
+                .header("Accept", "text/event-stream")
+                .header("Mcp-Session-Id", session)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(running.tool_list_changes.receiver_count(), 1);
+            shutdown.cancel();
+            tokio::time::timeout(std::time::Duration::from_secs(2), server)
+                .await
+                .unwrap()
+                .unwrap();
+            tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                running.tool_list_changes.closed(),
+            )
+            .await
+            .unwrap();
+            drop(response);
+        }
+
+        #[tokio::test]
+        async fn repeated_initialized_notifications_keep_one_forwarder() {
+            // rmcp dispatches notifications concurrently. Observe completion of
+            // each real callback rather than treating a later request as a barrier.
+            struct ObservedService {
+                running: Running,
+                completed: tokio::sync::mpsc::UnboundedSender<()>,
+            }
+            impl ServerHandler for ObservedService {
+                fn get_info(&self) -> ServerInfo {
+                    self.running.get_info()
+                }
+
+                async fn on_initialized(&self, context: NotificationContext<RoleServer>) {
+                    self.running.on_initialized(context).await;
+                    self.completed.send(()).unwrap();
+                }
+            }
+            let running = create_test_running();
+            let (completed, mut callbacks) = tokio::sync::mpsc::unbounded_channel();
+            let service = StreamableHttpService::new(
+                {
+                    let running = running.clone();
+                    move || {
+                        Ok(ObservedService {
+                            running: running.for_service(),
+                            completed: completed.clone(),
+                        })
+                    }
+                },
+                Arc::new(LocalSessionManager::default()),
+                StreamableHttpServerConfig::default().with_legacy_session_mode(true),
+            );
+            let response = service
+                .clone()
+                .oneshot(build_initialize_request())
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let session = response.headers()["Mcp-Session-Id"]
+                .to_str()
+                .unwrap()
+                .to_owned();
+            assert_eq!(running.tool_list_changes.receiver_count(), 0);
+            for _ in 0..2 {
+                let response = service
+                    .clone()
+                    .oneshot(session_post(
+                        &session,
+                        json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+                    ))
+                    .await
+                    .unwrap();
+                assert_eq!(response.status(), StatusCode::ACCEPTED);
+                tokio::time::timeout(std::time::Duration::from_secs(2), callbacks.recv())
+                    .await
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(running.tool_list_changes.receiver_count(), 1);
+            }
+            service
+                .oneshot(build_delete_request(&session))
+                .await
+                .unwrap();
+            tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                running.tool_list_changes.closed(),
+            )
+            .await
+            .unwrap();
+        }
+
+        #[tokio::test]
+        async fn http_clients_receive_catalog_updates_across_sse_reconnects() {
+            let mut running = create_test_running();
+            running.enable_output_schema = true;
+            let fixture = LegacyHttp::new(running.clone());
+            let service = fixture.service.clone();
+            let mut sessions = Vec::new();
+            for _ in 0..2 {
+                sessions.push(fixture.connect().await);
+            }
+            let mut streams = Vec::new();
+            for session in &sessions {
+                let response = service.clone().oneshot(session_get(session)).await.unwrap();
+                assert_eq!(response.status(), StatusCode::OK);
+                streams.push(response.into_body());
+            }
+            running
+                .update_operations(vec![("query Hello { hello }".to_owned(), None).into()])
+                .await;
+            for stream in &mut streams {
+                assert_eq!(
+                    next_message(stream).await["method"],
+                    "notifications/tools/list_changed"
+                );
+            }
+            let list = json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"});
+            let mut response = service
+                .clone()
+                .oneshot(session_post(&sessions[0], list.clone()))
+                .await
+                .unwrap()
+                .into_body();
+            let before = next_message(&mut response).await;
+            assert_eq!(before["result"]["tools"][0]["name"], "Hello");
+
+            // Closing a GET stream must not tear down a reconnectable legacy session.
+            streams.clear();
+            for session in &sessions {
+                let response = service.clone().oneshot(session_get(session)).await.unwrap();
+                assert_eq!(response.status(), StatusCode::OK);
+                streams.push(response.into_body());
+            }
+            running
+                .update_schema(
+                    apollo_compiler::Schema::parse_and_validate(
+                        "type Query { hello: Int! }",
+                        "test",
+                    )
+                    .unwrap(),
+                )
+                .await;
+            for stream in &mut streams {
+                assert_eq!(
+                    next_message(stream).await["method"],
+                    "notifications/tools/list_changed"
+                );
+            }
+            let mut response = service
+                .clone()
+                .oneshot(session_post(&sessions[0], list))
+                .await
+                .unwrap()
+                .into_body();
+            let after = next_message(&mut response).await;
+            assert_ne!(
+                before["result"]["tools"][0]["outputSchema"],
+                after["result"]["tools"][0]["outputSchema"]
+            );
+            for session in &sessions {
+                service
+                    .clone()
+                    .oneshot(build_delete_request(session))
+                    .await
+                    .unwrap();
+            }
+            drop(streams);
+            tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                running.tool_list_changes.closed(),
+            )
+            .await
+            .unwrap();
+        }
+
+        #[tokio::test]
+        async fn stdio_delivers_changes_and_releases_forwarder_on_disconnect() {
+            use rmcp::ServiceExt as _;
+            use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
+            let running = create_test_running();
+            let connection = running.for_service();
+            let intermediate_clone = connection.clone();
+            let (server_io, client_io) = tokio::io::duplex(4096);
+            let server = tokio::spawn(async move {
+                connection
+                    .serve(server_io)
+                    .await
+                    .unwrap()
+                    .waiting()
+                    .await
+                    .unwrap();
+            });
+            let (reader, mut writer) = tokio::io::split(client_io);
+            let mut reader = BufReader::new(reader);
+            let init = json!({"jsonrpc":"2.0", "id":1, "method":"initialize", "params": {
+                "protocolVersion":"2025-11-25", "capabilities":{}, "clientInfo":{"name":"test", "version":"1"}
+            }});
+            writer
+                .write_all(format!("{init}\n").as_bytes())
+                .await
+                .unwrap();
+            let mut line = String::new();
+            reader.read_line(&mut line).await.unwrap();
+            assert!(
+                serde_json::from_str::<Value>(&line)
+                    .unwrap()
+                    .get("result")
+                    .is_some()
+            );
+            assert_eq!(running.tool_list_changes.receiver_count(), 0);
+            let initialized = json!({"jsonrpc": "2.0", "method": "notifications/initialized"});
+            writer
+                .write_all(format!("{initialized}\n").as_bytes())
+                .await
+                .unwrap();
+            wait_for_forwarders(&running, 1).await;
+            drop(intermediate_clone);
+            running.update_operations(vec![]).await;
+            line.clear();
+            tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                reader.read_line(&mut line),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+            assert_eq!(
+                serde_json::from_str::<Value>(&line).unwrap()["method"],
+                "notifications/tools/list_changed"
+            );
+            drop(reader);
+            drop(writer);
+            tokio::time::timeout(std::time::Duration::from_secs(2), server)
+                .await
+                .unwrap()
+                .unwrap();
+            tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                running.tool_list_changes.closed(),
+            )
+            .await
+            .unwrap();
         }
     }
 
     mod logging_setlevel {
         use std::sync::Arc;
 
-        use axum::body::Body;
-        use http::{Request, StatusCode};
-        use http_body_util::BodyExt;
-        use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
-        use rmcp::transport::{StreamableHttpServerConfig, StreamableHttpService};
         use serde_json::json;
         use tokio::sync::RwLock;
-        use tower::ServiceExt;
 
         use super::*;
 
@@ -4221,7 +4423,8 @@ mod integration_tests {
                 explorer_tool: None,
                 validate_tool: None,
                 custom_scalar_map: None,
-                peers: Arc::new(RwLock::new(vec![])),
+                tool_list_changes: Default::default(),
+                legacy_tool_notifications: Default::default(),
                 cancellation_token: CancellationToken::new(),
                 mutation_mode: MutationMode::None,
                 disable_type_description: false,
@@ -4238,132 +4441,16 @@ mod integration_tests {
             }
         }
 
-        fn create_service(
-            running: Running,
-            session_manager: Arc<LocalSessionManager>,
-        ) -> StreamableHttpService<Running, LocalSessionManager> {
-            StreamableHttpService::new(
-                move || Ok(running.clone()),
-                session_manager,
-                StreamableHttpServerConfig::default().with_legacy_session_mode(true),
-            )
-        }
-
-        fn build_initialize_request() -> Request<Body> {
-            let body = json!({
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "initialize",
-                "params": {
-                    "protocolVersion": "2025-11-25",
-                    "capabilities": {},
-                    "clientInfo": { "name": "test-client", "version": "1.0.0" }
-                }
-            });
-            Request::builder()
-                .method("POST")
-                .uri("/mcp")
-                .header("Host", "localhost:8000")
-                .header("Content-Type", "application/json")
-                .header("Accept", "application/json, text/event-stream")
-                .body(Body::from(body.to_string()))
-                .unwrap()
-        }
-
-        fn build_notification_request(session_id: &str) -> Request<Body> {
-            let body = json!({
-                "jsonrpc": "2.0",
-                "method": "notifications/initialized"
-            });
-            Request::builder()
-                .method("POST")
-                .uri("/mcp")
-                .header("Host", "localhost:8000")
-                .header("Content-Type", "application/json")
-                .header("Accept", "application/json, text/event-stream")
-                .header("Mcp-Session-Id", session_id)
-                .body(Body::from(body.to_string()))
-                .unwrap()
-        }
-
-        fn build_set_level_request(session_id: &str, level: &str) -> Request<Body> {
-            let body = json!({
-                "jsonrpc": "2.0",
-                "id": 2,
-                "method": "logging/setLevel",
-                "params": { "level": level }
-            });
-            Request::builder()
-                .method("POST")
-                .uri("/mcp")
-                .header("Host", "localhost:8000")
-                .header("Content-Type", "application/json")
-                .header("Accept", "application/json, text/event-stream")
-                .header("Mcp-Session-Id", session_id)
-                .body(Body::from(body.to_string()))
-                .unwrap()
-        }
-
-        fn extract_session_id<B>(response: &http::Response<B>) -> String {
-            response
-                .headers()
-                .get("mcp-session-id")
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .to_string()
-        }
-
-        async fn extract_json_body<B>(response: http::Response<B>) -> serde_json::Value
-        where
-            B: BodyExt,
-            B::Error: std::fmt::Debug,
-        {
-            let bytes = response.into_body().collect().await.unwrap().to_bytes();
-            let body_str = String::from_utf8_lossy(&bytes);
-            for line in body_str.lines() {
-                if let Some(data) = line.strip_prefix("data: ")
-                    && let Ok(val) = serde_json::from_str::<serde_json::Value>(data)
-                {
-                    return val;
-                }
-            }
-            panic!("no JSON data found in SSE response");
-        }
-
-        async fn initialize_session(
-            running: &Running,
-            session_manager: &Arc<LocalSessionManager>,
-        ) -> String {
-            let service = create_service(running.clone(), Arc::clone(session_manager));
-            let response = service.oneshot(build_initialize_request()).await.unwrap();
-            assert_eq!(response.status(), StatusCode::OK);
-            let session_id = extract_session_id(&response);
-
-            let service = create_service(running.clone(), Arc::clone(session_manager));
-            let response = service
-                .oneshot(build_notification_request(&session_id))
-                .await
-                .unwrap();
-            assert_eq!(response.status(), StatusCode::ACCEPTED);
-
-            session_id
-        }
-
         #[tokio::test]
         async fn returns_empty_success_for_any_level() {
             let running = create_test_running();
-            let session_manager: Arc<LocalSessionManager> = LocalSessionManager::default().into();
-            let session_id = initialize_session(&running, &session_manager).await;
-
-            let service = create_service(running, session_manager);
-            let response = service
-                .oneshot(build_set_level_request(&session_id, "debug"))
-                .await
-                .unwrap();
-
-            assert_eq!(response.status(), StatusCode::OK);
-            let body = extract_json_body(response).await;
+            let body = super::stateless_request(
+                running,
+                "2025-11-25",
+                "logging/setLevel",
+                json!({"level": "debug"}),
+            )
+            .await;
             assert!(
                 body.get("error").is_none(),
                 "set_level should not return an error: {body}"
@@ -4409,7 +4496,8 @@ mod integration_tests {
                 explorer_tool: None,
                 validate_tool: None,
                 custom_scalar_map: None,
-                peers: Arc::new(RwLock::new(vec![])),
+                tool_list_changes: Default::default(),
+                legacy_tool_notifications: Default::default(),
                 cancellation_token: CancellationToken::new(),
                 mutation_mode: MutationMode::None,
                 disable_type_description: false,
@@ -4431,7 +4519,7 @@ mod integration_tests {
             session_manager: Arc<LocalSessionManager>,
         ) -> StreamableHttpService<Running, LocalSessionManager> {
             StreamableHttpService::new(
-                move || Ok(running.clone()),
+                move || Ok(running.for_service()),
                 session_manager,
                 StreamableHttpServerConfig::default().with_legacy_session_mode(true),
             )

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -3929,6 +3929,7 @@ mod integration_tests {
         use tokio::sync::RwLock;
         use tower::ServiceExt;
 
+        use super::super::test_support::{SseReader, next_message};
         use super::*;
 
         fn create_test_running() -> Running {
@@ -4066,12 +4067,14 @@ mod integration_tests {
 
             let service = create_service(running.clone(), Arc::clone(&session_manager));
             let session_id = initialize_legacy_session(&service, &running).await;
-            let mut stream = service
-                .clone()
-                .oneshot(session_get(&session_id))
-                .await
-                .unwrap()
-                .into_body();
+            let mut stream = SseReader::new(Body::new(
+                service
+                    .clone()
+                    .oneshot(session_get(&session_id))
+                    .await
+                    .unwrap()
+                    .into_body(),
+            ));
             running.update_operations(vec![]).await;
             assert_eq!(
                 next_message(&mut stream).await["method"],
@@ -4093,134 +4096,6 @@ mod integration_tests {
             .await
             .expect("session teardown must release its change receiver without another update");
         }
-        async fn next_message<B>(body: &mut B) -> Value
-        where
-            B: http_body_util::BodyExt + Unpin,
-            B::Data: AsRef<[u8]>,
-            B::Error: std::fmt::Debug,
-        {
-            tokio::time::timeout(std::time::Duration::from_secs(2), async {
-                let mut buffer = String::new();
-                loop {
-                    let frame = body.frame().await.expect("stream closed").unwrap();
-                    if let Some(data) = frame.data_ref() {
-                        buffer.push_str(&String::from_utf8_lossy(data.as_ref()));
-                        for line in buffer.lines() {
-                            if let Some(data) = line.strip_prefix("data: ")
-                                && let Ok(message) = serde_json::from_str(data)
-                            {
-                                return message;
-                            }
-                        }
-                    }
-                }
-            })
-            .await
-            .expect("expected MCP message")
-        }
-
-        // Keep unread bytes across events so a frame containing multiple SSE
-        // events cannot discard the event following the one a test observes.
-        struct NotificationStream {
-            body: Body,
-            buffer: Vec<u8>,
-        }
-
-        impl NotificationStream {
-            fn new(body: Body) -> Self {
-                Self {
-                    body,
-                    buffer: Vec::new(),
-                }
-            }
-
-            async fn next_notification(&mut self) -> String {
-                use http_body_util::BodyExt as _;
-
-                tokio::time::timeout(std::time::Duration::from_secs(2), async {
-                    loop {
-                        let boundary = self
-                            .buffer
-                            .windows(2)
-                            .position(|bytes| bytes == b"\n\n")
-                            .map(|position| (position, 2))
-                            .into_iter()
-                            .chain(
-                                self.buffer
-                                    .windows(4)
-                                    .position(|bytes| bytes == b"\r\n\r\n")
-                                    .map(|position| (position, 4)),
-                            )
-                            .min_by_key(|(position, _)| *position);
-                        if let Some((position, delimiter_len)) = boundary {
-                            let event: Vec<_> =
-                                self.buffer.drain(..position + delimiter_len).collect();
-                            let event = std::str::from_utf8(&event).unwrap();
-                            let mut id = None;
-                            let mut data = Vec::new();
-                            for line in event.lines() {
-                                if let Some(value) = line.strip_prefix("id:") {
-                                    id = Some(value.strip_prefix(' ').unwrap_or(value).to_owned());
-                                } else if let Some(value) = line.strip_prefix("data:") {
-                                    data.push(value.strip_prefix(' ').unwrap_or(value));
-                                }
-                            }
-                            let data = data.join("\n");
-                            if data.is_empty() {
-                                continue; // Ignore keep-alive and retry-only events.
-                            }
-                            let message: Value = serde_json::from_str(&data).unwrap();
-                            assert_eq!(message["method"], "notifications/tools/list_changed");
-                            return id.expect("legacy notifications must have an SSE event ID");
-                        }
-                        let frame = self
-                            .body
-                            .frame()
-                            .await
-                            .expect("notification stream closed")
-                            .unwrap();
-                        if let Some(data) = frame.data_ref() {
-                            self.buffer.extend_from_slice(data);
-                        }
-                    }
-                })
-                .await
-                .expect("expected a complete tool-list notification")
-            }
-        }
-
-        proptest::proptest! {
-            #[test]
-            fn notification_stream_preserves_events_across_frame_boundaries(
-                chunk_sizes in proptest::collection::vec(1usize..128, 1..16),
-                crlf in proptest::bool::ANY,
-            ) {
-                // Framing must not affect event identity, including when several
-                // events share a frame or an event is split between frames.
-                let newline = if crlf { "\r\n" } else { "\n" };
-                let payload = format!(
-                    ": keep-alive{newline}{newline}data:{newline}{newline}id: first{newline}data: {{\"method\":\"notifications/tools/list_changed\"}}{newline}{newline}id: second{newline}data: {{\"method\":\"notifications/tools/list_changed\"}}{newline}{newline}"
-                );
-                let mut remaining = payload.as_bytes();
-                let mut chunks = Vec::new();
-                for size in chunk_sizes.into_iter().cycle() {
-                    if remaining.is_empty() {
-                        break;
-                    }
-                    let (chunk, rest) = remaining.split_at(size.min(remaining.len()));
-                    chunks.push(Ok::<_, std::convert::Infallible>(chunk.to_vec()));
-                    remaining = rest;
-                }
-                let runtime = tokio::runtime::Builder::new_current_thread().enable_time().build().unwrap();
-                runtime.block_on(async {
-                    let body = Body::from_stream(futures::stream::iter(chunks));
-                    let mut stream = NotificationStream::new(body);
-                    assert_eq!(stream.next_notification().await, "first");
-                    assert_eq!(stream.next_notification().await, "second");
-                });
-            }
-        }
-
         fn session_request(session: &str, method: http::Method, body: Value) -> Request<Body> {
             Request::builder()
                 .method(method.clone())
@@ -4367,24 +4242,28 @@ mod integration_tests {
                 .unwrap();
             callbacks.recv().await.unwrap();
             let list = json!({"jsonrpc":"2.0","id":2,"method":"tools/list"});
-            let mut before = service
-                .clone()
-                .oneshot(session_post(&session, list.clone()))
-                .await
-                .unwrap()
-                .into_body();
+            let mut before = SseReader::new(Body::new(
+                service
+                    .clone()
+                    .oneshot(session_post(&session, list.clone()))
+                    .await
+                    .unwrap()
+                    .into_body(),
+            ));
             assert!(
                 next_message(&mut before).await["result"]["tools"]
                     .as_array()
                     .unwrap()
                     .is_empty()
             );
-            let mut stream = service
-                .clone()
-                .oneshot(session_get(&session))
-                .await
-                .unwrap()
-                .into_body();
+            let mut stream = SseReader::new(Body::new(
+                service
+                    .clone()
+                    .oneshot(session_get(&session))
+                    .await
+                    .unwrap()
+                    .into_body(),
+            ));
             running
                 .update_operations(vec![("query Hello { hello }".to_owned(), None).into()])
                 .await;
@@ -4394,12 +4273,14 @@ mod integration_tests {
                 next_message(&mut stream).await["method"],
                 "notifications/tools/list_changed"
             );
-            let mut after = service
-                .clone()
-                .oneshot(session_post(&session, list))
-                .await
-                .unwrap()
-                .into_body();
+            let mut after = SseReader::new(Body::new(
+                service
+                    .clone()
+                    .oneshot(session_post(&session, list))
+                    .await
+                    .unwrap()
+                    .into_body(),
+            ));
             assert_eq!(
                 next_message(&mut after).await["result"]["tools"][0]["name"],
                 "Hello"
@@ -4509,7 +4390,7 @@ mod integration_tests {
             for session in &sessions {
                 let response = service.clone().oneshot(session_get(session)).await.unwrap();
                 assert_eq!(response.status(), StatusCode::OK);
-                streams.push(NotificationStream::new(Body::new(response.into_body())));
+                streams.push(SseReader::new(Body::new(response.into_body())));
             }
             running
                 .update_operations(vec![("query Hello { hello }".to_owned(), None).into()])
@@ -4519,12 +4400,14 @@ mod integration_tests {
                 last_event_ids.push(stream.next_notification().await);
             }
             let list = json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"});
-            let mut response = service
-                .clone()
-                .oneshot(session_post(&sessions[0], list.clone()))
-                .await
-                .unwrap()
-                .into_body();
+            let mut response = SseReader::new(Body::new(
+                service
+                    .clone()
+                    .oneshot(session_post(&sessions[0], list.clone()))
+                    .await
+                    .unwrap()
+                    .into_body(),
+            ));
             let before = next_message(&mut response).await;
             assert_eq!(before["result"]["tools"][0]["name"], "Hello");
 
@@ -4547,7 +4430,7 @@ mod integration_tests {
                     .insert("Last-Event-ID", last_event_id.parse().unwrap());
                 let response = service.clone().oneshot(request).await.unwrap();
                 assert_eq!(response.status(), StatusCode::OK);
-                streams.push(NotificationStream::new(Body::new(response.into_body())));
+                streams.push(SseReader::new(Body::new(response.into_body())));
             }
             for (stream, last_event_id) in streams.iter_mut().zip(&mut last_event_ids) {
                 let mut next_event_id = stream.next_notification().await;
@@ -4560,12 +4443,14 @@ mod integration_tests {
                 *last_event_id = next_event_id;
             }
 
-            let mut response = service
-                .clone()
-                .oneshot(session_post(&sessions[0], list))
-                .await
-                .unwrap()
-                .into_body();
+            let mut response = SseReader::new(Body::new(
+                service
+                    .clone()
+                    .oneshot(session_post(&sessions[0], list))
+                    .await
+                    .unwrap()
+                    .into_body(),
+            ));
             let after = next_message(&mut response).await;
             assert_ne!(
                 before["result"]["tools"][0]["outputSchema"],
@@ -4952,3 +4837,9 @@ mod integration_tests {
         }
     }
 }
+
+#[cfg(test)]
+mod backpressure_tests;
+
+#[cfg(test)]
+mod test_support;

--- a/crates/apollo-mcp-server/src/server/states/running/backpressure_tests.rs
+++ b/crates/apollo-mcp-server/src/server/states/running/backpressure_tests.rs
@@ -1,0 +1,497 @@
+//! Real-transport pressure tests. Observers report readiness without altering I/O.
+use super::*;
+use rmcp::{Peer, ServiceExt as _};
+use std::{
+    pin::Pin,
+    sync::atomic::{AtomicBool, Ordering},
+    task::{Context, Poll},
+    time::Duration,
+};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader, DuplexStream},
+    sync::mpsc,
+};
+use tokio_util::task::AbortOnDropHandle;
+
+struct ObservedService {
+    inner: McpService,
+    initialized: mpsc::UnboundedSender<Peer<RoleServer>>,
+}
+impl ServerHandler for ObservedService {
+    fn get_info(&self) -> ServerInfo {
+        self.inner.get_info()
+    }
+    async fn initialize(
+        &self,
+        request: InitializeRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<InitializeResult, McpError> {
+        self.inner.initialize(request, context).await
+    }
+    async fn on_initialized(&self, context: rmcp::service::NotificationContext<RoleServer>) {
+        let peer = context.peer.clone();
+        self.inner.on_initialized(context).await;
+        self.initialized.send(peer).unwrap();
+    }
+    async fn list_tools(
+        &self,
+        request: Option<PaginatedRequestParams>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        self.inner.list_tools(request, context).await
+    }
+}
+
+struct ObservedWriter {
+    output: DuplexStream,
+    armed: Arc<AtomicBool>,
+    blocked: mpsc::UnboundedSender<()>,
+}
+impl AsyncWrite for ObservedWriter {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bytes: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let result = Pin::new(&mut self.output).poll_write(cx, bytes);
+        if result.is_pending() && self.armed.swap(false, Ordering::SeqCst) {
+            self.blocked.send(()).unwrap();
+        }
+        result
+    }
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.output).poll_flush(cx)
+    }
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.output).poll_shutdown(cx)
+    }
+}
+
+fn initialize_message() -> Value {
+    serde_json::json!({"jsonrpc":"2.0", "id":1, "method":"initialize", "params": {
+        "protocolVersion":"2025-11-25", "capabilities":{}, "clientInfo":{"name":"pressure-test", "version":"1"}
+    }})
+}
+async fn write_message(writer: &mut DuplexStream, message: Value) {
+    writer
+        .write_all(format!("{message}\n").as_bytes())
+        .await
+        .unwrap();
+}
+async fn read_message(reader: &mut BufReader<DuplexStream>) -> Value {
+    let mut line = String::new();
+    assert_ne!(
+        reader.read_line(&mut line).await.unwrap(),
+        0,
+        "unexpected stdio EOF"
+    );
+    serde_json::from_str(&line).unwrap()
+}
+
+struct StdioClient {
+    input: DuplexStream,
+    output: BufReader<DuplexStream>,
+    server: rmcp::service::RunningService<RoleServer, ObservedService>,
+    blocked: mpsc::UnboundedReceiver<()>,
+}
+async fn connect_stdio(running: &Running) -> StdioClient {
+    let (server_input, mut input) = tokio::io::duplex(4096);
+    let (server_output, output) = tokio::io::duplex(8);
+    let (blocked, observed) = mpsc::unbounded_channel();
+    let armed = Arc::new(AtomicBool::new(false));
+    let (initialized, mut ready) = mpsc::unbounded_channel();
+    let handler = ObservedService {
+        inner: running.for_service(),
+        initialized,
+    };
+    let writer = ObservedWriter {
+        output: server_output,
+        armed: armed.clone(),
+        blocked,
+    };
+    let startup = AbortOnDropHandle::new(tokio::spawn(async move {
+        handler.serve((server_input, writer)).await.unwrap()
+    }));
+    let mut output = BufReader::new(output);
+    write_message(&mut input, initialize_message()).await;
+    assert!(read_message(&mut output).await.get("result").is_some());
+    write_message(
+        &mut input,
+        serde_json::json!({"jsonrpc":"2.0", "method":"notifications/initialized"}),
+    )
+    .await;
+    ready.recv().await.unwrap();
+    let server = startup.await.unwrap();
+    armed.store(true, Ordering::SeqCst);
+    StdioClient {
+        input,
+        output,
+        server,
+        blocked: observed,
+    }
+}
+fn update(running: &Running, operations: Vec<RawOperation>) -> AbortOnDropHandle<()> {
+    let running = running.clone();
+    AbortOnDropHandle::new(tokio::spawn(async move {
+        running.update_operations(operations).await;
+    }))
+}
+
+#[rstest::rstest]
+#[case::brief(Duration::ZERO)]
+#[case::past_old_cutoff(Duration::from_secs(6))]
+#[tokio::test(start_paused = true)]
+#[timeout(Duration::from_secs(15))]
+async fn stdio_recovers_from_actual_write_backpressure(#[case] stall: Duration) {
+    let running = create_test_running();
+    let mut client = connect_stdio(&running).await;
+    let first = update(&running, vec![]);
+    client.blocked.recv().await.unwrap();
+    tokio::time::advance(stall).await;
+    let second = update(
+        &running,
+        vec![("query Hello { hello }".to_owned(), None).into()],
+    );
+    let (messages, mut received) = mpsc::unbounded_channel();
+    let reader = AbortOnDropHandle::new(tokio::spawn(async move {
+        loop {
+            let mut line = String::new();
+            if client.output.read_line(&mut line).await.unwrap() == 0 {
+                break;
+            }
+            messages
+                .send(serde_json::from_str::<Value>(&line).unwrap())
+                .unwrap();
+        }
+    }));
+    first.await.unwrap();
+    second.await.unwrap();
+    write_message(
+        &mut client.input,
+        serde_json::json!({"jsonrpc":"2.0", "id":2, "method":"tools/list"}),
+    )
+    .await;
+    loop {
+        let message = received.recv().await.unwrap();
+        if message["id"] == 2 {
+            assert_eq!(message["result"]["tools"][0]["name"], "Hello");
+            break;
+        }
+    }
+    // The request/response above drains earlier notifications. Require fresh delivery.
+    let third = update(&running, vec![]);
+    assert_eq!(
+        received.recv().await.unwrap()["method"],
+        "notifications/tools/list_changed"
+    );
+    third.await.unwrap();
+    drop(client.input);
+    client.server.waiting().await.unwrap();
+    reader.await.unwrap();
+}
+
+#[rstest::rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(10))]
+async fn stdio_full_disconnect_releases_a_blocked_write() {
+    let running = create_test_running();
+    let mut client = connect_stdio(&running).await;
+    let pending = update(&running, vec![]);
+    client.blocked.recv().await.unwrap();
+    drop(client.output);
+    drop(client.input);
+    client.server.waiting().await.unwrap();
+    pending.await.unwrap();
+    assert_delivery_released(&running).await;
+}
+fn create_test_running() -> Running {
+    let schema =
+        apollo_compiler::Schema::parse_and_validate("type Query { hello: String }", "test")
+            .unwrap();
+    Running {
+        schema: Arc::new(RwLock::new(schema)),
+        operations: Arc::new(RwLock::new(vec![])),
+        apps: vec![],
+        prompts: vec![],
+        headers: http::HeaderMap::new(),
+        forward_headers: vec![],
+        endpoint: url::Url::parse("http://localhost:4000").unwrap(),
+        execute_tool: None,
+        introspect_tool: None,
+        search_tool: None,
+        explorer_tool: None,
+        validate_tool: None,
+        custom_scalar_map: None,
+        tool_list_changes: Default::default(),
+        cancellation_token: CancellationToken::new(),
+        mutation_mode: MutationMode::All,
+        disable_type_description: false,
+        disable_schema_description: false,
+        enable_output_schema: false,
+        disable_auth_token_passthrough: false,
+        descriptions: HashMap::new(),
+        annotations: HashMap::new(),
+        health_check: None,
+        server_info: Default::default(),
+        instructions: None,
+        rhai_engine: Arc::new(parking_lot::Mutex::new(RhaiEngine::new("rhai"))),
+    }
+}
+
+use super::test_support::{SseReader, next_message};
+use axum::body::Body;
+use http::{Request, StatusCode};
+use rmcp::transport::{
+    StreamableHttpServerConfig, StreamableHttpService,
+    streamable_http_server::session::{SessionManager, local::LocalSessionManager},
+};
+use tower::ServiceExt as _;
+
+struct HttpFixture {
+    running: Running,
+    service: StreamableHttpService<ObservedService, LocalSessionManager>,
+    manager: Arc<LocalSessionManager>,
+    initialized: mpsc::UnboundedReceiver<Peer<RoleServer>>,
+}
+impl HttpFixture {
+    fn new() -> Self {
+        let running = create_test_running();
+        let mut manager = LocalSessionManager::default();
+        manager.session_config.channel_capacity = 1;
+        manager.session_config.sse_retry = None;
+        let manager = Arc::new(manager);
+        let (initialized, ready) = mpsc::unbounded_channel();
+        let application = running.clone();
+        let service = StreamableHttpService::new(
+            move || {
+                Ok(ObservedService {
+                    inner: application.for_service(),
+                    initialized: initialized.clone(),
+                })
+            },
+            manager.clone(),
+            StreamableHttpServerConfig::default()
+                .with_legacy_session_mode(true)
+                .with_cancellation_token(running.cancellation_token.child_token()),
+        );
+        Self {
+            running,
+            service,
+            manager,
+            initialized: ready,
+        }
+    }
+    async fn connect(&mut self) -> (String, Peer<RoleServer>) {
+        let response = self
+            .service
+            .clone()
+            .oneshot(http_request("POST", None, initialize_message()))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let session = response.headers()["Mcp-Session-Id"]
+            .to_str()
+            .unwrap()
+            .to_owned();
+        let response = self
+            .service
+            .clone()
+            .oneshot(http_request(
+                "POST",
+                Some(&session),
+                serde_json::json!({"jsonrpc":"2.0", "method":"notifications/initialized"}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        (session, self.initialized.recv().await.unwrap())
+    }
+    async fn stream(&self, session: &str) -> SseReader {
+        let response = self
+            .service
+            .clone()
+            .oneshot(http_request("GET", Some(session), Value::Null))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        SseReader::new(Body::new(response.into_body()))
+    }
+    async fn list(&self, session: &str) -> Value {
+        let response = self
+            .service
+            .clone()
+            .oneshot(http_request(
+                "POST",
+                Some(session),
+                serde_json::json!({"jsonrpc":"2.0", "id":2, "method":"tools/list"}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        next_message(&mut SseReader::new(Body::new(response.into_body()))).await["result"].clone()
+    }
+    async fn delete(&self, session: &str) {
+        let response = self
+            .service
+            .clone()
+            .oneshot(http_request("DELETE", Some(session), Value::Null))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        assert!(
+            !self
+                .manager
+                .has_session(&session.to_owned().into())
+                .await
+                .unwrap()
+        );
+    }
+}
+fn http_request(method: &str, session: Option<&str>, message: Value) -> Request<Body> {
+    let mut request = Request::builder()
+        .method(method)
+        .uri("/mcp")
+        .header("Host", "localhost")
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream");
+    if let Some(session) = session {
+        request = request.header("Mcp-Session-Id", session);
+    }
+    request
+        .body(if method == "POST" {
+            Body::from(message.to_string())
+        } else {
+            Body::empty()
+        })
+        .unwrap()
+}
+
+#[rstest::rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(15))]
+async fn http_backpressure_is_isolated_and_delivery_recovers() {
+    let mut fixture = HttpFixture::new();
+    let (slow_session, peer) = fixture.connect().await;
+    let (fast_session, _) = fixture.connect().await;
+    let mut slow = fixture.stream(&slow_session).await;
+    let mut fast = fixture.stream(&fast_session).await;
+    // A completed send fills the one-slot channel. Without polling the body,
+    // the next send cannot finish, irrespective of how rmcp schedules it.
+    peer.notify_tool_list_changed().await.unwrap();
+    let blocked = peer.notify_tool_list_changed();
+    tokio::pin!(blocked);
+    assert!(futures::poll!(&mut blocked).is_pending());
+    let changed = update(
+        &fixture.running,
+        vec![("query Hello { hello }".to_owned(), None).into()],
+    );
+    fast.next_notification().await;
+    assert_eq!(
+        fixture.list(&fast_session).await["tools"][0]["name"],
+        "Hello"
+    );
+    slow.next_notification().await;
+    slow.next_notification().await;
+    blocked.await.unwrap();
+    // Receive the application notification after the two pressure-setting sends.
+    slow.next_notification().await;
+    changed.await.unwrap();
+    assert_eq!(
+        fixture.list(&slow_session).await["tools"][0]["name"],
+        "Hello"
+    );
+    let changed = update(&fixture.running, vec![]);
+    fast.next_notification().await;
+    slow.next_notification().await;
+    changed.await.unwrap();
+    drop(slow);
+    drop(fast);
+    fixture.delete(&slow_session).await;
+    fixture.delete(&fast_session).await;
+    assert_delivery_released(&fixture.running).await;
+}
+
+#[rstest::rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(10))]
+async fn closing_a_backpressured_get_allows_reconnection() {
+    let mut fixture = HttpFixture::new();
+    let (session, peer) = fixture.connect().await;
+    let stream = fixture.stream(&session).await;
+    peer.notify_tool_list_changed().await.unwrap();
+    let blocked = peer.notify_tool_list_changed();
+    tokio::pin!(blocked);
+    assert!(futures::poll!(&mut blocked).is_pending());
+    drop(stream);
+    blocked.await.unwrap();
+    let mut stream = fixture.stream(&session).await;
+    let previous = stream.next_notification().await;
+    let changed = update(
+        &fixture.running,
+        vec![("query Hello { hello }".to_owned(), None).into()],
+    );
+    assert_ne!(stream.next_notification().await, previous);
+    changed.await.unwrap();
+    assert_eq!(fixture.list(&session).await["tools"][0]["name"], "Hello");
+    drop(stream);
+    fixture.delete(&session).await;
+    assert_delivery_released(&fixture.running).await;
+}
+
+#[rstest::rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(10))]
+async fn deleting_a_backpressured_session_finishes_after_get_disconnects() {
+    let mut fixture = HttpFixture::new();
+    let (session, peer) = fixture.connect().await;
+    let stream = fixture.stream(&session).await;
+    peer.notify_tool_list_changed().await.unwrap();
+    let blocked = peer.notify_tool_list_changed();
+    tokio::pin!(blocked);
+    assert!(futures::poll!(&mut blocked).is_pending());
+    fixture.delete(&session).await;
+    // DELETE removes the session ID before the worker finishes. Release the
+    // output too, then independently establish that forwarding was torn down.
+    drop(stream);
+    let _ = blocked.await;
+    assert_delivery_released(&fixture.running).await;
+}
+
+async fn assert_delivery_released(running: &Running) {
+    running.tool_list_changes.closed().await;
+}
+
+#[rstest::rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(10))]
+async fn application_cancellation_releases_forwarder_during_blocked_stdio_write() {
+    let running = create_test_running();
+    let mut client = connect_stdio(&running).await;
+    let pending = update(&running, vec![]);
+    client.blocked.recv().await.unwrap();
+    running.cancellation_token.cancel();
+    assert_delivery_released(&running).await;
+    // This establishes application-task cleanup, not cancellation of rmcp's
+    // separately owned write. Releasing the I/O allows its teardown to finish.
+    drop(client.output);
+    drop(client.input);
+    client.server.waiting().await.unwrap();
+    pending.await.unwrap();
+}
+
+#[rstest::rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(10))]
+async fn application_cancellation_releases_forwarder_with_http_output_full() {
+    let mut fixture = HttpFixture::new();
+    let (session, peer) = fixture.connect().await;
+    let stream = fixture.stream(&session).await;
+    peer.notify_tool_list_changed().await.unwrap();
+    let pending = update(&fixture.running, vec![]);
+    pending.await.unwrap();
+    assert_eq!(fixture.running.tool_list_changes.receiver_count(), 1);
+    fixture.running.cancellation_token.cancel();
+    assert_delivery_released(&fixture.running).await;
+    drop(stream);
+    fixture.delete(&session).await;
+}

--- a/crates/apollo-mcp-server/src/server/states/running/backpressure_tests.rs
+++ b/crates/apollo-mcp-server/src/server/states/running/backpressure_tests.rs
@@ -1,17 +1,30 @@
 //! Real-transport pressure tests. Observers report readiness without altering I/O.
-use super::*;
-use rmcp::{Peer, ServiceExt as _};
+
 use std::{
     pin::Pin,
     sync::atomic::{AtomicBool, Ordering},
     task::{Context, Poll},
     time::Duration,
 };
+
+use axum::body::Body;
+use http::{Request, StatusCode};
+use rmcp::{
+    Peer, ServiceExt as _,
+    transport::{
+        StreamableHttpServerConfig, StreamableHttpService,
+        streamable_http_server::session::{SessionManager, local::LocalSessionManager},
+    },
+};
 use tokio::{
     io::{AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader, DuplexStream},
     sync::mpsc,
 };
 use tokio_util::task::AbortOnDropHandle;
+use tower::ServiceExt as _;
+
+use super::test_support::{SseReader, create_test_running, next_message};
+use super::*;
 
 struct ObservedService {
     inner: McpService,
@@ -204,49 +217,6 @@ async fn stdio_full_disconnect_releases_a_blocked_write() {
     pending.await.unwrap();
     assert_delivery_released(&running).await;
 }
-fn create_test_running() -> Running {
-    let schema =
-        apollo_compiler::Schema::parse_and_validate("type Query { hello: String }", "test")
-            .unwrap();
-    Running {
-        schema: Arc::new(RwLock::new(schema)),
-        operations: Arc::new(RwLock::new(vec![])),
-        apps: vec![],
-        prompts: vec![],
-        headers: http::HeaderMap::new(),
-        forward_headers: vec![],
-        endpoint: url::Url::parse("http://localhost:4000").unwrap(),
-        execute_tool: None,
-        introspect_tool: None,
-        search_tool: None,
-        explorer_tool: None,
-        validate_tool: None,
-        custom_scalar_map: None,
-        tool_list_changes: Default::default(),
-        cancellation_token: CancellationToken::new(),
-        mutation_mode: MutationMode::All,
-        disable_type_description: false,
-        disable_schema_description: false,
-        enable_output_schema: false,
-        disable_auth_token_passthrough: false,
-        descriptions: HashMap::new(),
-        annotations: HashMap::new(),
-        health_check: None,
-        server_info: Default::default(),
-        instructions: None,
-        rhai_engine: Arc::new(parking_lot::Mutex::new(RhaiEngine::new("rhai"))),
-        caching: Default::default(),
-    }
-}
-
-use super::test_support::{SseReader, next_message};
-use axum::body::Body;
-use http::{Request, StatusCode};
-use rmcp::transport::{
-    StreamableHttpServerConfig, StreamableHttpService,
-    streamable_http_server::session::{SessionManager, local::LocalSessionManager},
-};
-use tower::ServiceExt as _;
 
 struct HttpFixture {
     running: Running,

--- a/crates/apollo-mcp-server/src/server/states/running/backpressure_tests.rs
+++ b/crates/apollo-mcp-server/src/server/states/running/backpressure_tests.rs
@@ -235,6 +235,7 @@ fn create_test_running() -> Running {
         server_info: Default::default(),
         instructions: None,
         rhai_engine: Arc::new(parking_lot::Mutex::new(RhaiEngine::new("rhai"))),
+        caching: Default::default(),
     }
 }
 

--- a/crates/apollo-mcp-server/src/server/states/running/test_support.rs
+++ b/crates/apollo-mcp-server/src/server/states/running/test_support.rs
@@ -1,0 +1,119 @@
+use axum::body::Body;
+use serde_json::Value;
+
+pub(super) struct SseEvent {
+    pub(super) id: Option<String>,
+    pub(super) message: Value,
+}
+
+pub(super) async fn next_message(reader: &mut SseReader) -> Value {
+    reader.next_event().await.message
+}
+
+// Keep unread bytes across events so a frame containing multiple SSE
+// events cannot discard the event following the one a test observes.
+pub(super) struct SseReader {
+    body: Body,
+    buffer: Vec<u8>,
+}
+
+impl SseReader {
+    pub(super) async fn next_notification(&mut self) -> String {
+        let event = self.next_event().await;
+        assert_eq!(event.message["method"], "notifications/tools/list_changed");
+        event
+            .id
+            .expect("legacy notifications must have an SSE event ID")
+    }
+
+    pub(super) fn new(body: Body) -> Self {
+        Self {
+            body,
+            buffer: Vec::new(),
+        }
+    }
+
+    pub(super) async fn next_event(&mut self) -> SseEvent {
+        use http_body_util::BodyExt as _;
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let boundary = self
+                    .buffer
+                    .windows(2)
+                    .position(|bytes| bytes == b"\n\n")
+                    .map(|position| (position, 2))
+                    .into_iter()
+                    .chain(
+                        self.buffer
+                            .windows(4)
+                            .position(|bytes| bytes == b"\r\n\r\n")
+                            .map(|position| (position, 4)),
+                    )
+                    .min_by_key(|(position, _)| *position);
+                if let Some((position, delimiter_len)) = boundary {
+                    let event: Vec<_> = self.buffer.drain(..position + delimiter_len).collect();
+                    let event = std::str::from_utf8(&event).unwrap();
+                    let mut id = None;
+                    let mut data = Vec::new();
+                    for line in event.lines() {
+                        if let Some(value) = line.strip_prefix("id:") {
+                            id = Some(value.strip_prefix(' ').unwrap_or(value).to_owned());
+                        } else if let Some(value) = line.strip_prefix("data:") {
+                            data.push(value.strip_prefix(' ').unwrap_or(value));
+                        }
+                    }
+                    let data = data.join("\n");
+                    if data.is_empty() {
+                        continue; // Ignore keep-alive and retry-only events.
+                    }
+                    let message: Value = serde_json::from_str(&data).unwrap();
+                    return SseEvent { id, message };
+                }
+                let frame = self
+                    .body
+                    .frame()
+                    .await
+                    .expect("notification stream closed")
+                    .unwrap();
+                if let Some(data) = frame.data_ref() {
+                    self.buffer.extend_from_slice(data);
+                }
+            }
+        })
+        .await
+        .expect("expected a complete tool-list notification")
+    }
+}
+
+proptest::proptest! {
+    #[test]
+    fn notification_stream_preserves_events_across_frame_boundaries(
+        chunk_sizes in proptest::collection::vec(1usize..128, 1..16),
+        crlf in proptest::bool::ANY,
+    ) {
+        // Framing must not affect event identity, including when several
+        // events share a frame or an event is split between frames.
+        let newline = if crlf { "\r\n" } else { "\n" };
+        let payload = format!(
+            ": keep-alive{newline}{newline}data:{newline}{newline}id: first{newline}data: {{\"method\":\"notifications/tools/list_changed\"}}{newline}{newline}id: second{newline}data: {{\"method\":\"notifications/tools/list_changed\"}}{newline}{newline}"
+        );
+        let mut remaining = payload.as_bytes();
+        let mut chunks = Vec::new();
+        for size in chunk_sizes.into_iter().cycle() {
+            if remaining.is_empty() {
+                break;
+            }
+            let (chunk, rest) = remaining.split_at(size.min(remaining.len()));
+            chunks.push(Ok::<_, std::convert::Infallible>(chunk.to_vec()));
+            remaining = rest;
+        }
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_time().build().unwrap();
+        runtime.block_on(async {
+            let body = Body::from_stream(futures::stream::iter(chunks));
+            let mut stream = SseReader::new(body);
+            assert_eq!(stream.next_notification().await, "first");
+            assert_eq!(stream.next_notification().await, "second");
+        });
+    }
+}

--- a/crates/apollo-mcp-server/src/server/states/running/test_support.rs
+++ b/crates/apollo-mcp-server/src/server/states/running/test_support.rs
@@ -1,5 +1,44 @@
 use axum::body::Body;
+use futures::StreamExt as _;
 use serde_json::Value;
+use sse_stream::SseStream;
+
+use super::*;
+
+pub(super) fn create_test_running() -> Running {
+    let schema =
+        apollo_compiler::Schema::parse_and_validate("type Query { hello: String }", "test")
+            .unwrap();
+    Running {
+        schema: Arc::new(RwLock::new(schema)),
+        operations: Arc::new(RwLock::new(vec![])),
+        apps: vec![],
+        prompts: vec![],
+        headers: http::HeaderMap::new(),
+        forward_headers: vec![],
+        endpoint: url::Url::parse("http://localhost:4000").unwrap(),
+        execute_tool: None,
+        introspect_tool: None,
+        search_tool: None,
+        explorer_tool: None,
+        validate_tool: None,
+        custom_scalar_map: None,
+        tool_list_changes: Default::default(),
+        cancellation_token: CancellationToken::new(),
+        mutation_mode: MutationMode::All,
+        disable_type_description: false,
+        disable_schema_description: false,
+        enable_output_schema: false,
+        disable_auth_token_passthrough: false,
+        descriptions: HashMap::new(),
+        annotations: HashMap::new(),
+        health_check: None,
+        server_info: Default::default(),
+        instructions: None,
+        rhai_engine: Arc::new(parking_lot::Mutex::new(RhaiEngine::new("rhai"))),
+        caching: Default::default(),
+    }
+}
 
 pub(super) struct SseEvent {
     pub(super) id: Option<String>,
@@ -10,14 +49,17 @@ pub(super) async fn next_message(reader: &mut SseReader) -> Value {
     reader.next_event().await.message
 }
 
-// Keep unread bytes across events so a frame containing multiple SSE
-// events cannot discard the event following the one a test observes.
 pub(super) struct SseReader {
-    body: Body,
-    buffer: Vec<u8>,
+    stream: SseStream<Body>,
 }
 
 impl SseReader {
+    pub(super) fn new(body: Body) -> Self {
+        Self {
+            stream: SseStream::new(body),
+        }
+    }
+
     pub(super) async fn next_notification(&mut self) -> String {
         let event = self.next_event().await;
         assert_eq!(event.message["method"], "notifications/tools/list_changed");
@@ -26,63 +68,22 @@ impl SseReader {
             .expect("legacy notifications must have an SSE event ID")
     }
 
-    pub(super) fn new(body: Body) -> Self {
-        Self {
-            body,
-            buffer: Vec::new(),
-        }
-    }
-
     pub(super) async fn next_event(&mut self) -> SseEvent {
-        use http_body_util::BodyExt as _;
-
-        tokio::time::timeout(std::time::Duration::from_secs(2), async {
-            loop {
-                let boundary = self
-                    .buffer
-                    .windows(2)
-                    .position(|bytes| bytes == b"\n\n")
-                    .map(|position| (position, 2))
-                    .into_iter()
-                    .chain(
-                        self.buffer
-                            .windows(4)
-                            .position(|bytes| bytes == b"\r\n\r\n")
-                            .map(|position| (position, 4)),
-                    )
-                    .min_by_key(|(position, _)| *position);
-                if let Some((position, delimiter_len)) = boundary {
-                    let event: Vec<_> = self.buffer.drain(..position + delimiter_len).collect();
-                    let event = std::str::from_utf8(&event).unwrap();
-                    let mut id = None;
-                    let mut data = Vec::new();
-                    for line in event.lines() {
-                        if let Some(value) = line.strip_prefix("id:") {
-                            id = Some(value.strip_prefix(' ').unwrap_or(value).to_owned());
-                        } else if let Some(value) = line.strip_prefix("data:") {
-                            data.push(value.strip_prefix(' ').unwrap_or(value));
-                        }
-                    }
-                    let data = data.join("\n");
-                    if data.is_empty() {
-                        continue; // Ignore keep-alive and retry-only events.
-                    }
-                    let message: Value = serde_json::from_str(&data).unwrap();
-                    return SseEvent { id, message };
-                }
-                let frame = self
-                    .body
-                    .frame()
-                    .await
-                    .expect("notification stream closed")
-                    .unwrap();
-                if let Some(data) = frame.data_ref() {
-                    self.buffer.extend_from_slice(data);
-                }
-            }
-        })
-        .await
-        .expect("expected a complete tool-list notification")
+        loop {
+            let event = self
+                .stream
+                .next()
+                .await
+                .expect("SSE stream closed before the expected message")
+                .expect("invalid SSE event");
+            let Some(data) = event.data.filter(|data| !data.is_empty()) else {
+                continue; // Ignore keep-alive and retry-only events.
+            };
+            return SseEvent {
+                id: event.id,
+                message: serde_json::from_str(&data).expect("SSE data must contain a JSON message"),
+            };
+        }
     }
 }
 

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -35,8 +35,6 @@ pub(super) struct Starting {
 
 impl Starting {
     pub(super) async fn start(mut self) -> Result<Running, ServerError> {
-        let peers = Arc::new(RwLock::new(Vec::new()));
-
         let operations: Vec<_> = self
             .operations
             .into_iter()
@@ -178,7 +176,8 @@ impl Starting {
             explorer_tool,
             validate_tool,
             custom_scalar_map: self.config.custom_scalar_map,
-            peers,
+            tool_list_changes: Default::default(),
+            legacy_tool_notifications: Default::default(),
             cancellation_token: cancellation_token.clone(),
             mutation_mode: self.config.mutation_mode,
             disable_type_description: self.config.disable_type_description,
@@ -206,10 +205,12 @@ impl Starting {
                 let running = running.clone();
                 let listen_address = SocketAddr::new(address, port);
                 let http_config = host_validation.apply_to(
-                    StreamableHttpServerConfig::default().with_legacy_session_mode(stateful_mode),
+                    StreamableHttpServerConfig::default()
+                        .with_legacy_session_mode(stateful_mode)
+                        .with_cancellation_token(cancellation_token.child_token()),
                 );
                 let service = StreamableHttpService::new(
-                    move || Ok(running.clone()),
+                    move || Ok(running.for_service()),
                     LocalSessionManager::default().into(),
                     http_config,
                 );
@@ -247,6 +248,7 @@ impl Starting {
                             _ = shutdown_signal() => {},
                             _ = shutdown_token.cancelled() => {},
                         }
+                        shutdown_token.cancel();
                     };
                     // Health check is already active from creation
                     if let Err(e) = axum::serve(tcp_listener, router)
@@ -261,7 +263,7 @@ impl Starting {
             Transport::Stdio {} => {
                 info!("Starting MCP server in stdio mode");
                 let service = running
-                    .clone()
+                    .for_service()
                     .serve(stdio())
                     .await
                     .inspect_err(|e| {

--- a/crates/apollo-mcp-server/src/server/states/starting.rs
+++ b/crates/apollo-mcp-server/src/server/states/starting.rs
@@ -177,7 +177,6 @@ impl Starting {
             validate_tool,
             custom_scalar_map: self.config.custom_scalar_map,
             tool_list_changes: Default::default(),
-            legacy_tool_notifications: Default::default(),
             cancellation_token: cancellation_token.clone(),
             mutation_mode: self.config.mutation_mode,
             disable_type_description: self.config.disable_type_description,
@@ -204,16 +203,7 @@ impl Starting {
                 info!(port = ?port, address = ?address, "Starting MCP server in Streamable HTTP mode");
                 let running = running.clone();
                 let listen_address = SocketAddr::new(address, port);
-                let http_config = host_validation.apply_to(
-                    StreamableHttpServerConfig::default()
-                        .with_legacy_session_mode(stateful_mode)
-                        .with_cancellation_token(cancellation_token.child_token()),
-                );
-                let service = StreamableHttpService::new(
-                    move || Ok(running.for_service()),
-                    LocalSessionManager::default().into(),
-                    http_config,
-                );
+                let service = build_http_service(running, stateful_mode, &host_validation);
                 let mut router = axum::Router::new().nest_service("/mcp", service);
                 if let Some(auth) = auth {
                     router = auth
@@ -239,23 +229,11 @@ impl Starting {
                 }
 
                 let tcp_listener = tokio::net::TcpListener::bind(listen_address).await?;
-                let shutdown_token = cancellation_token.clone();
                 tokio::spawn(async move {
-                    // Shut down when either a signal (CTRL+C/SIGTERM) is received
-                    // or the cancellation token is cancelled (e.g., config change restart).
-                    let graceful_shutdown = async move {
-                        tokio::select! {
-                            _ = shutdown_signal() => {},
-                            _ = shutdown_token.cancelled() => {},
-                        }
-                        shutdown_token.cancel();
-                    };
-                    // Health check is already active from creation
-                    if let Err(e) = axum::serve(tcp_listener, router)
-                        .with_graceful_shutdown(graceful_shutdown)
-                        .await
+                    if let Err(e) =
+                        serve_http(tcp_listener, router, cancellation_token, shutdown_signal())
+                            .await
                     {
-                        // This can never really happen
                         error!("Failed to start MCP server: {e:?}");
                     }
                 });
@@ -276,6 +254,42 @@ impl Starting {
 
         Ok(running)
     }
+}
+
+/// Construct the production transport, including cancellation of open streams.
+pub(super) fn build_http_service(
+    running: Running,
+    stateful_mode: bool,
+    host_validation: &crate::host_validation::HostValidationConfig,
+) -> StreamableHttpService<super::running::McpService, LocalSessionManager> {
+    let config = host_validation.apply_to(
+        StreamableHttpServerConfig::default()
+            .with_legacy_session_mode(stateful_mode)
+            .with_cancellation_token(running.cancellation_token.child_token()),
+    );
+    StreamableHttpService::new(
+        move || Ok(running.for_service()),
+        LocalSessionManager::default().into(),
+        config,
+    )
+}
+
+/// Both shutdown sources cancel transport streams before Axum drains connections.
+pub(super) async fn serve_http(
+    listener: tokio::net::TcpListener,
+    router: axum::Router,
+    shutdown: CancellationToken,
+    signal: impl std::future::Future<Output = ()> + Send + 'static,
+) -> std::io::Result<()> {
+    axum::serve(listener, router)
+        .with_graceful_shutdown(async move {
+            tokio::select! {
+                _ = signal => {},
+                _ = shutdown.cancelled() => {},
+            }
+            shutdown.cancel();
+        })
+        .await
 }
 
 fn with_cors(router: axum::Router, config: &CorsConfig) -> Result<axum::Router, ServerError> {

--- a/crates/apollo-mcp-server/src/server/states/tool_list_changes.rs
+++ b/crates/apollo-mcp-server/src/server/states/tool_list_changes.rs
@@ -1,10 +1,6 @@
 //! Application catalog invalidation, independent of MCP notification delivery.
 
-use std::{
-    future::Future,
-    sync::{Arc, OnceLock},
-    time::Duration,
-};
+use std::{future::Future, sync::Arc, time::Duration};
 
 use rmcp::{Peer, RoleServer, ServiceError};
 use tokio::sync::watch;
@@ -42,39 +38,41 @@ impl ToolListChanges {
     }
 }
 
-/// Separates application state from the notification task owned by an rmcp service.
-///
-/// Service clones share one task owner. Dropping the last clone aborts delivery;
-/// the task must never capture its owner. Stateless requests leave the cell empty.
-/// Once delivery ends on a terminal error, it is not restarted for that service.
+/// One legacy lifecycle shared by clones of an rmcp service. The task never
+/// captures this owner, so final-owner drop releases pending or active delivery.
 #[derive(Clone, Default)]
-pub(super) enum LegacyToolNotifications {
+pub(super) struct LegacyToolNotifications(Arc<parking_lot::Mutex<Lifecycle>>);
+
+#[derive(Default)]
+enum Lifecycle {
     #[default]
-    Application,
-    Service(Arc<OnceLock<AbortOnDropHandle<()>>>),
+    AwaitingInitialize,
+    AwaitingInitialized(watch::Receiver<()>),
+    // Records that delivery was started, even after a terminal send error. Such
+    // failures do not implicitly restart delivery on repeated notifications.
+    Started {
+        _task: AbortOnDropHandle<()>,
+    },
 }
 
 impl LegacyToolNotifications {
-    pub(super) fn for_service() -> Self {
-        Self::Service(Arc::default())
+    pub(super) fn initialize(&self, changes: &ToolListChanges) {
+        let mut state = self.0.lock();
+        if matches!(*state, Lifecycle::AwaitingInitialize) {
+            *state = Lifecycle::AwaitingInitialized(changes.subscribe());
+        }
     }
 
-    pub(super) fn on_initialized(
-        &self,
-        peer: Peer<RoleServer>,
-        changes: &ToolListChanges,
-        shutdown: CancellationToken,
-    ) {
-        let Self::Service(task) = self else {
-            return;
+    pub(super) fn on_initialized(&self, peer: Peer<RoleServer>, shutdown: CancellationToken) {
+        let mut state = self.0.lock();
+        *state = match std::mem::take(&mut *state) {
+            Lifecycle::AwaitingInitialized(receiver) => Lifecycle::Started {
+                _task: AbortOnDropHandle::new(tokio::spawn(async move {
+                    forward_changes(receiver, shutdown, || peer.notify_tool_list_changed()).await;
+                })),
+            },
+            unchanged => unchanged,
         };
-        task.get_or_init(|| {
-            // Subscribe synchronously so updates cannot race with task scheduling.
-            let receiver = changes.subscribe();
-            AbortOnDropHandle::new(tokio::spawn(async move {
-                forward_changes(receiver, shutdown, || peer.notify_tool_list_changed()).await;
-            }))
-        });
     }
 }
 
@@ -124,64 +122,136 @@ async fn forward_changes<F: Future<Output = Result<(), ServiceError>>>(
 mod tests {
     use super::*;
 
+    #[derive(Clone, Copy, Debug)]
+    enum Action {
+        Publish,
+        Succeed,
+        RecoverableFailure,
+        TerminalFailure,
+        Cancel,
+    }
+
+    #[derive(Clone, Copy)]
+    enum Model {
+        Idle,
+        Sending { pending: bool },
+        Stopped,
+    }
+
     proptest::proptest! {
-        /// Each scheduled batch leaves at most one pending invalidation. A simple
-        /// boolean model predicts sends without reproducing the watch implementation.
         #[test]
         fn forwarding_matches_pending_invalidation_model(
-            batches in proptest::collection::vec(0usize..8, 1..32),
-            stop_after in 0usize..32,
+            actions in proptest::collection::vec(proptest::prop_oneof![
+                proptest::strategy::Just(Action::Publish),
+                proptest::strategy::Just(Action::Succeed),
+                proptest::strategy::Just(Action::RecoverableFailure),
+                proptest::strategy::Just(Action::TerminalFailure),
+                proptest::strategy::Just(Action::Cancel),
+            ], 1..64)
         ) {
             let runtime = tokio::runtime::Builder::new_current_thread().enable_time().build().unwrap();
-            runtime.block_on(async {
-                let changes = ToolListChanges::default();
-                let shutdown = CancellationToken::new();
-                let token = shutdown.clone();
-                let receiver = changes.subscribe();
-                let (sent, mut received) = tokio::sync::mpsc::unbounded_channel();
-                let release = Arc::new(tokio::sync::Semaphore::new(0));
-                let permits = release.clone();
-                let task = tokio::spawn(async move {
-                    let mut attempts = 0;
-                    forward_changes(receiver, token, || {
-                        attempts += 1;
-                        sent.send(()).unwrap();
-                        async {
-                            permits.acquire().await.unwrap().forget();
-                            Ok(())
-                        }
-                    }).await;
-                    attempts
-                });
-                // Hold a first send in progress while generating further changes.
-                changes.publish();
-                received.recv().await.unwrap();
-                let mut expected = 1;
-                for count in batches.into_iter().take(stop_after) {
-                    let mut pending = false;
-                    for _ in 0..count {
-                        changes.publish();
-                        pending = true;
-                    }
-                    if pending {
-                        expected += 1;
-                        release.add_permits(1);
-                        tokio::time::timeout(Duration::from_secs(2), received.recv()).await.unwrap().unwrap();
-                    }
-                    assert!(received.try_recv().is_err());
-                }
-                // Cancellation must end even a blocked send, discarding pending work.
-                changes.publish();
-                shutdown.cancel();
-                let attempts = tokio::time::timeout(Duration::from_secs(2), task).await.unwrap().unwrap();
-                assert_eq!(attempts, expected);
-                assert!(received.try_recv().is_err());
-                assert_eq!(changes.receiver_count(), 0);
-            });
+            runtime.block_on(check_forwarding_model(actions));
         }
     }
 
+    async fn check_forwarding_model(actions: Vec<Action>) {
+        use std::cell::{Cell, RefCell};
+        let changes = ToolListChanges::default();
+        let shutdown = CancellationToken::new();
+        let attempts = Cell::new(0);
+        let completion = RefCell::new(None);
+        let forwarding = forward_changes(changes.subscribe(), shutdown.clone(), || {
+            attempts.set(attempts.get() + 1);
+            let (send, receive) = tokio::sync::oneshot::channel();
+            *completion.borrow_mut() = Some(send);
+            async move { receive.await.unwrap() }
+        });
+        tokio::pin!(forwarding);
+        let mut model = Model::Idle;
+        let mut expected = 0;
+        assert!(futures::poll!(&mut forwarding).is_pending());
+        // Polling explicitly controls scheduling: each action runs to the next
+        // suspension point, without scheduler sleeps or production test hooks.
+        for action in actions.into_iter().chain([Action::Cancel]) {
+            if matches!(model, Model::Stopped) {
+                changes.publish();
+                assert_eq!(attempts.get(), expected);
+                continue;
+            }
+            match action {
+                Action::Publish => {
+                    changes.publish();
+                    model = match model {
+                        Model::Idle => {
+                            expected += 1;
+                            Model::Sending { pending: false }
+                        }
+                        Model::Sending { .. } => Model::Sending { pending: true },
+                        Model::Stopped => Model::Stopped,
+                    };
+                }
+                Action::Cancel => {
+                    shutdown.cancel();
+                    model = Model::Stopped;
+                }
+                Action::Succeed | Action::RecoverableFailure | Action::TerminalFailure => {
+                    if let Model::Sending { pending } = model {
+                        let result = match action {
+                            Action::Succeed => Ok(()),
+                            Action::RecoverableFailure => Err(ServiceError::UnexpectedResponse),
+                            _ => Err(ServiceError::TransportClosed),
+                        };
+                        completion
+                            .borrow_mut()
+                            .take()
+                            .unwrap()
+                            .send(result)
+                            .unwrap();
+                        model = if matches!(action, Action::TerminalFailure) {
+                            Model::Stopped
+                        } else if pending {
+                            expected += 1;
+                            Model::Sending { pending: false }
+                        } else {
+                            Model::Idle
+                        };
+                    }
+                }
+            }
+            assert_eq!(
+                futures::poll!(&mut forwarding).is_ready(),
+                matches!(model, Model::Stopped)
+            );
+            assert_eq!(attempts.get(), expected);
+        }
+    }
+
+    #[test]
+    fn pending_initialization_is_shared_and_released_with_its_final_owner() {
+        let changes = ToolListChanges::default();
+        let owner = LegacyToolNotifications::default();
+        owner.initialize(&changes);
+        changes.publish();
+        owner.initialize(&changes);
+        let clone = owner.clone();
+        drop(owner);
+        assert_eq!(changes.receiver_count(), 1);
+        let state = clone.0.lock();
+        let Lifecycle::AwaitingInitialized(receiver) = &*state else {
+            panic!("expected pending initialization")
+        };
+        assert!(
+            receiver.has_changed().unwrap(),
+            "reinitialization must preserve pending invalidation"
+        );
+        drop(state);
+        drop(clone);
+        assert_eq!(changes.receiver_count(), 0);
+    }
+
+    #[rstest::rstest]
     #[tokio::test]
+    #[timeout(std::time::Duration::from_secs(10))]
     async fn changes_are_coalesced_for_each_receiver_without_replay() {
         let changes = ToolListChanges::default();
         changes.publish(); // No subscribers is normal.
@@ -196,7 +266,9 @@ mod tests {
         assert!(!second.has_changed().unwrap());
     }
 
+    #[rstest::rstest]
     #[tokio::test]
+    #[timeout(std::time::Duration::from_secs(10))]
     async fn shutdown_interrupts_a_blocked_send() {
         let changes = ToolListChanges::default();
         let shutdown = CancellationToken::new();
@@ -217,7 +289,9 @@ mod tests {
         changes.closed().await;
     }
 
+    #[rstest::rstest]
     #[tokio::test]
+    #[timeout(std::time::Duration::from_secs(10))]
     async fn recoverable_send_errors_do_not_stop_delivery() {
         let changes = ToolListChanges::default();
         let receiver = changes.subscribe();
@@ -242,7 +316,9 @@ mod tests {
         assert_eq!(task.await.unwrap(), 2);
         changes.closed().await;
     }
+    #[rstest::rstest]
     #[tokio::test(start_paused = true)]
+    #[timeout(std::time::Duration::from_secs(10))]
     async fn slow_client_times_out_without_delaying_another_client() {
         let changes = ToolListChanges::default();
         let slow = changes.subscribe();
@@ -276,7 +352,9 @@ mod tests {
         changes.closed().await;
     }
 
+    #[rstest::rstest]
     #[tokio::test]
+    #[timeout(std::time::Duration::from_secs(10))]
     async fn dropping_the_change_source_ends_delivery() {
         let changes = ToolListChanges::default();
         let receiver = changes.subscribe();
@@ -287,7 +365,9 @@ mod tests {
         .await;
     }
 
+    #[rstest::rstest]
     #[tokio::test]
+    #[timeout(std::time::Duration::from_secs(10))]
     async fn changes_during_a_send_are_delivered_after_it_finishes() {
         let changes = ToolListChanges::default();
         let receiver = changes.subscribe();

--- a/crates/apollo-mcp-server/src/server/states/tool_list_changes.rs
+++ b/crates/apollo-mcp-server/src/server/states/tool_list_changes.rs
@@ -1,0 +1,316 @@
+//! Application catalog invalidation, independent of MCP notification delivery.
+
+use std::{
+    future::Future,
+    sync::{Arc, OnceLock},
+    time::Duration,
+};
+
+use rmcp::{Peer, RoleServer, ServiceError};
+use tokio::sync::watch;
+use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
+use tracing::error;
+
+/// A coalescing signal to refetch the current tool catalog. No history is replayed.
+#[derive(Clone)]
+pub(super) struct ToolListChanges(watch::Sender<()>);
+
+impl Default for ToolListChanges {
+    fn default() -> Self {
+        Self(watch::channel(()).0)
+    }
+}
+
+impl ToolListChanges {
+    /// Publish after committing the catalog and releasing its write locks.
+    pub(super) fn publish(&self) {
+        self.0.send_replace(());
+    }
+
+    pub(super) fn subscribe(&self) -> watch::Receiver<()> {
+        self.0.subscribe()
+    }
+
+    #[cfg(test)]
+    pub(super) fn receiver_count(&self) -> usize {
+        self.0.receiver_count()
+    }
+
+    #[cfg(test)]
+    pub(super) async fn closed(&self) {
+        self.0.closed().await;
+    }
+}
+
+/// Separates application state from the notification task owned by an rmcp service.
+///
+/// Service clones share one task owner. Dropping the last clone aborts delivery;
+/// the task must never capture its owner. Stateless requests leave the cell empty.
+/// Once delivery ends on a terminal error, it is not restarted for that service.
+#[derive(Clone, Default)]
+pub(super) enum LegacyToolNotifications {
+    #[default]
+    Application,
+    Service(Arc<OnceLock<AbortOnDropHandle<()>>>),
+}
+
+impl LegacyToolNotifications {
+    pub(super) fn for_service() -> Self {
+        Self::Service(Arc::default())
+    }
+
+    pub(super) fn on_initialized(
+        &self,
+        peer: Peer<RoleServer>,
+        changes: &ToolListChanges,
+        shutdown: CancellationToken,
+    ) {
+        let Self::Service(task) = self else {
+            return;
+        };
+        task.get_or_init(|| {
+            // Subscribe synchronously so updates cannot race with task scheduling.
+            let receiver = changes.subscribe();
+            AbortOnDropHandle::new(tokio::spawn(async move {
+                forward_changes(receiver, shutdown, || peer.notify_tool_list_changed()).await;
+            }))
+        });
+    }
+}
+
+const NOTIFY_TIMEOUT: Duration = Duration::from_secs(5);
+
+async fn forward_changes<F: Future<Output = Result<(), ServiceError>>>(
+    mut changes: watch::Receiver<()>,
+    shutdown: CancellationToken,
+    mut notify: impl FnMut() -> F,
+) {
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => return,
+            changed = changes.changed() => {
+                if changed.is_err() {
+                    return;
+                }
+            }
+        }
+
+        let result = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => return,
+            result = tokio::time::timeout(NOTIFY_TIMEOUT, notify()) => result,
+        };
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(ServiceError::TransportSend(_) | ServiceError::TransportClosed)) => {
+                error!("Failed to notify client of tool list change - stopping legacy delivery");
+                return;
+            }
+            Ok(Err(error)) => {
+                error!(?error, "Failed to notify client of tool list change");
+            }
+            Err(_) => {
+                error!(
+                    "Timed out notifying client of tool list change after 5s - stopping legacy delivery"
+                );
+                return;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    proptest::proptest! {
+        /// Each scheduled batch leaves at most one pending invalidation. A simple
+        /// boolean model predicts sends without reproducing the watch implementation.
+        #[test]
+        fn forwarding_matches_pending_invalidation_model(
+            batches in proptest::collection::vec(0usize..8, 1..32),
+            stop_after in 0usize..32,
+        ) {
+            let runtime = tokio::runtime::Builder::new_current_thread().enable_time().build().unwrap();
+            runtime.block_on(async {
+                let changes = ToolListChanges::default();
+                let shutdown = CancellationToken::new();
+                let token = shutdown.clone();
+                let receiver = changes.subscribe();
+                let (sent, mut received) = tokio::sync::mpsc::unbounded_channel();
+                let release = Arc::new(tokio::sync::Semaphore::new(0));
+                let permits = release.clone();
+                let task = tokio::spawn(async move {
+                    let mut attempts = 0;
+                    forward_changes(receiver, token, || {
+                        attempts += 1;
+                        sent.send(()).unwrap();
+                        async {
+                            permits.acquire().await.unwrap().forget();
+                            Ok(())
+                        }
+                    }).await;
+                    attempts
+                });
+                // Hold a first send in progress while generating further changes.
+                changes.publish();
+                received.recv().await.unwrap();
+                let mut expected = 1;
+                for count in batches.into_iter().take(stop_after) {
+                    let mut pending = false;
+                    for _ in 0..count {
+                        changes.publish();
+                        pending = true;
+                    }
+                    if pending {
+                        expected += 1;
+                        release.add_permits(1);
+                        tokio::time::timeout(Duration::from_secs(2), received.recv()).await.unwrap().unwrap();
+                    }
+                    assert!(received.try_recv().is_err());
+                }
+                // Cancellation must end even a blocked send, discarding pending work.
+                changes.publish();
+                shutdown.cancel();
+                let attempts = tokio::time::timeout(Duration::from_secs(2), task).await.unwrap().unwrap();
+                assert_eq!(attempts, expected);
+                assert!(received.try_recv().is_err());
+                assert_eq!(changes.receiver_count(), 0);
+            });
+        }
+    }
+
+    #[tokio::test]
+    async fn changes_are_coalesced_for_each_receiver_without_replay() {
+        let changes = ToolListChanges::default();
+        changes.publish(); // No subscribers is normal.
+        let mut first = changes.subscribe();
+        let mut second = changes.clone().subscribe();
+        assert!(!first.has_changed().unwrap());
+        changes.publish();
+        changes.publish();
+        first.changed().await.unwrap();
+        second.changed().await.unwrap();
+        assert!(!first.has_changed().unwrap());
+        assert!(!second.has_changed().unwrap());
+    }
+
+    #[tokio::test]
+    async fn shutdown_interrupts_a_blocked_send() {
+        let changes = ToolListChanges::default();
+        let shutdown = CancellationToken::new();
+        let (started_tx, mut started_rx) = tokio::sync::mpsc::unbounded_channel();
+        let receiver = changes.subscribe();
+        let token = shutdown.clone();
+        let task = tokio::spawn(async move {
+            forward_changes(receiver, token, || {
+                started_tx.send(()).unwrap();
+                std::future::pending()
+            })
+            .await;
+        });
+        changes.publish();
+        started_rx.recv().await.unwrap();
+        shutdown.cancel();
+        task.await.unwrap();
+        changes.closed().await;
+    }
+
+    #[tokio::test]
+    async fn recoverable_send_errors_do_not_stop_delivery() {
+        let changes = ToolListChanges::default();
+        let receiver = changes.subscribe();
+        let (sent, mut received) = tokio::sync::mpsc::unbounded_channel();
+        let task = tokio::spawn(async move {
+            let mut attempts = 0;
+            forward_changes(receiver, CancellationToken::new(), || {
+                attempts += 1;
+                sent.send(()).unwrap();
+                std::future::ready(if attempts == 1 {
+                    Err(ServiceError::UnexpectedResponse)
+                } else {
+                    Err(ServiceError::TransportClosed)
+                })
+            })
+            .await;
+            attempts
+        });
+        changes.publish();
+        received.recv().await.unwrap();
+        changes.publish();
+        assert_eq!(task.await.unwrap(), 2);
+        changes.closed().await;
+    }
+    #[tokio::test(start_paused = true)]
+    async fn slow_client_times_out_without_delaying_another_client() {
+        let changes = ToolListChanges::default();
+        let slow = changes.subscribe();
+        let fast = changes.subscribe();
+        let shutdown = CancellationToken::new();
+        let fast_shutdown = shutdown.clone();
+        let (sent, mut received) = tokio::sync::mpsc::unbounded_channel();
+        let slow_task = tokio::spawn(forward_changes(
+            slow,
+            CancellationToken::new(),
+            std::future::pending,
+        ));
+        let fast_task = tokio::spawn(async move {
+            forward_changes(fast, fast_shutdown, || {
+                sent.send(()).unwrap();
+                std::future::ready(Ok(()))
+            })
+            .await;
+        });
+        let start = tokio::time::Instant::now();
+        changes.publish();
+        received.recv().await.unwrap();
+        // A second update can be delivered while the first client's send is blocked.
+        changes.publish();
+        received.recv().await.unwrap();
+        assert_eq!(start.elapsed(), Duration::ZERO);
+        shutdown.cancel();
+        fast_task.await.unwrap();
+        slow_task.await.unwrap();
+        assert_eq!(start.elapsed(), NOTIFY_TIMEOUT);
+        changes.closed().await;
+    }
+
+    #[tokio::test]
+    async fn dropping_the_change_source_ends_delivery() {
+        let changes = ToolListChanges::default();
+        let receiver = changes.subscribe();
+        drop(changes);
+        forward_changes(receiver, CancellationToken::new(), || async {
+            panic!("closed source must not send a notification")
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn changes_during_a_send_are_delivered_after_it_finishes() {
+        let changes = ToolListChanges::default();
+        let receiver = changes.subscribe();
+        let shutdown = CancellationToken::new();
+        let task_shutdown = shutdown.clone();
+        let release = Arc::new(tokio::sync::Semaphore::new(0));
+        let permit = release.clone();
+        let (sent, mut received) = tokio::sync::mpsc::unbounded_channel();
+        let task = tokio::spawn(async move {
+            forward_changes(receiver, task_shutdown, || async {
+                sent.send(()).unwrap();
+                permit.acquire().await.unwrap().forget();
+                Ok(())
+            })
+            .await;
+        });
+        changes.publish();
+        received.recv().await.unwrap();
+        changes.publish();
+        changes.publish();
+        release.add_permits(1);
+        received.recv().await.unwrap();
+        shutdown.cancel();
+        task.await.unwrap();
+    }
+}

--- a/crates/apollo-mcp-server/src/server/states/tool_list_changes.rs
+++ b/crates/apollo-mcp-server/src/server/states/tool_list_changes.rs
@@ -1,11 +1,11 @@
 //! Application catalog invalidation, independent of MCP notification delivery.
 
-use std::{future::Future, sync::Arc, time::Duration};
+use std::{future::Future, sync::Arc};
 
 use rmcp::{Peer, RoleServer, ServiceError};
 use tokio::sync::watch;
 use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
-use tracing::error;
+use tracing::{debug, error};
 
 /// A coalescing signal to refetch the current tool catalog. No history is replayed.
 #[derive(Clone)]
@@ -76,8 +76,6 @@ impl LegacyToolNotifications {
     }
 }
 
-const NOTIFY_TIMEOUT: Duration = Duration::from_secs(5);
-
 async fn forward_changes<F: Future<Output = Result<(), ServiceError>>>(
     mut changes: watch::Receiver<()>,
     shutdown: CancellationToken,
@@ -97,22 +95,25 @@ async fn forward_changes<F: Future<Output = Result<(), ServiceError>>>(
         let result = tokio::select! {
             biased;
             _ = shutdown.cancelled() => return,
-            result = tokio::time::timeout(NOTIFY_TIMEOUT, notify()) => result,
+            result = notify() => result,
         };
         match result {
-            Ok(Ok(())) => {}
-            Ok(Err(ServiceError::TransportSend(_) | ServiceError::TransportClosed)) => {
-                error!("Failed to notify client of tool list change - stopping legacy delivery");
-                return;
-            }
-            Ok(Err(error)) => {
-                error!(?error, "Failed to notify client of tool list change");
-            }
-            Err(_) => {
+            Ok(()) => {}
+            // Preserve the previous best-effort delivery policy for transport
+            // failures; TransportSend does not universally imply permanent closure.
+            Err(ServiceError::TransportSend(error)) => {
                 error!(
-                    "Timed out notifying client of tool list change after 5s - stopping legacy delivery"
+                    ?error,
+                    "Failed to notify client of tool list change - stopping legacy delivery"
                 );
                 return;
+            }
+            Err(ServiceError::TransportClosed) => {
+                debug!("Client transport closed - stopping legacy tool notifications");
+                return;
+            }
+            Err(error) => {
+                error!(?error, "Failed to notify client of tool list change");
             }
         }
     }
@@ -120,6 +121,8 @@ async fn forward_changes<F: Future<Output = Result<(), ServiceError>>>(
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
     #[derive(Clone, Copy, Debug)]
@@ -127,8 +130,17 @@ mod tests {
         Publish,
         Succeed,
         RecoverableFailure,
-        TerminalFailure,
+        TransportClosed,
+        TransportSend,
         Cancel,
+    }
+
+    fn transport_send_error() -> ServiceError {
+        ServiceError::TransportSend(rmcp::transport::DynamicTransportError::from_parts(
+            "test transport",
+            std::any::TypeId::of::<()>(),
+            Box::new(std::io::Error::from(std::io::ErrorKind::BrokenPipe)),
+        ))
     }
 
     #[derive(Clone, Copy)]
@@ -145,7 +157,8 @@ mod tests {
                 proptest::strategy::Just(Action::Publish),
                 proptest::strategy::Just(Action::Succeed),
                 proptest::strategy::Just(Action::RecoverableFailure),
-                proptest::strategy::Just(Action::TerminalFailure),
+                proptest::strategy::Just(Action::TransportClosed),
+                proptest::strategy::Just(Action::TransportSend),
                 proptest::strategy::Just(Action::Cancel),
             ], 1..64)
         ) {
@@ -194,11 +207,15 @@ mod tests {
                     shutdown.cancel();
                     model = Model::Stopped;
                 }
-                Action::Succeed | Action::RecoverableFailure | Action::TerminalFailure => {
+                Action::Succeed
+                | Action::RecoverableFailure
+                | Action::TransportClosed
+                | Action::TransportSend => {
                     if let Model::Sending { pending } = model {
                         let result = match action {
                             Action::Succeed => Ok(()),
                             Action::RecoverableFailure => Err(ServiceError::UnexpectedResponse),
+                            Action::TransportSend => Err(transport_send_error()),
                             _ => Err(ServiceError::TransportClosed),
                         };
                         completion
@@ -207,7 +224,8 @@ mod tests {
                             .unwrap()
                             .send(result)
                             .unwrap();
-                        model = if matches!(action, Action::TerminalFailure) {
+                        model = if matches!(action, Action::TransportClosed | Action::TransportSend)
+                        {
                             Model::Stopped
                         } else if pending {
                             expected += 1;
@@ -292,7 +310,9 @@ mod tests {
     #[rstest::rstest]
     #[tokio::test]
     #[timeout(std::time::Duration::from_secs(10))]
-    async fn recoverable_send_errors_do_not_stop_delivery() {
+    async fn other_errors_defensively_allow_later_changes() {
+        // rmcp notification sends currently expose transport errors. Preserve
+        // the fallback policy if other ServiceError variants become possible.
         let changes = ToolListChanges::default();
         let receiver = changes.subscribe();
         let (sent, mut received) = tokio::sync::mpsc::unbounded_channel();
@@ -319,37 +339,65 @@ mod tests {
     #[rstest::rstest]
     #[tokio::test(start_paused = true)]
     #[timeout(std::time::Duration::from_secs(10))]
-    async fn slow_client_times_out_without_delaying_another_client() {
+    async fn slow_client_recovers_without_delaying_another_client() {
         let changes = ToolListChanges::default();
-        let slow = changes.subscribe();
-        let fast = changes.subscribe();
         let shutdown = CancellationToken::new();
-        let fast_shutdown = shutdown.clone();
-        let (sent, mut received) = tokio::sync::mpsc::unbounded_channel();
-        let slow_task = tokio::spawn(forward_changes(
-            slow,
-            CancellationToken::new(),
-            std::future::pending,
-        ));
-        let fast_task = tokio::spawn(async move {
-            forward_changes(fast, fast_shutdown, || {
-                sent.send(()).unwrap();
-                std::future::ready(Ok(()))
-            })
-            .await;
+        let (started, mut attempts) = tokio::sync::mpsc::unbounded_channel();
+        let slow = forward_changes(changes.subscribe(), shutdown.clone(), || {
+            let (complete, completed) = tokio::sync::oneshot::channel();
+            started.send(complete).unwrap();
+            async move { completed.await.unwrap() }
         });
-        let start = tokio::time::Instant::now();
+        let (sent, mut received) = tokio::sync::mpsc::unbounded_channel();
+        let fast = forward_changes(changes.subscribe(), shutdown.clone(), || {
+            sent.send(()).unwrap();
+            std::future::ready(Ok(()))
+        });
+        tokio::pin!(slow, fast);
         changes.publish();
-        received.recv().await.unwrap();
-        // A second update can be delivered while the first client's send is blocked.
-        changes.publish();
-        received.recv().await.unwrap();
-        assert_eq!(start.elapsed(), Duration::ZERO);
+        assert!(futures::poll!(&mut slow).is_pending());
+        let first_send = attempts.try_recv().unwrap();
+        assert!(futures::poll!(&mut fast).is_pending());
+        received.try_recv().unwrap();
+
+        // Cross the former cutoff while the first send is still outstanding.
+        tokio::time::advance(Duration::from_secs(6)).await;
+        assert!(futures::poll!(&mut slow).is_pending());
+        assert!(!first_send.is_closed());
+        for _ in 0..3 {
+            changes.publish();
+            assert!(futures::poll!(&mut slow).is_pending());
+            assert!(futures::poll!(&mut fast).is_pending());
+            received.try_recv().unwrap();
+        }
+        assert!(attempts.try_recv().is_err());
+        first_send.send(Ok(())).unwrap();
+        assert!(futures::poll!(&mut slow).is_pending());
+        // All changes during the stall become one subsequent send.
+        attempts.try_recv().unwrap().send(Ok(())).unwrap();
+        assert!(futures::poll!(&mut slow).is_pending());
+        assert!(attempts.try_recv().is_err());
         shutdown.cancel();
-        fast_task.await.unwrap();
-        slow_task.await.unwrap();
-        assert_eq!(start.elapsed(), NOTIFY_TIMEOUT);
-        changes.closed().await;
+        assert!(futures::poll!(&mut slow).is_ready());
+        assert!(futures::poll!(&mut fast).is_ready());
+        assert_eq!(changes.receiver_count(), 0);
+    }
+
+    #[rstest::rstest]
+    #[case::closed(ServiceError::TransportClosed)]
+    #[case::send(transport_send_error())]
+    #[tokio::test]
+    #[timeout(std::time::Duration::from_secs(10))]
+    async fn transport_failures_end_delivery(#[case] error: ServiceError) {
+        let changes = ToolListChanges::default();
+        let mut failure = Some(error);
+        let forwarding = forward_changes(changes.subscribe(), CancellationToken::new(), || {
+            std::future::ready(Err(failure.take().expect("only one send is attempted")))
+        });
+        changes.publish();
+        forwarding.await;
+        assert_eq!(changes.receiver_count(), 0);
+        changes.publish();
     }
 
     #[rstest::rstest]

--- a/crates/apollo-mcp-server/src/server/states/tool_list_changes.rs
+++ b/crates/apollo-mcp-server/src/server/states/tool_list_changes.rs
@@ -99,8 +99,8 @@ async fn forward_changes<F: Future<Output = Result<(), ServiceError>>>(
         };
         match result {
             Ok(()) => {}
-            // Preserve the previous best-effort delivery policy for transport
-            // failures; TransportSend does not universally imply permanent closure.
+            // Preserve the existing application policy: stop delivery after a
+            // transport send error rather than retrying on later catalog changes.
             Err(ServiceError::TransportSend(error)) => {
                 error!(
                     ?error,

--- a/docs/source/config-file.mdx
+++ b/docs/source/config-file.mdx
@@ -370,7 +370,7 @@ Some transport types support further configuration. For `streamable_http`, you c
 | :---------------- | :--------------- | :---------- | :------------------------------------------------------------- |
 | `address`         | `IpAddr`         | `127.0.0.1` | The IP address to bind to                                      |
 | `port`            | `u16`            | `8000`      | The port to bind to                                            |
-| `stateful_mode`   | `bool`           | `true`      | Flag to enable or disable stateful mode and session management |
+| `stateful_mode`   | `bool`           | `true`      | Enable legacy HTTP sessions. When disabled, requests are sessionless and unsolicited tool-change notifications are unavailable. |
 | `host_validation` | `HostValidation` |             | Host header validation configuration                           |
 
 <Note>


### PR DESCRIPTION
<!-- AMS-509 -->

# refactor: make legacy tool notifications service-owned

Catalog updates currently fan out through a shared registry of MCP peers, allowing slow clients to delay other clients and requiring manual cleanup. Replace that registry with a coalescing catalog-change signal and a notification task owned by each initialized legacy rmcp service. Catalog updates finish independently of notification delivery, and teardown releases delivery resources without another update.

A distinct `McpService` implements the protocol handler; application state cannot accidentally be served without lifecycle ownership. A receiver is registered before returning the initialize response, preserving catalog invalidations while rmcp schedules the initialized callback. Delivery starts after that callback and is shared across service clones.

Tests exercise delayed initialization, repeated callbacks, reconnects, session deletion, final-owner cleanup, and both shutdown sources through production HTTP construction and serving functions. The forwarding property model covers idle and pending changes, send success/failure, and cancellation. Existing sessionless requests remain covered separately from legacy notification tests.

This is preparatory work for the stateless-protocol ticket. It does not implement `subscriptions/listen`, enable MCP `2026-07-28`, or change the `stateful_mode` default. Those remain companion work; this PR should not close the overall ticket.

Validation: workspace tests and all-feature instrumented workspace tests pass; all-target Clippy with warnings denied, formatting, and diff checks pass. Changed production executable-line coverage is 101/104 (97.1%); including test code, it is 535/553 (96.7%). The production calculation excludes cfg(test) items. The missed-update regression was verified by temporarily restoring late registration: the test failed waiting for the missing notification. Documentation builds with the existing private-link warning in `host_validation.rs`.
