### PR TITLE
refactor: delegate protocol version negotiation to rmcp

### DIFF
--- a/.changeset/delegate_protocol_version_negotiation_to_rmcp.md
+++ b/.changeset/delegate_protocol_version_negotiation_to_rmcp.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+# Delegate protocol version negotiation to rmcp
+
+This server negotiated the `initialize` protocol version itself, echoing the client's requested version when supported and otherwise falling back to the newest revision it implements. rmcp 3.3.0 exposes that same rule through `ServerHandler::negotiate_initialize`, so the local copy has been removed in favor of the SDK's, along with the hand-filtered list of supported versions that `ProtocolVersion::known_up_to` now derives.
+
+Negotiated versions are unchanged on every transport: a supported version is still echoed back, and anything newer or unrecognized still falls back to the newest revision this server implements.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,7 +788,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1421,7 +1421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2349,7 +2349,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2817,7 +2817,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3588,7 +3588,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4090,7 +4090,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4148,7 +4148,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4856,7 +4856,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5769,7 +5769,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,7 +788,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1421,7 +1421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2349,7 +2349,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2817,7 +2817,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3588,7 +3588,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3931,9 +3931,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b6914fac0be956fe704a38239c3f44a9f841d1b06a5713d2f638065593f5b5"
+checksum = "b88db56b8ae316560e9e868b6b978ea940f27cb883323fc90e07435e44158f5c"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -3963,9 +3963,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf1c49bd4d52014b94db0877410db273c2008f01628b0252a2e9460ad9b7fda"
+checksum = "873b730df6f0a9b74b13eb514e0dca4c2db0d8b68b74af98a2e9bf3f9d436585"
 dependencies = [
  "darling 0.24.1",
  "proc-macro2",
@@ -4090,7 +4090,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4148,7 +4148,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4856,7 +4856,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5769,7 +5769,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ insta = { version = "1.43.1", features = [
   "yaml",
   "glob",
 ] }
-rmcp = { version = "3.2.0", features = [
+rmcp = { version = "3.3.0", features = [
   "server",
   "transport-io",
   "transport-streamable-http-server",

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -1116,6 +1116,46 @@ mod tests {
         service.cancel().await.unwrap();
     }
 
+    mod supported_protocol_versions {
+        use super::*;
+
+        fn supported() -> Cow<'static, [ProtocolVersion]> {
+            let schema = Schema::parse("type Query { id: String }", "schema.graphql")
+                .unwrap()
+                .validate()
+                .unwrap();
+
+            test_running(Arc::new(RwLock::new(schema)))
+                .for_service()
+                .supported_protocol_versions()
+        }
+
+        #[test]
+        fn advertises_the_max_supported_version() {
+            let supported = supported();
+
+            assert!(
+                supported.contains(&MAX_SUPPORTED_PROTOCOL_VERSION),
+                "advertised versions {supported:?} must include the server's max"
+            );
+        }
+
+        #[test]
+        fn never_advertises_a_version_above_the_max_supported() {
+            let supported = supported();
+
+            let newer: Vec<_> = supported
+                .iter()
+                .filter(|version| **version > MAX_SUPPORTED_PROTOCOL_VERSION)
+                .collect();
+
+            assert!(
+                newer.is_empty(),
+                "advertised versions newer than {MAX_SUPPORTED_PROTOCOL_VERSION}: {newer:?}"
+            );
+        }
+    }
+
     mod update_operations {
         use super::*;
         use rmcp::model::Tool;

--- a/crates/apollo-mcp-server/src/server/states/running.rs
+++ b/crates/apollo-mcp-server/src/server/states/running.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use apollo_compiler::{Schema, validation::Valid};
 use opentelemetry::KeyValue;
@@ -648,35 +648,6 @@ impl Running {
 /// than this server's capabilities.
 pub(crate) const MAX_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V_2025_11_25;
 
-/// The protocol versions this server negotiates and advertises: every version
-/// rmcp knows, capped at [`MAX_SUPPORTED_PROTOCOL_VERSION`]. Single source of
-/// truth for that set.
-static SUPPORTED_PROTOCOL_VERSIONS: LazyLock<Vec<ProtocolVersion>> = LazyLock::new(|| {
-    ProtocolVersion::KNOWN_VERSIONS
-        .iter()
-        .filter(|version| **version <= MAX_SUPPORTED_PROTOCOL_VERSION)
-        .cloned()
-        .collect()
-});
-
-/// Echoes the client-requested protocol version when it is in
-/// [`SUPPORTED_PROTOCOL_VERSIONS`], otherwise falls back to
-/// [`MAX_SUPPORTED_PROTOCOL_VERSION`].
-fn negotiate_protocol_version(client_requested: &ProtocolVersion) -> ProtocolVersion {
-    if SUPPORTED_PROTOCOL_VERSIONS.contains(client_requested) {
-        client_requested.clone()
-    } else {
-        // debug rather than warn: falling back is expected, handled behavior,
-        // and a pinned client would emit this on every stateless initialize.
-        debug!(
-            client_requested = %client_requested,
-            server_fallback = %MAX_SUPPORTED_PROTOCOL_VERSION,
-            "client requested unsupported protocol version; falling back to server default"
-        );
-        MAX_SUPPORTED_PROTOCOL_VERSION
-    }
-}
-
 /// Transport handler with its own legacy lifecycle. Application clones cannot
 /// accidentally be served without constructing this owner.
 #[derive(Clone)]
@@ -707,13 +678,10 @@ impl ServerHandler for McpService {
             .u64_counter(TelemetryMetric::InitializeCount.as_str())
             .build()
             .add(1, &attributes);
-        // Echo the client's requested protocol version when supported,
-        // falling back to our max supported version otherwise (#794). rmcp's
-        // handshake re-negotiates this after `initialize` on every
-        // transport, but `supported_protocol_versions` below keeps that
-        // re-negotiation capped at the same version (closes #803).
-        let mut info = self.get_info();
-        info.protocol_version = negotiate_protocol_version(&request.protocol_version);
+        // Negotiate rather than answering with `get_info` as-is (#794).
+        // `supported_protocol_versions` below bounds both this call and the
+        // re-negotiation rmcp runs afterwards on every transport (#803).
+        let info = self.negotiate_initialize(&request)?;
         self.notifications
             .initialize(&self.application.tool_list_changes);
         Ok(info)
@@ -724,13 +692,17 @@ impl ServerHandler for McpService {
             .on_initialized(context.peer, self.application.cancellation_token.clone());
     }
 
-    /// Narrows rmcp's re-negotiation (run on every transport after
-    /// `initialize`) to [`SUPPORTED_PROTOCOL_VERSIONS`], so it can't advertise
-    /// a newer version from rmcp's `KNOWN_VERSIONS` (e.g. `2026-07-28`'s
-    /// SEP-2243 headers and `subscriptions/listen`, which this server doesn't
-    /// yet handle).
+    /// The protocol versions this server negotiates and advertises: every
+    /// version rmcp knows, capped at [`MAX_SUPPORTED_PROTOCOL_VERSION`].
+    ///
+    /// This also narrows rmcp's re-negotiation (run on every transport after
+    /// `initialize`), so it can't advertise a newer version from rmcp's
+    /// `KNOWN_VERSIONS` (e.g. `2026-07-28`'s SEP-2243 headers and
+    /// `subscriptions/listen`, which this server doesn't yet handle).
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
-        Cow::Borrowed(&SUPPORTED_PROTOCOL_VERSIONS)
+        Cow::Borrowed(ProtocolVersion::known_up_to(
+            &MAX_SUPPORTED_PROTOCOL_VERSION,
+        ))
     }
 
     #[tracing::instrument(skip_all, parent = get_parent_span(&context), fields(apollo.mcp.tool_name = request.name.as_ref(), apollo.mcp.request_id = %context.id.clone(), apollo.mcp.tool_arguments = tracing::field::Empty, apollo.mcp.tool_result = tracing::field::Empty))]
@@ -870,9 +842,8 @@ impl ServerHandler for McpService {
         capabilities.prompts =
             (!self.application.prompts.is_empty()).then(PromptsCapability::default);
 
-        // Advertise the max supported version as the default. Our `initialize`
-        // handler negotiates the per-client value, echoing the client's requested
-        // version when supported and otherwise falling back to this one.
+        // Load-bearing: negotiation falls back to this when it cannot honor
+        // the version the client asked for.
         let protocol_version = MAX_SUPPORTED_PROTOCOL_VERSION;
 
         let mut impl_ = Implementation::new(
@@ -1143,46 +1114,6 @@ mod tests {
             assert_eq!(text, expected_resource);
         }
         service.cancel().await.unwrap();
-    }
-    mod protocol_version_negotiation {
-        use rstest::rstest;
-
-        use super::*;
-
-        /// Builds a version rmcp has no constant for; unknown versions are
-        /// only constructible through deserialization.
-        fn unknown_version(version: &str) -> ProtocolVersion {
-            serde_json::from_value(serde_json::json!(version)).unwrap()
-        }
-
-        #[rstest]
-        #[case::oldest_known(ProtocolVersion::V_2024_11_05)]
-        #[case::intermediate_known(ProtocolVersion::V_2025_06_18)]
-        #[case::max_supported(MAX_SUPPORTED_PROTOCOL_VERSION)]
-        fn echoes_known_version_at_or_below_cap(#[case] requested: ProtocolVersion) {
-            assert_eq!(negotiate_protocol_version(&requested), requested);
-        }
-
-        #[test]
-        fn caps_known_version_above_max_supported() {
-            // rmcp has a constant for 2026-07-28, but this server doesn't
-            // implement that revision.
-            assert_eq!(
-                negotiate_protocol_version(&ProtocolVersion::V_2026_07_28),
-                MAX_SUPPORTED_PROTOCOL_VERSION
-            );
-        }
-
-        #[rstest]
-        #[case::future_date("2999-01-01")]
-        #[case::past_date("2020-01-01")]
-        #[case::not_a_date("not-a-version")]
-        fn falls_back_when_version_is_unknown(#[case] requested: &str) {
-            assert_eq!(
-                negotiate_protocol_version(&unknown_version(requested)),
-                MAX_SUPPORTED_PROTOCOL_VERSION
-            );
-        }
     }
 
     mod update_operations {


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-580 -->

rmcp 3.3.0 added `ServerHandler::negotiate_initialize` and `ProtocolVersion::known_up_to` in https://github.com/modelcontextprotocol/rust-sdk/pull/1247. These provide the SDK equivalents of the negotiation this server was handling manually: choosing the protocol version for the `initialize` response and capping it at the newest version the server actually supports.

#820 made that cap apply across all transports by narrowing `supported_protocol_versions`. This refactor removes the remaining duplication by deleting the local `negotiate_protocol_version` and the `SUPPORTED_PROTOCOL_VERSIONS` `LazyLock`. That keeps the rule upstream, so it cannot drift when rmcp changes.